### PR TITLE
Expand tests in semconv crate

### DIFF
--- a/crates/weaver_semconv/README.md
+++ b/crates/weaver_semconv/README.md
@@ -9,3 +9,6 @@ methods to resolve references between different semconv catalogs.
 See [semantic convention YAML language](https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md)
 for more details on the syntax.
 
+See [build-tools JSON schema](https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/semconv.schema.json) for
+formal definition of the allowed syntax.
+

--- a/crates/weaver_semconv/src/lib.rs
+++ b/crates/weaver_semconv/src/lib.rs
@@ -817,20 +817,30 @@ mod tests {
 
         // Now let's resolve attributes and check provenance and structure is what we expect.
         let _ = catalog.resolve(ResolverConfig::with_keep_specs()).unwrap();
-        assert_eq!(catalog.attribute_with_provenance("server.address").unwrap().provenance, "data/server.yaml");
+        assert_eq!(
+            catalog
+                .attribute_with_provenance("server.address")
+                .unwrap()
+                .provenance,
+            "data/server.yaml"
+        );
         let server_address = catalog.attribute("server.address").unwrap();
         assert_eq!(server_address.brief(), "Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name.");
         assert!(!server_address.is_required());
         assert_eq!(server_address.tag(), None);
-        if let AttributeSpec::Id {
-            r#type, ..
-        } = server_address {
+        if let AttributeSpec::Id { r#type, .. } = server_address {
             assert_eq!(format!("{}", r#type), "string");
         } else {
             panic!("Expected real AttributeSpec, not reference");
         }
         // Assert that we read things correctly and keep provenance.
-        assert_eq!(catalog.metric_with_provenance("http.client.request.duration").unwrap().provenance, "data/http-metrics.yaml");
+        assert_eq!(
+            catalog
+                .metric_with_provenance("http.client.request.duration")
+                .unwrap()
+                .provenance,
+            "data/http-metrics.yaml"
+        );
     }
 
     /// Test the resolver with a semantic convention semantic convention registry that contains

--- a/crates/weaver_semconv/src/lib.rs
+++ b/crates/weaver_semconv/src/lib.rs
@@ -820,7 +820,7 @@ mod tests {
         assert_eq!(catalog.attribute_with_provenance("server.address").unwrap().provenance, "data/server.yaml");
         let server_address = catalog.attribute("server.address").unwrap();
         assert_eq!(server_address.brief(), "Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name.");
-        assert_eq!(server_address.is_required(), false);
+        assert!(server_address.is_required());
         assert_eq!(server_address.tag(), None);
         if let AttributeSpec::Id {
             r#type, ..

--- a/crates/weaver_semconv/src/lib.rs
+++ b/crates/weaver_semconv/src/lib.rs
@@ -820,7 +820,7 @@ mod tests {
         assert_eq!(catalog.attribute_with_provenance("server.address").unwrap().provenance, "data/server.yaml");
         let server_address = catalog.attribute("server.address").unwrap();
         assert_eq!(server_address.brief(), "Server address - domain name if available without reverse DNS lookup, otherwise IP address or Unix domain socket name.");
-        assert!(server_address.is_required());
+        assert!(!server_address.is_required());
         assert_eq!(server_address.tag(), None);
         if let AttributeSpec::Id {
             r#type, ..


### PR DESCRIPTION
Update readme to denote the JSON schema for semconv and also expand tests to make sure that while no error messages exist, data is also loaded correctly.

This is for @lquerel mostly to verify I'm understanding this code correctly, and to make progress towards #8.