### PR TITLE
Add filtering markdown by tag to markdown snippet generation

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -3,4 +3,5 @@ warn-on-all-wildcard-imports = true
 allow-expect-in-tests = true
 allow-unwrap-in-tests = true
 allow-dbg-in-tests = true
+allow-print-in-tests = true
 disallowed-methods = []

--- a/crates/weaver_semconv/src/attribute.rs
+++ b/crates/weaver_semconv/src/attribute.rs
@@ -319,6 +319,8 @@ pub struct EnumEntriesSpec {
     /// Longer description.
     /// It defaults to an empty string.
     pub note: Option<String>,
+    /// Stability of this enum value.
+    pub stability: Option<Stability>,
 }
 
 /// Implements a human readable display for EnumEntries.

--- a/crates/weaver_semconv_gen/data/http-metric-semconv.md
+++ b/crates/weaver_semconv_gen/data/http-metric-semconv.md
@@ -76,19 +76,36 @@ of `[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 
 <!-- endsemconv -->
 
 <!-- semconv metric.http.server.request.duration(full) -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|
-| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [1] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
-| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`url.scheme`](../attributes-registry/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. [2] | `http`; `https` | Required |
+| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [3] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
 | [`http.response.status_code`](../attributes-registry/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`http.route`](../attributes-registry/http.md) | string | The matched route, that is, the path template in the format used by the respective server framework. [3] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [4] | `http`; `spdy` | Conditionally Required: [5] |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [6] | `1.0`; `1.1`; `2`; `3` | Recommended |
-| [`server.address`](../attributes-registry/server.md) | string | Name of the local HTTP server that received the request. [7] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Opt-In |
-| [`server.port`](../attributes-registry/server.md) | int | Port of the local HTTP server that received the request. [8] | `80`; `8080`; `443` | Opt-In |
-| [`url.scheme`](../attributes-registry/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. [9] | `http`; `https` | Required |
+| [`http.route`](../attributes-registry/http.md) | string | The matched route, that is, the path template in the format used by the respective server framework. [4] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
+| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [5] | `http`; `spdy` | Conditionally Required: [6] |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [7] | `1.0`; `1.1`; `2`; `3` | Recommended |
+| [`server.address`](../attributes-registry/server.md) | string | Name of the local HTTP server that received the request. [8] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Opt-In |
+| [`server.port`](../attributes-registry/server.md) | int | Port of the local HTTP server that received the request. [9] | `80`; `8080`; `443` | Opt-In |
 
-**[1]:** If the request fails with an error before response status code was sent or received,
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
+By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+
+If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+
+HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** The scheme of the original client request, if known (e.g. from [Forwarded#proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded#proto), [X-Forwarded-Proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-Proto), or a similar header). Otherwise, the scheme of the immediate peer request.
+
+**[3]:** If the request fails with an error before response status code was sent or received,
 `error.type` SHOULD be set to exception type (its fully-qualified class name, if applicable)
 or a component-specific low cardinality error identifier.
 
@@ -105,62 +122,45 @@ additional filters are applied.
 
 If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
-By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-
-If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
-
-If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
-the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
-
-HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
-Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
-
-**[3]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+**[4]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
-**[4]:** The value SHOULD be normalized to lowercase.
+**[5]:** The value SHOULD be normalized to lowercase.
 
-**[5]:** If not `http` and `network.protocol.version` is set.
+**[6]:** If not `http` and `network.protocol.version` is set.
 
-**[6]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
-
-**[7]:** See [Setting `server.address` and `server.port` attributes](/docs/http/http-spans.md#setting-serveraddress-and-serverport-attributes).
-> **Warning**
-> Since this attribute is based on HTTP headers, opting in to it may allow an attacker
-> to trigger cardinality limits, degrading the usefulness of the metric.
+**[7]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
 **[8]:** See [Setting `server.address` and `server.port` attributes](/docs/http/http-spans.md#setting-serveraddress-and-serverport-attributes).
 > **Warning**
 > Since this attribute is based on HTTP headers, opting in to it may allow an attacker
 > to trigger cardinality limits, degrading the usefulness of the metric.
 
-**[9]:** The scheme of the original client request, if known (e.g. from [Forwarded#proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded#proto), [X-Forwarded-Proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-Proto), or a similar header). Otherwise, the scheme of the immediate peer request.
+**[9]:** See [Setting `server.address` and `server.port` attributes](/docs/http/http-spans.md#setting-serveraddress-and-serverport-attributes).
+> **Warning**
+> Since this attribute is based on HTTP headers, opting in to it may allow an attacker
+> to trigger cardinality limits, degrading the usefulness of the metric.
 
-`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value  | Description |
-|---|---|
-| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. |
+| Value  | Description | Stability |
+|---|---|---|
+| `CONNECT` | CONNECT method. | Experimental |
+| `DELETE` | DELETE method. | Experimental |
+| `GET` | GET method. | Experimental |
+| `HEAD` | HEAD method. | Experimental |
+| `OPTIONS` | OPTIONS method. | Experimental |
+| `PATCH` | PATCH method. | Experimental |
+| `POST` | POST method. | Experimental |
+| `PUT` | PUT method. | Experimental |
+| `TRACE` | TRACE method. | Experimental |
+| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. | Experimental |
 
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
+| Value  | Description | Stability |
+|---|---|---|
+| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. | Experimental |
 <!-- endsemconv -->
 
 ### Metric: `http.server.active_requests`
@@ -239,19 +239,36 @@ This metric is optional.
 <!-- endsemconv -->
 
 <!-- semconv metric.http.server.request.body.size(full) -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|
-| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [1] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
-| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`url.scheme`](../attributes-registry/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. [2] | `http`; `https` | Required |
+| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [3] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
 | [`http.response.status_code`](../attributes-registry/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`http.route`](../attributes-registry/http.md) | string | The matched route, that is, the path template in the format used by the respective server framework. [3] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [4] | `http`; `spdy` | Conditionally Required: [5] |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [6] | `1.0`; `1.1`; `2`; `3` | Recommended |
-| [`server.address`](../attributes-registry/server.md) | string | Name of the local HTTP server that received the request. [7] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Opt-In |
-| [`server.port`](../attributes-registry/server.md) | int | Port of the local HTTP server that received the request. [8] | `80`; `8080`; `443` | Opt-In |
-| [`url.scheme`](../attributes-registry/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. [9] | `http`; `https` | Required |
+| [`http.route`](../attributes-registry/http.md) | string | The matched route, that is, the path template in the format used by the respective server framework. [4] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
+| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [5] | `http`; `spdy` | Conditionally Required: [6] |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [7] | `1.0`; `1.1`; `2`; `3` | Recommended |
+| [`server.address`](../attributes-registry/server.md) | string | Name of the local HTTP server that received the request. [8] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Opt-In |
+| [`server.port`](../attributes-registry/server.md) | int | Port of the local HTTP server that received the request. [9] | `80`; `8080`; `443` | Opt-In |
 
-**[1]:** If the request fails with an error before response status code was sent or received,
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
+By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+
+If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+
+HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** The scheme of the original client request, if known (e.g. from [Forwarded#proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded#proto), [X-Forwarded-Proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-Proto), or a similar header). Otherwise, the scheme of the immediate peer request.
+
+**[3]:** If the request fails with an error before response status code was sent or received,
 `error.type` SHOULD be set to exception type (its fully-qualified class name, if applicable)
 or a component-specific low cardinality error identifier.
 
@@ -268,62 +285,45 @@ additional filters are applied.
 
 If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
-By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-
-If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
-
-If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
-the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
-
-HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
-Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
-
-**[3]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+**[4]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
-**[4]:** The value SHOULD be normalized to lowercase.
+**[5]:** The value SHOULD be normalized to lowercase.
 
-**[5]:** If not `http` and `network.protocol.version` is set.
+**[6]:** If not `http` and `network.protocol.version` is set.
 
-**[6]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
-
-**[7]:** See [Setting `server.address` and `server.port` attributes](/docs/http/http-spans.md#setting-serveraddress-and-serverport-attributes).
-> **Warning**
-> Since this attribute is based on HTTP headers, opting in to it may allow an attacker
-> to trigger cardinality limits, degrading the usefulness of the metric.
+**[7]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
 **[8]:** See [Setting `server.address` and `server.port` attributes](/docs/http/http-spans.md#setting-serveraddress-and-serverport-attributes).
 > **Warning**
 > Since this attribute is based on HTTP headers, opting in to it may allow an attacker
 > to trigger cardinality limits, degrading the usefulness of the metric.
 
-**[9]:** The scheme of the original client request, if known (e.g. from [Forwarded#proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded#proto), [X-Forwarded-Proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-Proto), or a similar header). Otherwise, the scheme of the immediate peer request.
+**[9]:** See [Setting `server.address` and `server.port` attributes](/docs/http/http-spans.md#setting-serveraddress-and-serverport-attributes).
+> **Warning**
+> Since this attribute is based on HTTP headers, opting in to it may allow an attacker
+> to trigger cardinality limits, degrading the usefulness of the metric.
 
-`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value  | Description |
-|---|---|
-| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. |
+| Value  | Description | Stability |
+|---|---|---|
+| `CONNECT` | CONNECT method. | Experimental |
+| `DELETE` | DELETE method. | Experimental |
+| `GET` | GET method. | Experimental |
+| `HEAD` | HEAD method. | Experimental |
+| `OPTIONS` | OPTIONS method. | Experimental |
+| `PATCH` | PATCH method. | Experimental |
+| `POST` | POST method. | Experimental |
+| `PUT` | PUT method. | Experimental |
+| `TRACE` | TRACE method. | Experimental |
+| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. | Experimental |
 
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
+| Value  | Description | Stability |
+|---|---|---|
+| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. | Experimental |
 <!-- endsemconv -->
 
 ### Metric: `http.server.response.body.size`
@@ -341,19 +341,36 @@ This metric is optional.
 <!-- endsemconv -->
 
 <!-- semconv metric.http.server.response.body.size(full) -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|
-| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [1] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
-| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`url.scheme`](../attributes-registry/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. [2] | `http`; `https` | Required |
+| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [3] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
 | [`http.response.status_code`](../attributes-registry/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`http.route`](../attributes-registry/http.md) | string | The matched route, that is, the path template in the format used by the respective server framework. [3] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [4] | `http`; `spdy` | Conditionally Required: [5] |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [6] | `1.0`; `1.1`; `2`; `3` | Recommended |
-| [`server.address`](../attributes-registry/server.md) | string | Name of the local HTTP server that received the request. [7] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Opt-In |
-| [`server.port`](../attributes-registry/server.md) | int | Port of the local HTTP server that received the request. [8] | `80`; `8080`; `443` | Opt-In |
-| [`url.scheme`](../attributes-registry/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. [9] | `http`; `https` | Required |
+| [`http.route`](../attributes-registry/http.md) | string | The matched route, that is, the path template in the format used by the respective server framework. [4] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
+| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [5] | `http`; `spdy` | Conditionally Required: [6] |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [7] | `1.0`; `1.1`; `2`; `3` | Recommended |
+| [`server.address`](../attributes-registry/server.md) | string | Name of the local HTTP server that received the request. [8] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Opt-In |
+| [`server.port`](../attributes-registry/server.md) | int | Port of the local HTTP server that received the request. [9] | `80`; `8080`; `443` | Opt-In |
 
-**[1]:** If the request fails with an error before response status code was sent or received,
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
+By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+
+If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+
+HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** The scheme of the original client request, if known (e.g. from [Forwarded#proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded#proto), [X-Forwarded-Proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-Proto), or a similar header). Otherwise, the scheme of the immediate peer request.
+
+**[3]:** If the request fails with an error before response status code was sent or received,
 `error.type` SHOULD be set to exception type (its fully-qualified class name, if applicable)
 or a component-specific low cardinality error identifier.
 
@@ -370,62 +387,45 @@ additional filters are applied.
 
 If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
-By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-
-If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
-
-If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
-the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
-
-HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
-Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
-
-**[3]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+**[4]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
 
-**[4]:** The value SHOULD be normalized to lowercase.
+**[5]:** The value SHOULD be normalized to lowercase.
 
-**[5]:** If not `http` and `network.protocol.version` is set.
+**[6]:** If not `http` and `network.protocol.version` is set.
 
-**[6]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
-
-**[7]:** See [Setting `server.address` and `server.port` attributes](/docs/http/http-spans.md#setting-serveraddress-and-serverport-attributes).
-> **Warning**
-> Since this attribute is based on HTTP headers, opting in to it may allow an attacker
-> to trigger cardinality limits, degrading the usefulness of the metric.
+**[7]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
 **[8]:** See [Setting `server.address` and `server.port` attributes](/docs/http/http-spans.md#setting-serveraddress-and-serverport-attributes).
 > **Warning**
 > Since this attribute is based on HTTP headers, opting in to it may allow an attacker
 > to trigger cardinality limits, degrading the usefulness of the metric.
 
-**[9]:** The scheme of the original client request, if known (e.g. from [Forwarded#proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded#proto), [X-Forwarded-Proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-Proto), or a similar header). Otherwise, the scheme of the immediate peer request.
+**[9]:** See [Setting `server.address` and `server.port` attributes](/docs/http/http-spans.md#setting-serveraddress-and-serverport-attributes).
+> **Warning**
+> Since this attribute is based on HTTP headers, opting in to it may allow an attacker
+> to trigger cardinality limits, degrading the usefulness of the metric.
 
-`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value  | Description |
-|---|---|
-| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. |
+| Value  | Description | Stability |
+|---|---|---|
+| `CONNECT` | CONNECT method. | Experimental |
+| `DELETE` | DELETE method. | Experimental |
+| `GET` | GET method. | Experimental |
+| `HEAD` | HEAD method. | Experimental |
+| `OPTIONS` | OPTIONS method. | Experimental |
+| `PATCH` | PATCH method. | Experimental |
+| `POST` | POST method. | Experimental |
+| `PUT` | PUT method. | Experimental |
+| `TRACE` | TRACE method. | Experimental |
+| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. | Experimental |
 
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
+| Value  | Description | Stability |
+|---|---|---|
+| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. | Experimental |
 <!-- endsemconv -->
 
 ## HTTP Client
@@ -449,18 +449,37 @@ of `[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 
 <!-- endsemconv -->
 
 <!-- semconv metric.http.client.request.duration(full) -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|
-| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [1] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
-| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`server.address`](../attributes-registry/server.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
+| [`server.port`](../attributes-registry/server.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Required |
+| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [4] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
 | [`http.response.status_code`](../attributes-registry/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [3] | `http`; `spdy` | Conditionally Required: [4] |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [5] | `1.0`; `1.1`; `2`; `3` | Recommended |
-| [`server.address`](../attributes-registry/server.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [6] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
-| [`server.port`](../attributes-registry/server.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [7] | `80`; `8080`; `443` | Required |
+| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [5] | `http`; `spdy` | Conditionally Required: [6] |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [7] | `1.0`; `1.1`; `2`; `3` | Recommended |
 | [`url.scheme`](../attributes-registry/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Opt-In |
 
-**[1]:** If the request fails with an error before response status code was sent or received,
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
+By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+
+If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+
+HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
+
+**[3]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
+
+**[4]:** If the request fails with an error before response status code was sent or received,
 `error.type` SHOULD be set to exception type (its fully-qualified class name, if applicable)
 or a component-specific low cardinality error identifier.
 
@@ -477,51 +496,32 @@ additional filters are applied.
 
 If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
-By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+**[5]:** The value SHOULD be normalized to lowercase.
 
-If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+**[6]:** If not `http` and `network.protocol.version` is set.
 
-If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
-the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+**[7]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
-Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-**[3]:** The value SHOULD be normalized to lowercase.
+| Value  | Description | Stability |
+|---|---|---|
+| `CONNECT` | CONNECT method. | Experimental |
+| `DELETE` | DELETE method. | Experimental |
+| `GET` | GET method. | Experimental |
+| `HEAD` | HEAD method. | Experimental |
+| `OPTIONS` | OPTIONS method. | Experimental |
+| `PATCH` | PATCH method. | Experimental |
+| `POST` | POST method. | Experimental |
+| `PUT` | PUT method. | Experimental |
+| `TRACE` | TRACE method. | Experimental |
+| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. | Experimental |
 
-**[4]:** If not `http` and `network.protocol.version` is set.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-**[5]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
-
-**[6]:** If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
-
-**[7]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
-
-`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. |
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
+| Value  | Description | Stability |
+|---|---|---|
+| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. | Experimental |
 <!-- endsemconv -->
 
 ### Metric: `http.client.request.body.size`
@@ -539,18 +539,37 @@ This metric is optional.
 <!-- endsemconv -->
 
 <!-- semconv metric.http.client.request.body.size(full) -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|
-| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [1] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
-| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`server.address`](../attributes-registry/server.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
+| [`server.port`](../attributes-registry/server.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Required |
+| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [4] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
 | [`http.response.status_code`](../attributes-registry/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [3] | `http`; `spdy` | Conditionally Required: [4] |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [5] | `1.0`; `1.1`; `2`; `3` | Recommended |
-| [`server.address`](../attributes-registry/server.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [6] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
-| [`server.port`](../attributes-registry/server.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [7] | `80`; `8080`; `443` | Required |
+| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [5] | `http`; `spdy` | Conditionally Required: [6] |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [7] | `1.0`; `1.1`; `2`; `3` | Recommended |
 | [`url.scheme`](../attributes-registry/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Opt-In |
 
-**[1]:** If the request fails with an error before response status code was sent or received,
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
+By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+
+If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+
+HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
+
+**[3]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
+
+**[4]:** If the request fails with an error before response status code was sent or received,
 `error.type` SHOULD be set to exception type (its fully-qualified class name, if applicable)
 or a component-specific low cardinality error identifier.
 
@@ -567,51 +586,32 @@ additional filters are applied.
 
 If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
-By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+**[5]:** The value SHOULD be normalized to lowercase.
 
-If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+**[6]:** If not `http` and `network.protocol.version` is set.
 
-If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
-the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+**[7]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
-Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-**[3]:** The value SHOULD be normalized to lowercase.
+| Value  | Description | Stability |
+|---|---|---|
+| `CONNECT` | CONNECT method. | Experimental |
+| `DELETE` | DELETE method. | Experimental |
+| `GET` | GET method. | Experimental |
+| `HEAD` | HEAD method. | Experimental |
+| `OPTIONS` | OPTIONS method. | Experimental |
+| `PATCH` | PATCH method. | Experimental |
+| `POST` | POST method. | Experimental |
+| `PUT` | PUT method. | Experimental |
+| `TRACE` | TRACE method. | Experimental |
+| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. | Experimental |
 
-**[4]:** If not `http` and `network.protocol.version` is set.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-**[5]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
-
-**[6]:** If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
-
-**[7]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
-
-`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. |
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
+| Value  | Description | Stability |
+|---|---|---|
+| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. | Experimental |
 <!-- endsemconv -->
 
 ### Metric: `http.client.response.body.size`
@@ -629,18 +629,37 @@ This metric is optional.
 <!-- endsemconv -->
 
 <!-- semconv metric.http.client.response.body.size(full) -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|
-| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [1] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
-| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`server.address`](../attributes-registry/server.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
+| [`server.port`](../attributes-registry/server.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Required |
+| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [4] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
 | [`http.response.status_code`](../attributes-registry/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [3] | `http`; `spdy` | Conditionally Required: [4] |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [5] | `1.0`; `1.1`; `2`; `3` | Recommended |
-| [`server.address`](../attributes-registry/server.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [6] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
-| [`server.port`](../attributes-registry/server.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [7] | `80`; `8080`; `443` | Required |
+| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [5] | `http`; `spdy` | Conditionally Required: [6] |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [7] | `1.0`; `1.1`; `2`; `3` | Recommended |
 | [`url.scheme`](../attributes-registry/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Opt-In |
 
-**[1]:** If the request fails with an error before response status code was sent or received,
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
+By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+
+If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+
+HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
+
+**[3]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
+
+**[4]:** If the request fails with an error before response status code was sent or received,
 `error.type` SHOULD be set to exception type (its fully-qualified class name, if applicable)
 or a component-specific low cardinality error identifier.
 
@@ -657,51 +676,32 @@ additional filters are applied.
 
 If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
-By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+**[5]:** The value SHOULD be normalized to lowercase.
 
-If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+**[6]:** If not `http` and `network.protocol.version` is set.
 
-If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
-the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+**[7]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
-Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-**[3]:** The value SHOULD be normalized to lowercase.
+| Value  | Description | Stability |
+|---|---|---|
+| `CONNECT` | CONNECT method. | Experimental |
+| `DELETE` | DELETE method. | Experimental |
+| `GET` | GET method. | Experimental |
+| `HEAD` | HEAD method. | Experimental |
+| `OPTIONS` | OPTIONS method. | Experimental |
+| `PATCH` | PATCH method. | Experimental |
+| `POST` | POST method. | Experimental |
+| `PUT` | PUT method. | Experimental |
+| `TRACE` | TRACE method. | Experimental |
+| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. | Experimental |
 
-**[4]:** If not `http` and `network.protocol.version` is set.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-**[5]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
-
-**[6]:** If an HTTP client request is explicitly made to an IP address, e.g. `http://x.x.x.x:8080`, then `server.address` SHOULD be the IP address `x.x.x.x`. A DNS lookup SHOULD NOT be used.
-
-**[7]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
-
-`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. |
-
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
-
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
+| Value  | Description | Stability |
+|---|---|---|
+| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. | Experimental |
 <!-- endsemconv -->
 
 ### Metric: `http.client.open_connections`
@@ -757,19 +757,19 @@ This metric is optional.
 <!-- endsemconv -->
 
 <!-- semconv metric.http.client.connection.duration(full) -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|
+| [`server.address`](../attributes-registry/server.md) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [1] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
+| [`server.port`](../attributes-registry/server.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `80`; `8080`; `443` | Required |
 | [`network.peer.address`](../attributes-registry/network.md) | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` | Recommended |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [1] | `3.1.1` | Recommended |
-| [`server.address`](../attributes-registry/server.md) | string | Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. [2] | `example.com`; `10.1.2.80`; `/tmp/my.sock` | Required |
-| [`server.port`](../attributes-registry/server.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Required |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [3] | `3.1.1` | Recommended |
 | [`url.scheme`](../attributes-registry/url.md) | string | The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol. | `http`; `https` | Opt-In |
 
-**[1]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[1]:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
 
-**[2]:** When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
+**[2]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
 
-**[3]:** When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
+**[3]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 <!-- endsemconv -->
 
 ### Metric: `http.client.active_requests`

--- a/crates/weaver_semconv_gen/data/http-span-full-attribute-table.md
+++ b/crates/weaver_semconv_gen/data/http-span-full-attribute-table.md
@@ -1,18 +1,33 @@
 <!-- semconv trace.http.common(full) -->
-| Attribute  | Type | Description  | Examples  | Requirement Level |
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|
-| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [1] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
-| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [2] | `GET`; `POST`; `HEAD` | Required |
+| [`http.request.method`](../attributes-registry/http.md) | string | HTTP request method. [1] | `GET`; `POST`; `HEAD` | Required |
+| [`error.type`](../attributes-registry/error.md) | string | Describes a class of error the operation ended with. [2] | `timeout`; `java.net.UnknownHostException`; `server_certificate_invalid`; `500` | Conditionally Required: If request has ended with an error. |
 | [`http.request.method_original`](../attributes-registry/http.md) | string | Original HTTP method sent by the client in the request line. | `GeT`; `ACL`; `foo` | Conditionally Required: [3] |
-| [`http.response.header.<key>`](../attributes-registry/http.md) | string[] | HTTP response headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values. [4] | `http.response.header.content-type=["application/json"]`; `http.response.header.my-custom-header=["abc", "def"]` | Opt-In |
 | [`http.response.status_code`](../attributes-registry/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [4] | `http`; `spdy` | Conditionally Required: [5] |
 | [`network.peer.address`](../attributes-registry/network.md) | string | Peer address of the network connection - IP address or Unix domain socket name. | `10.1.2.80`; `/tmp/my.sock` | Recommended |
 | [`network.peer.port`](../attributes-registry/network.md) | int | Peer port number of the network connection. | `65123` | Recommended: If `network.peer.address` is set. |
-| [`network.protocol.name`](../attributes-registry/network.md) | string | [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent. [5] | `http`; `spdy` | Conditionally Required: [6] |
-| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [7] | `1.0`; `1.1`; `2`; `3` | Recommended |
+| [`network.protocol.version`](../attributes-registry/network.md) | string | Version of the protocol specified in `network.protocol.name`. [6] | `1.0`; `1.1`; `2`; `3` | Recommended |
+| [`http.response.header.<key>`](../attributes-registry/http.md) | string[] | HTTP response headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values. [7] | `http.response.header.content-type=["application/json"]`; `http.response.header.my-custom-header=["abc", "def"]` | Opt-In |
 | [`network.transport`](../attributes-registry/network.md) | string | [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication). [8] | `tcp`; `udp` | Opt-In |
 
-**[1]:** If the request fails with an error before response status code was sent or received,
+**[1]:** HTTP request method value SHOULD be "known" to the instrumentation.
+By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+
+If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+
+If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+
+HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+
+**[2]:** If the request fails with an error before response status code was sent or received,
 `error.type` SHOULD be set to exception type (its fully-qualified class name, if applicable)
 or a component-specific low cardinality error identifier.
 
@@ -29,32 +44,17 @@ additional filters are applied.
 
 If the request has completed successfully, instrumentations SHOULD NOT set `error.type`.
 
-**[2]:** HTTP request method value SHOULD be "known" to the instrumentation.
-By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
-and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
-
-If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
-
-If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
-the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
-OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
-(this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
-
-HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
-Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
-Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
-
 **[3]:** If and only if it's different than `http.request.method`.
 
-**[4]:** Instrumentations SHOULD require an explicit configuration of which headers are to be captured. Including all response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
+**[4]:** The value SHOULD be normalized to lowercase.
+
+**[5]:** If not `http` and `network.protocol.version` is set.
+
+**[6]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[7]:** Instrumentations SHOULD require an explicit configuration of which headers are to be captured. Including all response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
 Users MAY explicitly configure instrumentations to capture them even though it is not recommended.
 The attribute value MUST consist of either multiple header values as an array of strings or a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.
-
-**[5]:** The value SHOULD be normalized to lowercase.
-
-**[6]:** If not `http` and `network.protocol.version` is set.
-
-**[7]:** `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
 **[8]:** Generally `tcp` for `HTTP/1.0`, `HTTP/1.1`, and `HTTP/2`. Generally `udp` for `HTTP/3`. Other obscure implementations are possible.
 
@@ -62,33 +62,33 @@ The following attributes can be important for making sampling decisions and SHOU
 
 * [`http.request.method`](../attributes-registry/http.md)
 
-`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value  | Description |
-|---|---|
-| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. |
+| Value  | Description | Stability |
+|---|---|---|
+| `CONNECT` | CONNECT method. | Experimental |
+| `DELETE` | DELETE method. | Experimental |
+| `GET` | GET method. | Experimental |
+| `HEAD` | HEAD method. | Experimental |
+| `OPTIONS` | OPTIONS method. | Experimental |
+| `PATCH` | PATCH method. | Experimental |
+| `POST` | POST method. | Experimental |
+| `PUT` | PUT method. | Experimental |
+| `TRACE` | TRACE method. | Experimental |
+| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. | Experimental |
 
-`http.request.method` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`error.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value  | Description |
-|---|---|
-| `CONNECT` | CONNECT method. |
-| `DELETE` | DELETE method. |
-| `GET` | GET method. |
-| `HEAD` | HEAD method. |
-| `OPTIONS` | OPTIONS method. |
-| `PATCH` | PATCH method. |
-| `POST` | POST method. |
-| `PUT` | PUT method. |
-| `TRACE` | TRACE method. |
-| `_OTHER` | Any HTTP method that the instrumentation has no prior knowledge of. |
+| Value  | Description | Stability |
+|---|---|---|
+| `_OTHER` | A fallback error value to be used when the instrumentation doesn't define a custom value. | Experimental |
 
-`network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
+`network.transport` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 
-| Value  | Description |
-|---|---|
-| `tcp` | TCP |
-| `udp` | UDP |
-| `pipe` | Named or anonymous pipe. |
-| `unix` | Unix domain socket |
+| Value  | Description | Stability |
+|---|---|---|
+| `tcp` | TCP | Experimental |
+| `udp` | UDP | Experimental |
+| `pipe` | Named or anonymous pipe. | Experimental |
+| `unix` | Unix domain socket | Experimental |
 <!-- endsemconv -->

--- a/crates/weaver_semconv_gen/legacy_tests/parameter_tag/database.yaml
+++ b/crates/weaver_semconv_gen/legacy_tests/parameter_tag/database.yaml
@@ -1,0 +1,308 @@
+# Note: this spec is part of an open PR (https://github.com/open-telemetry/opentelemetry-specification/pull/575, currently at commit 1ffcead5a5) and subject to change.
+groups:
+  - id: db
+    type: span
+    prefix: db
+    brief: >
+      This document defines the attributes used to
+      perform database client calls.
+    span_kind: client
+    attributes:
+      - id: type
+        stability: experimental
+        tag: connection-level
+        type:
+          allow_custom_values: true
+          members:
+            - id: sql
+              value: 'sql'
+              brief: 'A SQL database'
+              stability: experimental
+            - id: cassandra
+              value: 'cassandra'
+              brief: 'Apache Cassandra'
+              stability: experimental
+            - id: hbase
+              value: 'hbase'
+              brief: 'Apache HBase'
+              stability: experimental
+            - id: mongodb
+              value: 'mongodb'
+              brief: 'MongoDB'
+              stability: experimental
+            - id: redis
+              value: 'redis'
+              brief: 'Redis'
+              stability: experimental
+            - id: couchbase
+              value: 'couchbase'
+              brief: 'Couchbase'
+              stability: experimental
+            - id: couchdb
+              value: 'couchdb'
+              brief: 'CouchDB'
+              stability: experimental
+        requirement_level: required
+        brief: >
+          Database type. For any SQL database, "sql".
+          For others, the lower-case database category.
+      - id: dbms
+        stability: experimental
+        type:
+          allow_custom_values: true
+          members:
+            - id: mssql
+              value: 'mssql'
+              brief: 'Microsoft SQL Server'
+              stability: experimental
+            - id: mysql
+              value: 'mysql'
+              brief: 'MySQL'
+              stability: experimental
+            - id: oracle
+              value: 'oracle'
+              brief: 'Oracle'
+              stability: experimental
+            - id: db2
+              value: 'db2'
+              brief: 'IBM Db2'
+              stability: experimental
+            - id: postgresql
+              value: 'postgresql'
+              brief: 'PostgreSQL'
+              stability: experimental
+            - id: redshift
+              value: 'redshift'
+              brief: 'Amazon Redshift'
+              stability: experimental
+            - id: hive
+              value: 'hive'
+              brief: 'Apache Hive'
+              stability: experimental
+            - id: cloudscape
+              value: 'cloudscape'
+              brief: 'Cloudscape'
+              stability: experimental
+            - id: hsqlsb
+              value: 'hsqlsb'
+              brief: 'HyperSQL DataBase'
+              stability: experimental
+            - id: progress
+              value: 'progress'
+              brief: 'Progress Database'
+              stability: experimental
+            - id: maxdb
+              value: 'maxdb'
+              brief: 'SAP MaxDB'
+              stability: experimental
+            - id: hanadb
+              value: 'hanadb'
+              brief: 'SAP HANA'
+              stability: experimental
+            - id: ingres
+              value: 'ingres'
+              brief: 'Ingres'
+              stability: experimental
+            - id: firstsql
+              value: 'firstsql'
+              brief: 'FirstSQL'
+              stability: experimental
+            - id: edb
+              value: 'edb'
+              brief: 'EnterpriseDB'
+              stability: experimental
+            - id: cache
+              value: 'cache'
+              brief: 'InterSystems Caché'
+              stability: experimental
+            - id: adabas
+              value: 'adabas'
+              brief: 'Adabas (Adaptable Database System)'
+              stability: experimental
+            - id: firebird
+              value: 'firebird'
+              brief: 'Firebird'
+              stability: experimental
+            - id: derby
+              value: 'derby'
+              brief: 'Apache Derby'
+              stability: experimental
+            - id: filemaker
+              value: 'filemaker'
+              brief: 'FileMaker'
+              stability: experimental
+            - id: informix
+              value: 'informix'
+              brief: 'Informix'
+              stability: experimental
+            - id: instantdb
+              value: 'instantdb'
+              brief: 'InstantDB'
+              stability: experimental
+            - id: interbase
+              value: 'interbase'
+              brief: 'InterBase'
+              stability: experimental
+            - id: mariadb
+              value: 'mariadb'
+              brief: 'MariaDB'
+              stability: experimental
+            - id: netezza
+              value: 'netezza'
+              brief: 'Netezza'
+              stability: experimental
+            - id: pervasive
+              value: 'pervasive'
+              brief: 'Pervasive PSQL'
+              stability: experimental
+            - id: pointbase
+              value: 'pointbase'
+              brief: 'PointBase'
+              stability: experimental
+            - id: sqlite
+              value: 'sqlite'
+              brief: 'SQLite'
+              stability: experimental
+            - id: sybase
+              value: 'sybase'
+              brief: 'Sybase'
+              stability: experimental
+            - id: teradata
+              value: 'teradata'
+              brief: 'Teradata'
+              stability: experimental
+            - id: vertica
+              value: 'vertica'
+              brief: 'Vertica'
+              stability: experimental
+            - id: h2
+              value: 'h2'
+              brief: 'H2'
+              stability: experimental
+            - id: coldfusion
+              value: 'coldfusion'
+              brief: 'ColdFusion IMQ'
+              stability: experimental
+        requirement_level:
+          recommended: for `db.type="sql"`
+        brief: >
+          An identifier for the DBMS (database management system) product
+      - id: connection_string
+        stability: experimental
+        tag: connection-level
+        type: string
+        note: 'It is recommended to remove embedded credentials.'
+        brief: >
+          The connection string used to connect to the database.
+        examples: 'Server=(localdb)\v11.0;Integrated Security=true;'
+      - id: user
+        stability: experimental
+        tag: connection-level
+        type: string
+        brief: >
+          Username for accessing the database.
+        examples: ['readonly_user', 'reporting_user']
+      - id: mssql.instance_name
+        stability: experimental
+        type: string
+        note: >
+          If setting a `db.mssql.instance_name`, `net.peer.port` is no longer
+          required (but still recommended if non-standard).
+        brief: >
+          The Microsoft SQL Server [instance name](https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15)
+          connecting to. This name is used to determine the port of a named instance.
+        examples: 'MSSQLSERVER'
+      - id: jdbc.driver_classname
+        stability: experimental
+        type: string
+        brief: >
+          The fully-qualified class name of the JDBC driver used to connect.
+        examples: ['org.postgresql.Driver', 'com.microsoft.sqlserver.jdbc.SQLServerDriver']
+      - id: name
+        stability: experimental
+        type: string
+        requirement_level:
+          conditionally_required: >
+            if applicable and no more-specific attribute is defined.
+        brief: >
+          If no tech-specific attribute is defined below, this attribute is used to report the name
+          of the database being accessed. For commands that switch the database, this should be set
+          to the target database (even if the command fails).
+        note:
+          In some SQL databases, the database name to be used is called "schema name".
+          Redis does not have a database name to used here.
+        examples: [ 'customers', 'master' ]
+      - id: statement
+        stability: experimental
+        type: string
+        requirement_level:
+          conditionally_required: if applicable.
+        note: The value may be sanitized to exclude sensitive information.
+        brief: >
+          A database statement for the given database type.
+        examples: ['SELECT * FROM wuser_table', 'SET mykey "WuValue"']
+      - id: operation
+        stability: experimental
+        type: string
+        requirement_level:
+          conditionally_required: if `db.statement` is not applicable.
+        brief: >
+          The type of operation that is executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations)
+          such as `findAndModify`. While it would semantically make sense to set this, e.g., to a SQL
+          keyword like `SELECT` or `INSERT`, it is not recommended to attempt any client-side parsing
+          of `db.statement` just to get this property (the back end can do that if required).
+        examples: ['findAndModify']
+      - ref: net.peer.name
+        tag: connection-level
+      - ref: net.peer.ip
+        tag: connection-level
+      - ref: net.peer.port
+        tag: connection-level
+
+    constraints:
+      - any_of:
+        - 'net.peer.name'
+        - 'net.peer.ip'
+  - id: db.cassandra
+    type: span
+    prefix: db.cassandra
+    extends: db
+    brief: >
+      Call-level attributes for Cassandra
+    attributes:
+      - id: keyspace
+        stability: experimental
+        type: string
+        requirement_level: required
+        brief: >
+          The name of the keyspace being accessed. To be used instead of the general `db.name` attribute.
+        examples: 'mykeyspace'
+  - id: db.hbase
+    type: span
+    prefix: db.hbase
+    extends: db
+    brief: >
+      Call-level attributes for Apache HBase
+    attributes:
+      - id: namespace
+        stability: experimental
+        type: string
+        requirement_level: required
+        brief: >
+          The [HBase namespace](https://hbase.apache.org/book.html#_namespace) being accessed.
+          To be used instead of the general `db.name` attribute.
+        examples: 'default'
+  - id: db.mongodb
+    type: span
+    prefix: db.mongodb
+    extends: db
+    brief: >
+      Call-level attributes for MongoDB
+    attributes:
+      - id: collection
+        stability: experimental
+        type: string
+        requirement_level: required
+        brief: >
+          The collection being accessed within the database stated in `db.name`.
+        examples: [ 'customers', 'products' ]

--- a/crates/weaver_semconv_gen/legacy_tests/parameter_tag/database.yaml
+++ b/crates/weaver_semconv_gen/legacy_tests/parameter_tag/database.yaml
@@ -259,10 +259,11 @@ groups:
       - ref: net.peer.port
         tag: connection-level
 
-    constraints:
-      - any_of:
-        - 'net.peer.name'
-        - 'net.peer.ip'
+    # Note: We are removing constraints from YAML.
+    #constraints:
+    #  - any_of:
+    #    - 'net.peer.name'
+    #    - 'net.peer.ip'
   - id: db.cassandra
     type: span
     prefix: db.cassandra

--- a/crates/weaver_semconv_gen/legacy_tests/parameter_tag/general.yaml
+++ b/crates/weaver_semconv_gen/legacy_tests/parameter_tag/general.yaml
@@ -1,0 +1,65 @@
+groups:
+  - id: network
+    prefix: net
+    type: span
+    brief: >
+        These attributes may be used for any network related operation.
+    attributes:
+      - id: peer.ip
+        stability: experimental
+        type: string
+        brief: >
+          Remote address of the peer (dotted decimal for IPv4 or
+          [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6)
+        examples: '127.0.0.1'
+      - id: peer.port
+        stability: experimental
+        type: int
+        brief: 'Remote port number.'
+        examples: [80, 8080, 443]
+      - id: peer.name
+        stability: experimental
+        type: string
+        brief: 'Remote hostname or similar, see note below.'
+        examples: 'example.com'
+      - id: host.ip
+        stability: experimental
+        type: string
+        brief: 'Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.'
+        examples: '192.168.0.1'
+      - id: host.port
+        stability: experimental
+        type: int
+        brief: 'Like `net.peer.port` but for the host port.'
+        examples: 35555
+      - id: host.name
+        stability: experimental
+        type: string
+        brief: 'Local hostname or similar, see note below.'
+        examples: 'localhost'
+  - id: identity
+    type: span
+    prefix: enduser
+    brief: >
+        These attributes may be used for any operation with an authenticated and/or authorized enduser.
+    attributes:
+      - id: id
+        stability: experimental
+        type: string
+        brief: >
+          Username or client_id extracted from the access token or Authorization header
+          in the inbound request from outside the system.
+        examples: 'username'
+      - id: role
+        stability: experimental
+        type: string
+        brief: 'Actual/assumed role the client is making the request under extracted from token or application security context.'
+        examples: 'admin'
+      - id: scope
+        stability: experimental
+        type: string
+        brief: >
+          Scopes or granted authorities the client currently possesses extracted from token
+          or application security context. The value would come from the scope associated
+          with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
+        examples: 'read:message, write:files'

--- a/crates/weaver_semconv_gen/legacy_tests/parameter_tag/test.md
+++ b/crates/weaver_semconv_gen/legacy_tests/parameter_tag/test.md
@@ -1,6 +1,6 @@
 # DB
 
-<!-- Note: Compared to build-tools, we've removed any-of contraint text *AND* added attribute registry links. -->
+<!-- Note: Compared to build-tools, we've removed any-of constraint text *AND* added attribute registry links. -->
 
 <!-- semconv db(tag=connection-level) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |

--- a/crates/weaver_semconv_gen/legacy_tests/parameter_tag/test.md
+++ b/crates/weaver_semconv_gen/legacy_tests/parameter_tag/test.md
@@ -1,21 +1,18 @@
 # DB
 
+<!-- Note: Compared to build-tools, we've removed any-of contraint text *AND* added attribute registry links. -->
+
 <!-- semconv db(tag=connection-level) -->
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
-|---|---|---|---|---|---|
-| `db.type` | string | Database type. For any SQL database, "sql". For others, the lower-case database category. | `sql` | `Required` | Experimental |
-| `db.connection_string` | string | The connection string used to connect to the database. [1] | `Server=(localdb)\v11.0;Integrated Security=true;` | `Recommended` | Experimental |
-| `db.user` | string | Username for accessing the database. | `readonly_user`; `reporting_user` | `Recommended` | Experimental |
-| `net.peer.ip` | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | See below | Experimental |
-| `net.peer.name` | string | Remote hostname or similar, see note below. | `example.com` | See below | Experimental |
-| `net.peer.port` | int | Remote port number. | `80`; `8080`; `443` | `Recommended` | Experimental |
+|---|---|---|---|---|
+| [`db.type`](../attributes-registry/db.md) | string | Database type. For any SQL database, "sql". For others, the lower-case database category. | `sql`; `cassandra`; `hbase`; `mongodb`; `redis`; `couchbase`; `couchdb` | Required |
+| [`db.connection_string`](../attributes-registry/db.md) | string | The connection string used to connect to the database. [1] | `Server=(localdb)\v11.0;Integrated Security=true;` | Recommended |
+| [`db.user`](../attributes-registry/db.md) | string | Username for accessing the database. | `readonly_user`; `reporting_user` | Recommended |
+| [`net.peer.ip`](../attributes-registry/net.md) | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | Recommended |
+| [`net.peer.name`](../attributes-registry/net.md) | string | Remote hostname or similar, see note below. | `example.com` | Recommended |
+| [`net.peer.port`](../attributes-registry/net.md) | int | Remote port number. | `80`; `8080`; `443` | Recommended |
 
 **[1]:** It is recommended to remove embedded credentials.
-
-**Additional attribute requirements:** At least one of the following sets of attributes is required:
-
-* `net.peer.name`
-* `net.peer.ip`
 
 `db.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
 

--- a/crates/weaver_semconv_gen/legacy_tests/parameter_tag/test.md
+++ b/crates/weaver_semconv_gen/legacy_tests/parameter_tag/test.md
@@ -1,0 +1,31 @@
+# DB
+
+<!-- semconv db(tag=connection-level) -->
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
+|---|---|---|---|---|---|
+| `db.type` | string | Database type. For any SQL database, "sql". For others, the lower-case database category. | `sql` | `Required` | Experimental |
+| `db.connection_string` | string | The connection string used to connect to the database. [1] | `Server=(localdb)\v11.0;Integrated Security=true;` | `Recommended` | Experimental |
+| `db.user` | string | Username for accessing the database. | `readonly_user`; `reporting_user` | `Recommended` | Experimental |
+| `net.peer.ip` | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | See below | Experimental |
+| `net.peer.name` | string | Remote hostname or similar, see note below. | `example.com` | See below | Experimental |
+| `net.peer.port` | int | Remote port number. | `80`; `8080`; `443` | `Recommended` | Experimental |
+
+**[1]:** It is recommended to remove embedded credentials.
+
+**Additional attribute requirements:** At least one of the following sets of attributes is required:
+
+* `net.peer.name`
+* `net.peer.ip`
+
+`db.type` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `sql` | A SQL database | Experimental |
+| `cassandra` | Apache Cassandra | Experimental |
+| `hbase` | Apache HBase | Experimental |
+| `mongodb` | MongoDB | Experimental |
+| `redis` | Redis | Experimental |
+| `couchbase` | Couchbase | Experimental |
+| `couchdb` | CouchDB | Experimental |
+<!-- endsemconv -->

--- a/crates/weaver_semconv_gen/src/gen.rs
+++ b/crates/weaver_semconv_gen/src/gen.rs
@@ -298,7 +298,7 @@ impl<'a> AttributeTableView<'a> {
     ) -> Result<AttributeTableView<'a>, Error> {
         match lookup.find_group(id) {
             Some(group) => Ok(AttributeTableView { group, lookup }),
-            None => Err(Error::GroupNotFound { id: id.to_string() }),
+            None => Err(Error::GroupNotFound { id: id.to_owned() }),
         }
     }
 
@@ -320,16 +320,12 @@ impl<'a> AttributeTableView<'a> {
             .iter()
             .filter_map(|attr| self.lookup.attribute(attr))
             .sorted_by(|lhs, rhs| {
-                let result = sort_ordinal_for_requirement(&lhs.requirement_level)
-                    - sort_ordinal_for_requirement(&rhs.requirement_level);
-
-                if result < 0 {
-                    std::cmp::Ordering::Less
-                } else if result > 0 {
-                    std::cmp::Ordering::Greater
-                } else {
-                    // Compare name.
-                    lhs.name.cmp(&rhs.name)
+                match sort_ordinal_for_requirement(&lhs.requirement_level)
+                    .cmp(&sort_ordinal_for_requirement(&rhs.requirement_level))
+                {
+                    // If requirement_level is the same, then we compare by string.
+                    std::cmp::Ordering::Equal => lhs.name.cmp(&rhs.name),
+                    other => other,
                 }
             })
             .dedup_by(|x, y| x.name == y.name)
@@ -435,7 +431,7 @@ impl<'a> MetricView<'a> {
 
         match metric {
             Some(group) => Ok(MetricView { group }),
-            None => Err(Error::GroupMustBeMetric { id: id.to_string() }),
+            None => Err(Error::GroupMustBeMetric { id: id.to_owned() }),
         }
     }
 

--- a/crates/weaver_semconv_gen/src/gen.rs
+++ b/crates/weaver_semconv_gen/src/gen.rs
@@ -273,7 +273,7 @@ impl<'a> AttributeView<'a> {
 }
 
 
-fn sort_oridinal_for_requirement(e: &RequirementLevel) -> i32 {
+fn sort_ordinal_for_requirement(e: &RequirementLevel) -> i32 {
     // For now use ordinals from python.
     match e {
         RequirementLevel::Basic(BasicRequirementLevelSpec::Required) => 1,
@@ -318,8 +318,8 @@ impl<'a> AttributeTableView<'a> {
             .iter()
             .filter_map(|attr| self.lookup.attribute(attr))
             .sorted_by(|lhs, rhs| {               
-                let result = sort_oridinal_for_requirement(&lhs.requirement_level) -
-                sort_oridinal_for_requirement(&rhs.requirement_level);
+                let result = sort_ordinal_for_requirement(&lhs.requirement_level) -
+                sort_ordinal_for_requirement(&rhs.requirement_level);
 
                 if result < 0 {
                     std::cmp::Ordering::Less

--- a/crates/weaver_semconv_gen/src/gen.rs
+++ b/crates/weaver_semconv_gen/src/gen.rs
@@ -4,7 +4,6 @@
 
 use crate::{Error, GenerateMarkdownArgs, ResolvedSemconvRegistry};
 use itertools::Itertools;
-use weaver_semconv::stability::Stability;
 use std::fmt::Write;
 use weaver_resolved_schema::attribute::Attribute;
 use weaver_resolved_schema::registry::Group;
@@ -13,6 +12,7 @@ use weaver_semconv::attribute::{
     RequirementLevel, TemplateTypeSpec, ValueSpec,
 };
 use weaver_semconv::group::{GroupType, InstrumentSpec};
+use weaver_semconv::stability::Stability;
 
 // The size a string is allowed to be before it is pushed into notes.
 const BREAK_COUNT: usize = 50;
@@ -154,7 +154,10 @@ impl<'a> AttributeView<'a> {
     }
 
     fn write_enum_spec_table<Out: Write>(&self, out: &mut Out) -> Result<(), Error> {
-        write!(out, "\n| Value  | Description | Stability |\n|---|---|---|\n")?;
+        write!(
+            out,
+            "\n| Value  | Description | Stability |\n|---|---|---|\n"
+        )?;
         if let AttributeType::Enum { members, .. } = &self.attribute.r#type {
             for m in members {
                 write!(out, "| ")?;
@@ -272,7 +275,6 @@ impl<'a> AttributeView<'a> {
     }
 }
 
-
 fn sort_ordinal_for_requirement(e: &RequirementLevel) -> i32 {
     // For now use ordinals from python.
     match e {
@@ -317,9 +319,9 @@ impl<'a> AttributeTableView<'a> {
             .attributes
             .iter()
             .filter_map(|attr| self.lookup.attribute(attr))
-            .sorted_by(|lhs, rhs| {               
-                let result = sort_ordinal_for_requirement(&lhs.requirement_level) -
-                sort_ordinal_for_requirement(&rhs.requirement_level);
+            .sorted_by(|lhs, rhs| {
+                let result = sort_ordinal_for_requirement(&lhs.requirement_level)
+                    - sort_ordinal_for_requirement(&rhs.requirement_level);
 
                 if result < 0 {
                     std::cmp::Ordering::Less
@@ -361,11 +363,10 @@ impl<'a> AttributeTableView<'a> {
         }
 
         // If the user defined a tag, use it to filter attributes.
-        let attributes: Vec<AttributeView<'_>> = 
-            match args.tag_filter() {
-                Some(tag) => self.attributes().filter(|a| a.has_tag(tag)).collect(),
-                None => self.attributes().collect(),
-            };
+        let attributes: Vec<AttributeView<'_>> = match args.tag_filter() {
+            Some(tag) => self.attributes().filter(|a| a.has_tag(tag)).collect(),
+            None => self.attributes().collect(),
+        };
 
         for attr in &attributes {
             write!(out, "| ")?;

--- a/crates/weaver_semconv_gen/src/lib.rs
+++ b/crates/weaver_semconv_gen/src/lib.rs
@@ -267,14 +267,12 @@ mod tests {
         // Note: We could update this to run all tests in parallel and join results.
         // For now we're just getting things working.
         let test_dirs = fs::read_dir("legacy_tests").unwrap();
-        for opt_dir in test_dirs {
-            if let Ok(dir) = opt_dir {
-                if dir.path().join("test.md").exists() {
-                    println!();
-                    println!("--- Running test: {} ---", dir.path().display());
-                    println!();
-                    force_print_error(run_legacy_test(dir.path()))
-                }
+        for dir in test_dirs.flatten() {
+            if dir.path().join("test.md").exists() {
+                println!();
+                println!("--- Running test: {} ---", dir.path().display());
+                println!();
+                force_print_error(run_legacy_test(dir.path()))
             }
         }
     }

--- a/crates/weaver_semconv_gen/src/lib.rs
+++ b/crates/weaver_semconv_gen/src/lib.rs
@@ -112,6 +112,14 @@ impl GenerateMarkdownArgs {
             .iter()
             .any(|a| matches!(a, MarkdownGenParameters::MetricTable))
     }
+
+    /// Returns the tag filter specified, if any.  Assumes only one.
+    fn tag_filter(&self) -> Option<&str> {
+        self.args.iter().find_map(|arg| match arg {
+            MarkdownGenParameters::Tag(value) => Some(value.as_str()),
+            _ => None,
+        })
+    }
 }
 
 /// Constructs a markdown snippet (without header/closer)
@@ -224,7 +232,8 @@ impl ResolvedSemconvRegistry {
 #[cfg(test)]
 mod tests {
     use weaver_logger::TestLogger;
-
+    use std::fs;
+    use std::path::PathBuf;
     use crate::{update_markdown, Error, ResolvedSemconvRegistry};
 
     fn force_print_error<T>(result: Result<T, Error>) -> T {
@@ -251,5 +260,31 @@ mod tests {
             true,
         ));
         Ok(())
+    }
+
+    #[test]
+    fn  run_legacy_tests() {
+        // Note: We could update this to run all tests in parallel and join results.
+        // For now we're just getting things working.
+        let test_dirs = fs::read_dir("legacy_tests").unwrap();
+        for opt_dir in test_dirs {
+            if let Ok(dir) = opt_dir {
+                if dir.path().join("test.md").exists() {
+                    println!();
+                    println!("--- Running test: {} ---", dir.path().display());
+                    println!();
+                    force_print_error(run_legacy_test(dir.path()))
+                }
+            }
+        }
+    }
+
+    fn run_legacy_test(path: PathBuf) -> Result<(), Error> {
+        let logger = TestLogger::default();
+        let semconv_path = format!("{}/*.yaml", path.display());
+        let lookup = ResolvedSemconvRegistry::try_from_path(&semconv_path, logger.clone())?;
+        let test_path = path.join("test.md").display().to_string();
+        // Attempts to update the test - will fail if there is any difference in the generated markdown.
+        update_markdown(&test_path, &lookup, true)
     }
 }

--- a/crates/weaver_semconv_gen/src/lib.rs
+++ b/crates/weaver_semconv_gen/src/lib.rs
@@ -231,10 +231,10 @@ impl ResolvedSemconvRegistry {
 
 #[cfg(test)]
 mod tests {
-    use weaver_logger::TestLogger;
+    use crate::{update_markdown, Error, ResolvedSemconvRegistry};
     use std::fs;
     use std::path::PathBuf;
-    use crate::{update_markdown, Error, ResolvedSemconvRegistry};
+    use weaver_logger::TestLogger;
 
     fn force_print_error<T>(result: Result<T, Error>) -> T {
         match result {
@@ -263,7 +263,7 @@ mod tests {
     }
 
     #[test]
-    fn  run_legacy_tests() {
+    fn run_legacy_tests() {
         // Note: We could update this to run all tests in parallel and join results.
         // For now we're just getting things working.
         let test_dirs = fs::read_dir("legacy_tests").unwrap();

--- a/crates/weaver_semconv_gen/src/parser.rs
+++ b/crates/weaver_semconv_gen/src/parser.rs
@@ -31,7 +31,7 @@ fn parse_value(input: &str) -> IResult<&str, &str> {
 fn parse_markdown_gen_tag(input: &str) -> IResult<&str, MarkdownGenParameters> {
     let (input, _) = tag("tag=")(input)?;
     let (input, value) = parse_value(input)?;
-    Ok((input, MarkdownGenParameters::Tag(value.to_string())))
+    Ok((input, MarkdownGenParameters::Tag(value.to_owned())))
 }
 
 /// nom parser for full.
@@ -89,7 +89,7 @@ fn parse_markdown_snippet_raw(input: &str) -> IResult<&str, GenerateMarkdownArgs
     Ok((
         input,
         GenerateMarkdownArgs {
-            id: id.to_string(),
+            id: id.to_owned(),
             args: opt_args.unwrap_or(Vec::new()),
         },
     ))

--- a/crates/weaver_semconv_gen/src/parser.rs
+++ b/crates/weaver_semconv_gen/src/parser.rs
@@ -110,9 +110,8 @@ pub fn is_markdown_snippet_directive(line: &str) -> bool {
 pub fn parse_markdown_snippet_directive(line: &str) -> Result<GenerateMarkdownArgs, Error> {
     match parse_markdown_snippet_raw(line) {
         Ok((rest, result)) if rest.trim().is_empty() => Ok(result),
-        // TODO - Translate error message better?
         _ => Err(Error::InvalidSnippetHeader {
-            header: line.to_string(),
+            header: line.to_owned(),
         }),
     }
 }


### PR DESCRIPTION
- Update model to deal with stability level now on enumeration values.
- Copy "parameter_tag" test from upstream build_tools to ensure complaince in weaver.
- Update various template fixes in latest build-tools release.
- Update sort-order of Attributes to be Requirement-Level then name (matching latest build-tools release).
- Add new mechanism to copy over build-tools markdown snippet tests