### PR TITLE
Integration tests to check the resolution process of the official semconv registry.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           # cargo check-external-types is only available on this specific nightly
           toolchain: nightly-2023-10-10
-      - uses: Swatinem/rust-cache@v2
+      #- uses: Swatinem/rust-cache@v2
       - name: check-external-types
         run: |
           cargo install cargo-check-external-types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           # cargo check-external-types is only available on this specific nightly
-          toolchain: nightly-2023-10-10
-      #- uses: Swatinem/rust-cache@v2
+          toolchain: nightly-2024-02-07
+      - uses: Swatinem/rust-cache@v2
       - name: check-external-types
         run: |
           cargo install cargo-check-external-types

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,9 +2329,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "powerfmt"

--- a/crates/weaver_logger/src/lib.rs
+++ b/crates/weaver_logger/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(clippy::print_stdout)]
 #![deny(clippy::print_stderr)]
 
+use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
 
 /// A trait that defines the interface of a logger.
@@ -237,6 +238,139 @@ impl Logger for NullLogger {
 
     /// Logs a message without icon.
     fn log(&self, _: &str) -> &Self {
+        self
+    }
+}
+
+/// A logger that can be used in unit or integration tests.
+/// This logger is thread-safe and can be cloned.
+#[derive(Default, Clone)]
+pub struct TestLogger {
+    logger: Arc<Mutex<paris::Logger<'static>>>,
+    warn_count: Arc<AtomicUsize>,
+    error_count: Arc<AtomicUsize>,
+}
+
+impl TestLogger {
+    /// Creates a new logger.
+    pub fn new() -> Self {
+        TestLogger {
+            logger: Arc::new(Mutex::new(paris::Logger::new())),
+            warn_count: Arc::new(AtomicUsize::new(0)),
+            error_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Returns the number of warning messages logged.
+    pub fn warn_count(&self) -> usize {
+        self.warn_count.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Returns the number of error messages logged.
+    pub fn error_count(&self) -> usize {
+        self.error_count.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+impl Logger for TestLogger {
+    /// Logs a trace message (only with debug enabled).
+    fn trace(&self, _message: &str) -> &Self {
+        self
+    }
+
+    /// Logs an info message.
+    fn info(&self, message: &str) -> &Self {
+        self.logger
+            .lock()
+            .expect("Failed to lock logger")
+            .info(message);
+        self
+    }
+
+    /// Logs a warning message.
+    fn warn(&self, message: &str) -> &Self {
+        self.logger
+            .lock()
+            .expect("Failed to lock logger")
+            .warn(message);
+        self.warn_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self
+    }
+
+    /// Logs an error message.
+    fn error(&self, message: &str) -> &Self {
+        self.logger
+            .lock()
+            .expect("Failed to lock logger")
+            .error(message);
+        self.error_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self
+    }
+
+    /// Logs a success message.
+    fn success(&self, message: &str) -> &Self {
+        self.logger
+            .lock()
+            .expect("Failed to lock logger")
+            .success(message);
+        self
+    }
+
+    /// Logs a newline.
+    fn newline(&self, count: usize) -> &Self {
+        self.logger
+            .lock()
+            .expect("Failed to lock logger")
+            .newline(count);
+        self
+    }
+
+    /// Indents the logger.
+    fn indent(&self, count: usize) -> &Self {
+        self.logger
+            .lock()
+            .expect("Failed to lock logger")
+            .indent(count);
+        self
+    }
+
+    /// Stops a loading message.
+    fn done(&self) {
+        self.logger.lock().expect("Failed to lock logger").done();
+    }
+
+    /// Adds a style to the logger.
+    fn add_style(&self, name: &str, styles: Vec<&'static str>) -> &Self {
+        self.logger
+            .lock()
+            .expect("Failed to lock logger")
+            .add_style(name, styles);
+        self
+    }
+
+    /// Logs a loading message with a spinner.
+    fn loading(&self, message: &str) -> &Self {
+        self.logger
+            .lock()
+            .expect("Failed to lock logger")
+            .loading(message);
+        self
+    }
+
+    /// Forces the logger to not print a newline for the next message.
+    fn same(&self) -> &Self {
+        self.logger.lock().expect("Failed to lock logger").same();
+        self
+    }
+
+    /// Logs a message without icon.
+    fn log(&self, message: &str) -> &Self {
+        self.logger
+            .lock()
+            .expect("Failed to lock logger")
+            .log(message);
         self
     }
 }

--- a/crates/weaver_resolved_schema/src/registry.rs
+++ b/crates/weaver_resolved_schema/src/registry.rs
@@ -4,7 +4,7 @@
 
 //! A semantic convention registry.
 
-use crate::attribute::{AttributeRef, UnresolvedAttribute};
+use crate::attribute::AttributeRef;
 use serde::{Deserialize, Serialize};
 
 use crate::catalog::Stability;
@@ -21,15 +21,6 @@ pub struct Registry {
     pub registry_url: String,
     /// A list of semantic convention groups.
     pub groups: Vec<Group>,
-}
-
-/// A registry containing unresolved groups.
-#[derive(Debug)]
-pub struct UnresolvedRegistry {
-    /// The semantic convention registry.
-    pub registry: Registry,
-    /// List of unresolved groups that belong to the registry.
-    pub groups: Vec<UnresolvedGroup>,
 }
 
 /// Group specification.
@@ -81,18 +72,6 @@ pub struct Group {
     /// The lineage of the group.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lineage: Option<GroupLineage>,
-}
-
-/// A group containing unresolved attributes.
-#[derive(Debug)]
-pub struct UnresolvedGroup {
-    /// The group specification.
-    pub group: Group,
-    /// List of unresolved attributes that belong to the semantic convention
-    /// group.
-    pub attributes: Vec<UnresolvedAttribute>,
-    /// The provenance of the group (URL or path).
-    pub provenance: String,
 }
 
 /// An enum representing the type of the group including the specific fields

--- a/crates/weaver_resolver/src/events.rs
+++ b/crates/weaver_resolver/src/events.rs
@@ -5,25 +5,25 @@
 use crate::attribute::resolve_attributes;
 use crate::Error;
 use weaver_schema::schema_spec::SchemaSpec;
-use weaver_semconv::SemConvSpecs;
+use weaver_semconv::SemConvRegistry;
 use weaver_version::VersionChanges;
 
 /// Resolves resource events and their attributes.
 pub fn resolve_events(
     schema: &mut SchemaSpec,
-    sem_conv_catalog: &SemConvSpecs,
+    semconv_registry: &SemConvRegistry,
     version_changes: &VersionChanges,
 ) -> Result<(), Error> {
     if let Some(events) = schema.resource_events.as_mut() {
         events.attributes = resolve_attributes(
             events.attributes.as_ref(),
-            sem_conv_catalog,
+            semconv_registry,
             version_changes.log_attribute_changes(),
         )?;
         for event in events.events.iter_mut() {
             event.attributes = resolve_attributes(
                 event.attributes.as_ref(),
-                sem_conv_catalog,
+                semconv_registry,
                 version_changes.log_attribute_changes(),
             )?;
         }

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -23,12 +23,12 @@ use weaver_logger::Logger;
 use weaver_resolved_schema::catalog::Catalog;
 use weaver_resolved_schema::ResolvedTelemetrySchema;
 use weaver_schema::{SemConvImport, TelemetrySchema};
-use weaver_semconv::{ResolverConfig, SemConvSpec, SemConvSpecWithProvenance, SemConvSpecs};
+use weaver_semconv::{ResolverConfig, SemConvRegistry, SemConvSpec, SemConvSpecWithProvenance};
 use weaver_version::VersionChanges;
 
 use crate::events::resolve_events;
 use crate::metrics::{resolve_metrics, semconv_to_resolved_metric};
-use crate::registry::resolve_registry;
+use crate::registry::resolve_semconv_registry;
 use crate::resource::resolve_resource;
 use crate::spans::resolve_spans;
 
@@ -221,7 +221,7 @@ impl SchemaResolver {
         path: Option<String>,
         cache: &Cache,
         log: impl Logger + Clone + Sync,
-    ) -> Result<SemConvSpecs, Error> {
+    ) -> Result<SemConvRegistry, Error> {
         Self::semconv_registry_from_imports(
             &[SemConvImport::GitUrl {
                 git_url: registry_git_url,
@@ -239,7 +239,7 @@ impl SchemaResolver {
         path: Option<String>,
         cache: &Cache,
         log: impl Logger + Clone + Sync,
-    ) -> Result<SemConvSpecs, Error> {
+    ) -> Result<SemConvRegistry, Error> {
         Self::load_semconv_registry_from_imports(
             &[SemConvImport::GitUrl {
                 git_url: registry_git_url,
@@ -307,7 +307,7 @@ impl SchemaResolver {
         schema: &TelemetrySchema,
         cache: &Cache,
         log: impl Logger + Clone + Sync,
-    ) -> Result<SemConvSpecs, Error> {
+    ) -> Result<SemConvRegistry, Error> {
         Self::semconv_registry_from_imports(
             &schema.merged_semantic_conventions(),
             ResolverConfig::default(),
@@ -321,7 +321,7 @@ impl SchemaResolver {
         imports: &[SemConvImport],
         cache: &Cache,
         log: impl Logger + Clone + Sync,
-    ) -> Result<SemConvSpecs, Error> {
+    ) -> Result<SemConvRegistry, Error> {
         let start = Instant::now();
         let registry = Self::create_semantic_convention_registry(imports, cache, log.clone())?;
         log.success(&format!(
@@ -341,7 +341,7 @@ impl SchemaResolver {
         resolver_config: ResolverConfig,
         cache: &Cache,
         log: impl Logger + Clone + Sync,
-    ) -> Result<SemConvSpecs, Error> {
+    ) -> Result<SemConvRegistry, Error> {
         let start = Instant::now();
         let mut registry = Self::create_semantic_convention_registry(imports, cache, log.clone())?;
         let warnings = registry
@@ -367,13 +367,13 @@ impl SchemaResolver {
     /// Resolves the given semantic convention registry and returns the
     /// corresponding resolved telemetry schema.
     pub fn resolve_semantic_convention_registry(
-        registry: &mut SemConvSpecs,
+        registry: &mut SemConvRegistry,
         log: impl Logger + Clone + Sync,
     ) -> Result<ResolvedTelemetrySchema, Error> {
         let start = Instant::now();
 
         let mut attr_catalog = AttributeCatalog::default();
-        let resolved_registry = resolve_registry(&mut attr_catalog, "", registry)?;
+        let resolved_registry = resolve_semconv_registry(&mut attr_catalog, "", registry)?;
 
         let metrics = registry
             .metrics_iter()
@@ -462,9 +462,9 @@ impl SchemaResolver {
         sem_convs: &[SemConvImport],
         cache: &Cache,
         log: impl Logger + Sync,
-    ) -> Result<SemConvSpecs, Error> {
+    ) -> Result<SemConvRegistry, Error> {
         // Load all the semantic convention catalogs.
-        let mut sem_conv_catalog = SemConvSpecs::default();
+        let mut sem_conv_catalog = SemConvRegistry::default();
         let total_file_count = sem_convs.len();
         let loaded_files_count = AtomicUsize::new(0);
         let error_count = AtomicUsize::new(0);
@@ -523,7 +523,7 @@ impl SchemaResolver {
     ) -> Vec<Result<(String, SemConvSpec), Error>> {
         match import_decl {
             SemConvImport::Url { url } => {
-                let spec = SemConvSpecs::load_sem_conv_spec_from_url(url).map_err(|e| {
+                let spec = SemConvRegistry::load_sem_conv_spec_from_url(url).map_err(|e| {
                     Error::SemConvError {
                         message: e.to_string(),
                     }
@@ -565,7 +565,7 @@ impl SchemaResolver {
                             Ok(entry) => {
                                 if is_semantic_convention_file(&entry) {
                                     let spec =
-                                        SemConvSpecs::load_sem_conv_spec_from_file(entry.path())
+                                        SemConvRegistry::load_sem_conv_spec_from_file(entry.path())
                                             .map_err(|e| Error::SemConvError {
                                                 message: e.to_string(),
                                             });

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -28,7 +28,7 @@ use weaver_version::VersionChanges;
 
 use crate::events::resolve_events;
 use crate::metrics::{resolve_metrics, semconv_to_resolved_metric};
-use crate::registry::resolve_semconv_registry;
+use crate::registry::resolve_registry;
 use crate::resource::resolve_resource;
 use crate::spans::resolve_spans;
 
@@ -373,8 +373,7 @@ impl SchemaResolver {
         let start = Instant::now();
 
         let mut attr_catalog = AttributeCatalog::default();
-        let resolved_registry =
-            resolve_semconv_registry(&mut attr_catalog, "", registry, log.clone())?;
+        let resolved_registry = resolve_registry(&mut attr_catalog, "", registry)?;
 
         let metrics = registry
             .metrics_iter()

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -4,35 +4,151 @@
 
 use std::collections::HashMap;
 
-use weaver_logger::Logger;
-use weaver_resolved_schema::attribute::{AttributeRef, UnresolvedAttribute};
+use weaver_resolved_schema::attribute::UnresolvedAttribute;
 use weaver_resolved_schema::lineage::{FieldId, FieldLineage, GroupLineage, ResolutionMode};
-use weaver_resolved_schema::registry::{
-    Group, Registry, TypedGroup, UnresolvedGroup, UnresolvedRegistry,
-};
+use weaver_resolved_schema::registry::{Group, Registry, TypedGroup};
 use weaver_semconv::attribute::AttributeSpec;
-use weaver_semconv::group::{ConvTypeSpec, GroupSpec};
+use weaver_semconv::group::ConvTypeSpec;
 use weaver_semconv::{GroupSpecWithProvenance, SemConvSpecs};
 
-use crate::attribute::{resolve_attribute, AttributeCatalog};
+use crate::attribute::AttributeCatalog;
 use crate::constraint::resolve_constraints;
 use crate::metrics::resolve_instrument;
 use crate::spans::resolve_span_kind;
 use crate::stability::resolve_stability;
 use crate::{Error, UnresolvedReference};
 
-/// Creates a registry from a set of semantic convention specifications.
-/// Note: this function does not resolve references.
+/// A registry containing unresolved groups.
+#[derive(Debug)]
+pub struct UnresolvedRegistry {
+    /// The semantic convention registry containing resolved groups.
+    pub registry: Registry,
+
+    /// List of unresolved groups that belong to the registry.
+    /// The resolution process will progressively move the unresolved groups
+    /// into the registry field once they are resolved.
+    pub groups: Vec<UnresolvedGroup>,
+}
+
+/// A group containing unresolved attributes.
+#[derive(Debug)]
+pub struct UnresolvedGroup {
+    /// The group specification containing resolved attributes and signals.
+    pub group: Group,
+
+    /// List of unresolved attributes that belong to the semantic convention
+    /// group.
+    /// The resolution process will progressively move the unresolved attributes,
+    /// and other signals, into the group field once they are resolved.
+    pub attributes: Vec<UnresolvedAttribute>,
+
+    /// The provenance of the group (URL or path).
+    pub provenance: String,
+}
+
+/// Resolves the semantic convention registry passed as argument and returns
+/// the resolved registry or an error if the resolution process failed.
+///
+/// The resolution process consists of the following steps:
+/// - Resolve all attribute references and apply the overrides when needed.
+/// - Resolve all the `extends` references.
+///
+/// # Arguments
+///
+/// * `attr_catalog` - The attribute catalog to use to resolve the attribute references.
+/// * `registry_url` - The URL of the registry.
+/// * `registry` - The semantic convention registry.
+///
+/// # Returns
+///
+/// This function returns the resolved registry or an error if the resolution process
+/// failed.
 #[allow(dead_code)] // ToDo remove this once this function is called from the CLI.
-pub fn unresolved_registry_from_specs(url: &str, specs: &SemConvSpecs) -> UnresolvedRegistry {
-    let groups = specs
+pub fn resolve_registry(
+    attr_catalog: &mut AttributeCatalog,
+    registry_url: &str,
+    registry: &SemConvSpecs,
+) -> Result<Registry, Error> {
+    let mut ureg = unresolved_registry_from_specs(registry_url, registry);
+    let mut all_refs_resolved = true;
+
+    all_refs_resolved &= resolve_attribute_references(&mut ureg, attr_catalog);
+    all_refs_resolved &= resolve_extends_references(&mut ureg);
+
+    if !all_refs_resolved {
+        // Process all unresolved references.
+        // An Error::UnresolvedReferences is built and returned.
+        let mut unresolved_refs = vec![];
+        for group in ureg.groups.iter() {
+            if let Some(extends) = group.group.extends.as_ref() {
+                unresolved_refs.push(UnresolvedReference::ExtendsRef {
+                    group_id: group.group.id.clone(),
+                    extends_ref: extends.clone(),
+                    provenance: group.provenance.clone(),
+                });
+            }
+            for attr in group.attributes.iter() {
+                if let AttributeSpec::Ref { r#ref, .. } = &attr.spec {
+                    unresolved_refs.push(UnresolvedReference::AttributeRef {
+                        group_id: group.group.id.clone(),
+                        attribute_ref: r#ref.clone(),
+                        provenance: group.provenance.clone(),
+                    });
+                }
+            }
+        }
+        if !unresolved_refs.is_empty() {
+            return Err(Error::UnresolvedReferences {
+                refs: unresolved_refs,
+            });
+        }
+    }
+
+    // Sort the attribute internal references in each group.
+    // This is needed to ensure that the resolved registry is easy to compare
+    // in unit tests.
+    ureg.registry.groups = ureg
+        .groups
+        .into_iter()
+        .map(|mut g| {
+            g.group.attributes.sort();
+            g.group
+        })
+        .collect();
+
+    Ok(ureg.registry)
+}
+
+/// Creates a semantic convention registry from a set of semantic convention
+/// specifications.
+///
+/// This function creates an unresolved registry from the given semantic
+/// convention specifications and registry url.
+///
+/// Note: this function does not resolve references.
+///
+/// # Arguments
+///
+/// * `registry_url` - The URL of the registry.
+/// * `registry` - The semantic convention specifications.
+///
+/// # Returns
+///
+/// This function returns an unresolved registry containing the semantic
+/// convention specifications.
+#[allow(dead_code)] // ToDo remove this once this function is called from the CLI.
+fn unresolved_registry_from_specs(
+    registry_url: &str,
+    registry: &SemConvSpecs,
+) -> UnresolvedRegistry {
+    let groups = registry
         .groups_with_provenance()
         .map(group_from_spec)
         .collect();
 
     UnresolvedRegistry {
         registry: Registry {
-            registry_url: url.to_string(),
+            registry_url: registry_url.to_string(),
             groups: vec![],
         },
         groups,
@@ -85,68 +201,6 @@ fn group_from_spec(group: GroupSpecWithProvenance) -> UnresolvedGroup {
     }
 }
 
-/// Resolve a semantic convention registry.
-pub fn resolve_semconv_registry(
-    attr_catalog: &mut AttributeCatalog,
-    url: &str,
-    registry: &SemConvSpecs,
-    _log: impl Logger + Sync + Clone,
-) -> Result<Registry, Error> {
-    let groups: Result<Vec<weaver_resolved_schema::registry::Group>, Error> = registry
-        .groups()
-        .map(|group| semconv_to_resolved_group(registry, attr_catalog, group))
-        .collect();
-
-    Ok(Registry {
-        registry_url: url.to_string(),
-        groups: groups?,
-    })
-}
-
-/// Resolve a semantic convention group.
-fn semconv_to_resolved_group(
-    registry: &SemConvSpecs,
-    attr_catalog: &mut AttributeCatalog,
-    group: &GroupSpec,
-) -> Result<Group, Error> {
-    let attr_refs: Result<Vec<AttributeRef>, Error> = group
-        .attributes
-        .iter()
-        .map(|attr| Ok(attr_catalog.attribute_ref(resolve_attribute(registry, attr)?)))
-        .collect();
-
-    Ok(Group {
-        id: group.id.clone(),
-        typed_group: match group.r#type {
-            ConvTypeSpec::AttributeGroup => TypedGroup::AttributeGroup {},
-            ConvTypeSpec::Span => TypedGroup::Span {
-                span_kind: group.span_kind.as_ref().map(resolve_span_kind),
-                events: group.events.clone(),
-            },
-            ConvTypeSpec::Event => TypedGroup::Event {
-                name: group.name.clone(),
-            },
-            ConvTypeSpec::Metric => TypedGroup::Metric {
-                metric_name: group.metric_name.clone(),
-                instrument: group.instrument.as_ref().map(resolve_instrument),
-                unit: group.unit.clone(),
-            },
-            ConvTypeSpec::MetricGroup => TypedGroup::MetricGroup {},
-            ConvTypeSpec::Resource => TypedGroup::Resource {},
-            ConvTypeSpec::Scope => TypedGroup::Scope {},
-        },
-        brief: group.brief.to_string(),
-        note: group.note.to_string(),
-        prefix: group.prefix.to_string(),
-        extends: group.extends.clone(),
-        stability: resolve_stability(&group.stability),
-        deprecated: group.deprecated.clone(),
-        constraints: resolve_constraints(&group.constraints),
-        attributes: attr_refs?,
-        lineage: None,
-    })
-}
-
 /// Resolves attribute references in the given registry.
 /// The resolution process is iterative. The process stops when all the
 /// attribute references are resolved or when no attribute reference could
@@ -156,7 +210,7 @@ fn semconv_to_resolved_group(
 /// attribute references.
 ///
 /// Returns true if all the attribute references could be resolved.
-pub fn resolve_attribute_references(
+fn resolve_attribute_references(
     ureg: &mut UnresolvedRegistry,
     attr_catalog: &mut AttributeCatalog,
 ) -> bool {
@@ -213,7 +267,7 @@ pub fn resolve_attribute_references(
 /// be resolved in an iteration.
 ///
 /// Returns true if all the `extends` references could be resolved.
-pub fn resolve_extends_references(ureg: &mut UnresolvedRegistry) -> bool {
+fn resolve_extends_references(ureg: &mut UnresolvedRegistry) -> bool {
     loop {
         let mut unresolved_extends_count = 0;
         let mut resolved_extends_count = 0;
@@ -269,64 +323,6 @@ pub fn resolve_extends_references(ureg: &mut UnresolvedRegistry) -> bool {
     true
 }
 
-/// Resolves the registry by resolving all groups and attributes.
-/// The resolution process consists of the following steps:
-/// - Resolve all attribute references and apply the overrides when needed.
-/// - Resolve all the `extends` references.
-#[allow(dead_code)] // ToDo remove this once this function is called from the CLI.
-pub fn resolve_registry(
-    mut ureg: UnresolvedRegistry,
-    attr_catalog: &mut AttributeCatalog,
-) -> Result<Registry, Error> {
-    let mut all_refs_resolved = true;
-
-    all_refs_resolved &= resolve_attribute_references(&mut ureg, attr_catalog);
-    all_refs_resolved &= resolve_extends_references(&mut ureg);
-
-    if !all_refs_resolved {
-        // Process all unresolved references.
-        // An Error::UnresolvedReferences is built and returned.
-        let mut unresolved_refs = vec![];
-        for group in ureg.groups.iter() {
-            if let Some(extends) = group.group.extends.as_ref() {
-                unresolved_refs.push(UnresolvedReference::ExtendsRef {
-                    group_id: group.group.id.clone(),
-                    extends_ref: extends.clone(),
-                    provenance: group.provenance.clone(),
-                });
-            }
-            for attr in group.attributes.iter() {
-                if let AttributeSpec::Ref { r#ref, .. } = &attr.spec {
-                    unresolved_refs.push(UnresolvedReference::AttributeRef {
-                        group_id: group.group.id.clone(),
-                        attribute_ref: r#ref.clone(),
-                        provenance: group.provenance.clone(),
-                    });
-                }
-            }
-        }
-        if !unresolved_refs.is_empty() {
-            return Err(Error::UnresolvedReferences {
-                refs: unresolved_refs,
-            });
-        }
-    }
-
-    // Sort the attribute internal references in each group.
-    // This is needed to ensure that the resolved registry is easy to compare
-    // in unit tests.
-    ureg.registry.groups = ureg
-        .groups
-        .into_iter()
-        .map(|mut g| {
-            g.group.attributes.sort();
-            g.group
-        })
-        .collect();
-
-    Ok(ureg.registry)
-}
-
 #[cfg(test)]
 mod tests {
     use glob::glob;
@@ -336,7 +332,7 @@ mod tests {
     use weaver_semconv::SemConvSpecs;
 
     use crate::attribute::AttributeCatalog;
-    use crate::registry::{resolve_registry, unresolved_registry_from_specs};
+    use crate::registry::resolve_registry;
 
     /// Test the resolution of semantic convention registries stored in the
     /// data directory.
@@ -380,11 +376,9 @@ mod tests {
             }
 
             let mut attr_catalog = AttributeCatalog::default();
-            let observed_registry = resolve_registry(
-                unresolved_registry_from_specs("https://semconv-registry.com", &sc_specs),
-                &mut attr_catalog,
-            )
-            .expect("Failed to resolve registry");
+            let observed_registry =
+                resolve_registry(&mut attr_catalog, "https://semconv-registry.com", &sc_specs)
+                    .expect("Failed to resolve registry");
 
             // Load the expected registry and attribute catalog.
             let expected_attr_catalog: Vec<attribute::Attribute> = serde_json::from_reader(

--- a/crates/weaver_resolver/src/resource.rs
+++ b/crates/weaver_resolver/src/resource.rs
@@ -5,20 +5,20 @@
 use crate::attribute::resolve_attributes;
 use crate::Error;
 use weaver_schema::schema_spec::SchemaSpec;
-use weaver_semconv::SemConvSpecs;
+use weaver_semconv::SemConvRegistry;
 use weaver_version::VersionChanges;
 
 /// Resolves resource attributes.
 pub fn resolve_resource(
     schema: &mut SchemaSpec,
-    sem_conv_catalog: &SemConvSpecs,
+    semconv_registry: &SemConvRegistry,
     version_changes: &VersionChanges,
 ) -> Result<(), Error> {
     // Resolve resource attributes
     if let Some(res) = schema.resource.as_mut() {
         res.attributes = resolve_attributes(
             res.attributes.as_ref(),
-            sem_conv_catalog,
+            semconv_registry,
             version_changes.log_attribute_changes(),
         )?;
     }

--- a/crates/weaver_resolver/src/spans.rs
+++ b/crates/weaver_resolver/src/spans.rs
@@ -6,38 +6,38 @@ use crate::attribute::resolve_attributes;
 use crate::Error;
 use weaver_schema::schema_spec::SchemaSpec;
 use weaver_semconv::group::SpanKindSpec;
-use weaver_semconv::SemConvSpecs;
+use weaver_semconv::SemConvRegistry;
 use weaver_version::VersionChanges;
 
 /// Resolves resource spans in the given schema.
 pub fn resolve_spans(
     schema: &mut SchemaSpec,
-    sem_conv_catalog: &SemConvSpecs,
+    semconv_registry: &SemConvRegistry,
     version_changes: VersionChanges,
 ) -> Result<(), Error> {
     if let Some(spans) = schema.resource_spans.as_mut() {
         spans.attributes = resolve_attributes(
             spans.attributes.as_ref(),
-            sem_conv_catalog,
+            semconv_registry,
             version_changes.span_attribute_changes(),
         )?;
         for span in spans.spans.iter_mut() {
             span.attributes = resolve_attributes(
                 span.attributes.as_ref(),
-                sem_conv_catalog,
+                semconv_registry,
                 version_changes.span_attribute_changes(),
             )?;
             for event in span.events.iter_mut() {
                 event.attributes = resolve_attributes(
                     event.attributes.as_ref(),
-                    sem_conv_catalog,
+                    semconv_registry,
                     version_changes.span_attribute_changes(),
                 )?;
             }
             for link in span.links.iter_mut() {
                 link.attributes = resolve_attributes(
                     link.attributes.as_ref(),
-                    sem_conv_catalog,
+                    semconv_registry,
                     version_changes.span_attribute_changes(),
                 )?;
             }

--- a/crates/weaver_schema/src/lib.rs
+++ b/crates/weaver_schema/src/lib.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use weaver_semconv::SemConvSpecs;
+use weaver_semconv::SemConvRegistry;
 use weaver_version::Versions;
 
 use crate::event::Event;
@@ -112,7 +112,7 @@ pub struct TelemetrySchema {
     /// The semantic convention registry used to resolve the schema
     /// (if resolved).
     #[serde(skip)]
-    pub semantic_convention_registry: SemConvSpecs,
+    pub semantic_convention_registry: SemConvRegistry,
 }
 
 /// A semantic convention import.
@@ -204,7 +204,7 @@ impl TelemetrySchema {
     }
 
     /// Sets the semantic convention catalog used to resolve the schema.
-    pub fn set_semantic_convention_catalog(&mut self, catalog: SemConvSpecs) {
+    pub fn set_semantic_convention_catalog(&mut self, catalog: SemConvRegistry) {
         self.semantic_convention_registry = catalog;
     }
 
@@ -240,7 +240,7 @@ impl TelemetrySchema {
     }
 
     /// Returns the semantic convention catalog used to resolve the schema (if resolved).
-    pub fn semantic_convention_catalog(&self) -> &SemConvSpecs {
+    pub fn semantic_convention_catalog(&self) -> &SemConvRegistry {
         &self.semantic_convention_registry
     }
 

--- a/crates/weaver_semconv/src/lib.rs
+++ b/crates/weaver_semconv/src/lib.rs
@@ -155,10 +155,10 @@ pub struct MetricSpecWithProvenance {
     pub provenance: String,
 }
 
-/// A semantic convention specs is a collection of semantic convention
+/// A semantic convention registry is a collection of semantic convention
 /// specifications indexed by group id.
 #[derive(Default, Debug)]
-pub struct SemConvSpecs {
+pub struct SemConvRegistry {
     /// The number of semantic convention assets added in the semantic convention registry.
     /// A asset can be a semantic convention loaded from a file or an URL.
     asset_count: usize,
@@ -280,7 +280,7 @@ struct MetricToResolve {
     r#ref: String,
 }
 
-impl SemConvSpecs {
+impl SemConvRegistry {
     /// Load and add a semantic convention file to the semantic convention registry.
     pub fn load_from_file<P: AsRef<Path> + Clone>(&mut self, path: P) -> Result<(), Error> {
         let spec = SemConvSpec::load_from_file(path.clone())?;
@@ -809,7 +809,7 @@ mod tests {
             "data/tls.yaml",
         ];
 
-        let mut catalog = SemConvSpecs::default();
+        let mut catalog = SemConvRegistry::default();
         for yaml in yaml_files {
             let result = catalog.load_from_file(yaml);
             assert!(result.is_ok(), "{:#?}", result.err().unwrap());
@@ -856,7 +856,7 @@ mod tests {
             "data/url.yaml",
         ];
 
-        let mut catalog = SemConvSpecs::default();
+        let mut catalog = SemConvRegistry::default();
         for yaml in yaml_files {
             let result = catalog.load_from_file(yaml);
             assert!(result.is_ok(), "{:#?}", result.err().unwrap());

--- a/scripts/check_external_types.sh
+++ b/scripts/check_external_types.sh
@@ -8,7 +8,7 @@
 for dir in crates/*/; do
   # Check if the public API is compliant with the allowed-external-types.toml
   echo "Checking the public API of $dir"
-  cargo +nightly-2023-10-10 check-external-types --all-features --manifest-path "$dir/Cargo.toml" --config "$dir/allowed-external-types.toml" || exit 1
+  cargo +nightly-2024-02-07 check-external-types --all-features --manifest-path "$dir/Cargo.toml" --config "$dir/allowed-external-types.toml" || exit 1
 done
 
 echo "The Cargo workspace is compliant with the 'allowed external types' policies."

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -30,7 +30,7 @@ use theme::ThemeConfig;
 use weaver_cache::Cache;
 use weaver_logger::Logger;
 use weaver_resolver::attribute::AttributeCatalog;
-use weaver_resolver::registry::resolve_registry;
+use weaver_resolver::registry::resolve_semconv_registry;
 use weaver_resolver::SchemaResolver;
 use weaver_schema::attribute::Attribute;
 use weaver_schema::TelemetrySchema;
@@ -226,7 +226,7 @@ fn search_registry_command2(
 
     let mut attr_catalog = AttributeCatalog::default();
     let resolved_registry =
-        resolve_registry(&mut attr_catalog, &registry_args.registry, &semconv_specs)
+        resolve_semconv_registry(&mut attr_catalog, &registry_args.registry, &semconv_specs)
             .unwrap_or_else(|e| {
                 log.error(&format!("{}", e));
                 std::process::exit(1);

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -30,7 +30,7 @@ use theme::ThemeConfig;
 use weaver_cache::Cache;
 use weaver_logger::Logger;
 use weaver_resolver::attribute::AttributeCatalog;
-use weaver_resolver::registry::{resolve_registry, unresolved_registry_from_specs};
+use weaver_resolver::registry::resolve_registry;
 use weaver_resolver::SchemaResolver;
 use weaver_schema::attribute::Attribute;
 use weaver_schema::TelemetrySchema;
@@ -225,14 +225,12 @@ fn search_registry_command2(
     });
 
     let mut attr_catalog = AttributeCatalog::default();
-    let resolved_registry = resolve_registry(
-        unresolved_registry_from_specs(&registry_args.registry, &semconv_specs),
-        &mut attr_catalog,
-    )
-    .unwrap_or_else(|e| {
-        log.error(&format!("{}", e));
-        std::process::exit(1);
-    });
+    let resolved_registry =
+        resolve_registry(&mut attr_catalog, &registry_args.registry, &semconv_specs)
+            .unwrap_or_else(|e| {
+                log.error(&format!("{}", e));
+                std::process::exit(1);
+            });
 
     dbg!(resolved_registry);
     //dbg!(attr_catalog);

--- a/tests/resolution_process.rs
+++ b/tests/resolution_process.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the resolution process.
+
+use weaver_cache::Cache;
+use weaver_logger::{Logger, TestLogger};
+use weaver_resolver::attribute::AttributeCatalog;
+use weaver_resolver::registry::resolve_semconv_registry;
+use weaver_resolver::SchemaResolver;
+
+/// The URL of the official semantic convention registry.
+const SEMCONV_REGISTRY_URL: &str = "https://github.com/open-telemetry/semantic-conventions.git";
+/// The directory name of the official semantic convention registry.
+const SEMCONV_REGISTRY_MODEL: &str = "model";
+
+/// Test the resolution process for the official semantic convention registry.
+/// Success criteria:
+/// - All semconv files downloaded from the official semconv repo.
+/// - The parsing process should not fail.
+/// - The resolution process should not fail.
+/// - No warn or error messages should be reported by the logger.
+#[test]
+fn test_semconv_registry_resolution() {
+    let log = TestLogger::new();
+    let cache = Cache::try_new().unwrap_or_else(|e| {
+        log.error(&e.to_string());
+        panic!("Failed to create the git cache repo, error: {e}");
+    });
+
+    // Load the official semantic convention registry into a local cache.
+    // No parsing errors should be observed.
+    let semconv_specs = SchemaResolver::load_semconv_registry(
+        SEMCONV_REGISTRY_URL.to_string(),
+        Some(SEMCONV_REGISTRY_MODEL.to_string()),
+        &cache,
+        log.clone(),
+    )
+    .unwrap_or_else(|e| {
+        panic!("Failed to load and parse the official semantic convention registry, error: {e}");
+    });
+
+    // Check if the logger has reported any warnings or errors.
+    assert_eq!(log.warn_count(), 0);
+    assert_eq!(log.error_count(), 0);
+
+    // Resolve the official semantic convention registry.
+    let mut attr_catalog = AttributeCatalog::default();
+    let resolved_registry =
+        resolve_semconv_registry(&mut attr_catalog, SEMCONV_REGISTRY_URL, &semconv_specs)
+            .unwrap_or_else(|e| {
+                panic!("Failed to resolve the official semantic convention registry, error: {e}");
+            });
+
+    // The number of semconv groups is fluctuating, so we can't check for a
+    // specific number, but we can check if there are any groups at all.
+    assert!(!resolved_registry.groups.is_empty());
+
+    // Check if the logger has reported any warnings or errors.
+    assert_eq!(log.warn_count(), 0);
+    assert_eq!(log.error_count(), 0);
+}
+
+/// Test the resolution process for the official Telemetry Schema.
+/// Success criteria: The resolution process should not fail.
+#[test]
+fn test_telemetry_schema_resolution() {
+    // ToDo once the official Application Telemetry Schema is approved and implemented by this project.
+}


### PR DESCRIPTION
This PR tests the resolution process of the official semantic registry. This integration test doesn't intend to precisely check that each reference and 'extends' clause are properly resolved. The goal is to ensure that no errors are raised during the loading and resolution of the official registry.

Success criteria:
- All semconv files downloaded from the official semconv repo.
- The parsing process should not fail.
- The resolution process should not fail.
- No warn or error messages should be reported by the logger.

This PR serves as an example of a first integration test. More should follow.

Note: some refactoring has also been performed to use the term 'semconv registry' instead of 'semconv catalog' to be more aligned with OpenTelemetry wording.