### PR TITLE
Add support for both local path and git url in registry commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -544,7 +544,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -555,7 +555,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "fastdivide"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
+checksum = "59668941c55e5c186b8b58c391629af56774ec768f73c08bbcd56f09348eb00b"
 
 [[package]]
 name = "faster-hex"
@@ -1181,7 +1181,7 @@ checksum = "1dff438f14e67e7713ab9332f5fd18c8f20eb7eb249494f6c2bf170522224032"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2008,13 +2008,12 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -2073,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912b45c753ff5f7f5208307e8ace7d2a2e30d024e26d3509f3dce546c044ce15"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 
 [[package]]
 name = "matchers"
@@ -2094,7 +2093,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2350,9 +2349,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2361,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
+checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2371,22 +2370,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
+checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
+checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
 dependencies = [
  "once_cell",
  "pest",
@@ -2433,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -2633,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom",
  "libredox",
@@ -2923,7 +2922,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3154,7 +3153,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3176,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3424,7 +3423,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3583,7 +3582,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3854,7 +3853,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3915,7 +3914,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
  "wasm-bindgen-shared",
 ]
 
@@ -3949,7 +3948,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4382,7 +4381,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.57",
 ]
 
 [[package]]

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -600,7 +600,9 @@ impl SchemaResolver {
         cache: &Cache,
     ) -> Vec<Result<(String, SemConvSpec), Error>> {
         match registry_path {
-            RegistryPath::Local { path } => Self::import_semconv_from_local_path(path.into(), path),
+            RegistryPath::Local { local_path: path } => {
+                Self::import_semconv_from_local_path(path.into(), path)
+            }
             RegistryPath::GitUrl { git_url, path } => {
                 match cache.git_repo(git_url.clone(), path.clone()) {
                     Ok(local_git_repo) => {

--- a/crates/weaver_schema/src/lib.rs
+++ b/crates/weaver_schema/src/lib.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 use url::Url;
+use weaver_semconv::path::RegistryPath;
 
 use weaver_semconv::SemConvRegistry;
 use weaver_version::Versions;
@@ -86,7 +87,7 @@ pub struct TelemetrySchema {
     /// The semantic conventions that are imported by the current schema (optional).
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub semantic_conventions: Vec<SemConvImport>,
+    pub semantic_conventions: Vec<RegistryPath>,
     /// Definition of the telemetry schema for an application or a library.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<SchemaSpec>,
@@ -209,7 +210,7 @@ impl TelemetrySchema {
 
     /// Returns the semantic conventions for the schema and its parent schemas.
     #[must_use]
-    pub fn merged_semantic_conventions(&self) -> Vec<SemConvImport> {
+    pub fn merged_semantic_conventions(&self) -> Vec<RegistryPath> {
         let mut result = vec![];
         if let Some(parent_schema) = self.parent_schema.as_ref() {
             result.extend(parent_schema.merged_semantic_conventions().iter().cloned());

--- a/crates/weaver_schema/src/lib.rs
+++ b/crates/weaver_schema/src/lib.rs
@@ -110,26 +110,6 @@ pub struct TelemetrySchema {
     pub semantic_convention_registry: SemConvRegistry,
 }
 
-/// A semantic convention import.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
-#[serde(untagged)]
-pub enum SemConvImport {
-    /// Variant to import a semantic convention from a URL.
-    Url {
-        /// The URL of the semantic convention.
-        url: String,
-    },
-    /// Variant to import semantic conventions from a git repo.
-    GitUrl {
-        /// The git URL of the semantic convention git repo.
-        git_url: String,
-        /// An optional path to the semantic convention directory containing
-        /// the semantic convention files.
-        path: Option<String>,
-    },
-}
-
 impl TelemetrySchema {
     /// Loads a telemetry schema from an URL or a local path.
     pub fn load(schema: &str) -> Result<TelemetrySchema, Error> {

--- a/crates/weaver_semconv/src/lib.rs
+++ b/crates/weaver_semconv/src/lib.rs
@@ -22,6 +22,7 @@ use crate::metric::MetricSpec;
 pub mod attribute;
 pub mod group;
 pub mod metric;
+pub mod path;
 pub mod stability;
 
 /// An error that can occur while loading a semantic convention registry.

--- a/crates/weaver_semconv/src/path.rs
+++ b/crates/weaver_semconv/src/path.rs
@@ -6,11 +6,13 @@ use serde::{Deserialize, Serialize};
 
 /// A semantic convention registry path.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(untagged)]
 pub enum RegistryPath {
     /// A local path to the semantic convention registry.
     Local {
         /// The local path to the semantic convention directory.
-        path: String,
+        local_path: String,
     },
     /// A git URL to the semantic convention registry.
     GitUrl {

--- a/crates/weaver_semconv/src/path.rs
+++ b/crates/weaver_semconv/src/path.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Semantic convention registry path.
+
+use serde::{Deserialize, Serialize};
+
+/// A semantic convention registry path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RegistryPath {
+    /// A local path to the semantic convention registry.
+    Local {
+        /// The local path to the semantic convention directory.
+        path: String,
+    },
+    /// A git URL to the semantic convention registry.
+    GitUrl {
+        /// The git URL of the semantic convention git repo.
+        git_url: String,
+        /// An optional path to the semantic convention directory containing
+        /// the semantic convention files.
+        path: Option<String>,
+    },
+}

--- a/crates/weaver_semconv_gen/allowed-external-types.toml
+++ b/crates/weaver_semconv_gen/allowed-external-types.toml
@@ -4,6 +4,7 @@
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
     "weaver_semconv::Error",
+    "weaver_semconv::path::RegistryPath",
     "weaver_resolver::Error",
     "weaver_logger::Logger",
     "weaver_cache::Cache",

--- a/crates/weaver_semconv_gen/src/lib.rs
+++ b/crates/weaver_semconv_gen/src/lib.rs
@@ -11,6 +11,7 @@ use weaver_resolved_schema::attribute::{Attribute, AttributeRef};
 use weaver_resolved_schema::registry::{Group, Registry};
 use weaver_resolved_schema::ResolvedTelemetrySchema;
 use weaver_resolver::SchemaResolver;
+use weaver_semconv::path::RegistryPath;
 use weaver_semconv::SemConvRegistry;
 
 mod diff;
@@ -217,21 +218,13 @@ impl ResolvedSemconvRegistry {
 
     /// Resolve semconv registry (possibly from git), and make it available for rendering.
     pub fn try_from_url(
-        // Local or GIT URL of semconv registry.
-        registry: String,
-        // Optional path where YAML files are located (default: model)
-        registry_sub_dir: Option<String>,
+        registry_path: RegistryPath,
         cache: &Cache,
         log: impl Logger + Clone + Sync,
     ) -> Result<ResolvedSemconvRegistry, Error> {
         let registry_id = "semantic_conventions";
-        let mut registry = SchemaResolver::load_semconv_registry(
-            registry_id,
-            registry,
-            registry_sub_dir,
-            cache,
-            log.clone(),
-        )?;
+        let mut registry =
+            SchemaResolver::load_semconv_registry(registry_id, registry_path, cache, log.clone())?;
         let schema = SchemaResolver::resolve_semantic_convention_registry(&mut registry, log)?;
         let lookup = ResolvedSemconvRegistry {
             schema,

--- a/src/registry/check.rs
+++ b/src/registry/check.rs
@@ -2,6 +2,7 @@
 
 //! Check a semantic convention registry.
 
+use crate::registry::{semconv_registry_path_from, RegistryPath};
 use clap::Args;
 use weaver_cache::Cache;
 use weaver_logger::Logger;
@@ -18,7 +19,7 @@ pub struct RegistryCheckArgs {
         long,
         default_value = "https://github.com/open-telemetry/semantic-conventions.git"
     )]
-    pub registry: String,
+    pub registry: RegistryPath,
 
     /// Optional path in the Git repository where the semantic convention
     /// registry is located
@@ -36,8 +37,7 @@ pub(crate) fn command(log: impl Logger + Sync + Clone, cache: &Cache, args: &Reg
     // No parsing errors should be observed.
     let semconv_specs = SchemaResolver::load_semconv_registry(
         registry_id,
-        args.registry.to_string(),
-        args.registry_git_sub_dir.clone(),
+        semconv_registry_path_from(&args.registry, &args.registry_git_sub_dir),
         cache,
         log.clone(),
     )
@@ -47,7 +47,8 @@ pub(crate) fn command(log: impl Logger + Sync + Clone, cache: &Cache, args: &Reg
 
     // Resolve the semantic convention registry.
     let mut attr_catalog = AttributeCatalog::default();
-    let _ = resolve_semconv_registry(&mut attr_catalog, &args.registry, &semconv_specs)
+    let registry_path = args.registry.to_string();
+    let _ = resolve_semconv_registry(&mut attr_catalog, &registry_path, &semconv_specs)
         .unwrap_or_else(|e| {
             panic!("Failed to resolve the semantic convention registry.\n{e}");
         });

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -5,6 +5,7 @@
 use clap::Args;
 use std::path::PathBuf;
 
+use crate::registry::{semconv_registry_path_from, RegistryPath};
 use weaver_cache::Cache;
 use weaver_forge::debug::print_dedup_errors;
 use weaver_forge::registry::TemplateRegistry;
@@ -34,7 +35,7 @@ pub struct RegistryGenerateArgs {
         long,
         default_value = "https://github.com/open-telemetry/semantic-conventions.git"
     )]
-    pub registry: String,
+    pub registry: RegistryPath,
 
     /// Optional path in the Git repository where the semantic convention
     /// registry is located
@@ -58,8 +59,7 @@ pub(crate) fn command(
     // Load the semantic convention registry into a local cache.
     let mut registry = SchemaResolver::load_semconv_registry(
         registry_id,
-        args.registry.to_string(),
-        args.registry_git_sub_dir.clone(),
+        semconv_registry_path_from(&args.registry, &args.registry_git_sub_dir),
         cache,
         logger.clone(),
     )

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -64,9 +64,9 @@ impl FromStr for RegistryPath {
     /// Parse a string into a `RegistryPath`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.starts_with("http://") || s.starts_with("https://") {
-            Ok(Self::Url(s.to_string()))
+            Ok(Self::Url(s.to_owned()))
         } else {
-            Ok(Self::Local(s.to_string()))
+            Ok(Self::Local(s.to_owned()))
         }
     }
 }
@@ -125,9 +125,9 @@ pub fn semconv_registry_path_from(
     path: &Option<String>,
 ) -> weaver_semconv::path::RegistryPath {
     match registry {
-        RegistryPath::Local(path) => {
-            weaver_semconv::path::RegistryPath::Local { path: path.clone() }
-        }
+        RegistryPath::Local(path) => weaver_semconv::path::RegistryPath::Local {
+            local_path: path.clone(),
+        },
         RegistryPath::Url(url) => weaver_semconv::path::RegistryPath::GitUrl {
             git_url: url.clone(),
             path: path.clone(),

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -3,14 +3,16 @@
 //! Commands to manage a semantic convention registry.
 
 use clap::{Args, Subcommand};
+use std::fmt::Display;
+use std::str::FromStr;
 
-use crate::registry::generate::RegistryGenerateArgs;
-use crate::registry::resolve::RegistryResolveArgs;
-use crate::registry::search::RegistrySearchArgs;
 use check::RegistryCheckArgs;
 use weaver_cache::Cache;
 use weaver_logger::Logger;
 
+use crate::registry::generate::RegistryGenerateArgs;
+use crate::registry::resolve::RegistryResolveArgs;
+use crate::registry::search::RegistrySearchArgs;
 use crate::registry::stats::RegistryStatsArgs;
 use crate::registry::update_markdown::RegistryUpdateMarkdownArgs;
 
@@ -46,6 +48,41 @@ pub enum RegistrySubCommand {
     UpdateMarkdown(RegistryUpdateMarkdownArgs),
 }
 
+/// Path to a semantic convention registry.
+/// The path can be a local directory or a Git URL.
+#[derive(Debug, Clone)]
+pub enum RegistryPath {
+    Local(String),
+    Url(String),
+}
+
+/// Implement the `FromStr` trait for `RegistryPath`, so that it can be used as
+/// a command-line argument.
+impl FromStr for RegistryPath {
+    type Err = String;
+
+    /// Parse a string into a `RegistryPath`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with("http://") || s.starts_with("https://") {
+            Ok(Self::Url(s.to_string()))
+        } else {
+            Ok(Self::Local(s.to_string()))
+        }
+    }
+}
+
+/// Implement the `Display` trait for `RegistryPath`, so that it can be printed
+/// to the console.
+impl Display for RegistryPath {
+    /// Format the `RegistryPath` as a string.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegistryPath::Local(path) => write!(f, "{}", path),
+            RegistryPath::Url(url) => write!(f, "{}", url),
+        }
+    }
+}
+
 /// Set of parameters used to specify a semantic convention registry.
 #[derive(Args, Debug)]
 pub struct RegistryArgs {
@@ -55,7 +92,7 @@ pub struct RegistryArgs {
         long,
         default_value = "https://github.com/open-telemetry/semantic-conventions.git"
     )]
-    pub registry: String,
+    pub registry: RegistryPath,
 
     /// Optional path in the Git repository where the semantic convention
     /// registry is located
@@ -79,5 +116,21 @@ pub fn semconv_registry(log: impl Logger + Sync + Clone, command: &RegistryComma
             unimplemented!()
         }
         RegistrySubCommand::UpdateMarkdown(args) => update_markdown::command(log, &cache, args),
+    }
+}
+
+/// Convert a `RegistryPath` to a `weaver_semconv::path::RegistryPath`.
+pub fn semconv_registry_path_from(
+    registry: &RegistryPath,
+    path: &Option<String>,
+) -> weaver_semconv::path::RegistryPath {
+    match registry {
+        RegistryPath::Local(path) => {
+            weaver_semconv::path::RegistryPath::Local { path: path.clone() }
+        }
+        RegistryPath::Url(url) => weaver_semconv::path::RegistryPath::GitUrl {
+            git_url: url.clone(),
+            path: path.clone(),
+        },
     }
 }

--- a/src/registry/resolve.rs
+++ b/src/registry/resolve.rs
@@ -12,7 +12,7 @@ use weaver_forge::registry::TemplateRegistry;
 use weaver_logger::Logger;
 use weaver_resolver::SchemaResolver;
 
-use crate::registry::RegistryArgs;
+use crate::registry::{semconv_registry_path_from, RegistryArgs};
 
 /// Supported output formats for the resolved schema
 #[derive(Debug, Clone, ValueEnum)]
@@ -67,8 +67,7 @@ pub(crate) fn command(
     // Load the semantic convention registry into a local cache.
     let mut registry = SchemaResolver::load_semconv_registry(
         registry_id,
-        args.registry.registry.to_string(),
-        args.registry.registry_git_sub_dir.clone(),
+        semconv_registry_path_from(&args.registry.registry, &args.registry.registry_git_sub_dir),
         cache,
         logger.clone(),
     )

--- a/src/registry/stats.rs
+++ b/src/registry/stats.rs
@@ -2,7 +2,7 @@
 
 //! Compute stats on a semantic convention registry.
 
-use crate::registry::RegistryArgs;
+use crate::registry::{semconv_registry_path_from, RegistryArgs};
 use clap::Args;
 use weaver_cache::Cache;
 use weaver_logger::Logger;
@@ -32,8 +32,7 @@ pub(crate) fn command(log: impl Logger + Sync + Clone, cache: &Cache, args: &Reg
     // Load the semantic convention registry into a local cache.
     let mut registry = SchemaResolver::load_semconv_registry(
         registry_id,
-        args.registry.registry.to_string(),
-        args.registry.registry_git_sub_dir.clone(),
+        semconv_registry_path_from(&args.registry.registry, &args.registry.registry_git_sub_dir),
         cache,
         log.clone(),
     )

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -3,6 +3,7 @@
 //! Update markdown files that contain markers indicating the templates used to
 //! update the specified sections.
 
+use crate::registry::{semconv_registry_path_from, RegistryPath};
 use clap::Args;
 use weaver_cache::Cache;
 use weaver_logger::Logger;
@@ -20,7 +21,7 @@ pub struct RegistryUpdateMarkdownArgs {
         long,
         default_value = "https://github.com/open-telemetry/semantic-conventions.git"
     )]
-    pub registry: String,
+    pub registry: RegistryPath,
 
     /// Optional path in the Git repository where the semantic convention
     /// registry is located
@@ -39,8 +40,7 @@ pub(crate) fn command(
     args: &RegistryUpdateMarkdownArgs,
 ) {
     let registry = ResolvedSemconvRegistry::try_from_url(
-        args.registry.clone(),
-        args.registry_git_sub_dir.clone(),
+        semconv_registry_path_from(&args.registry, &args.registry_git_sub_dir),
         cache,
         log.clone(),
     )

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -2,14 +2,14 @@
 
 //! Command to resolve a schema file, then output and display the results on the console.
 
-use clap::{Args, Subcommand};
+use clap::{command, Args, Subcommand};
 use std::path::PathBuf;
 use std::process::exit;
 use weaver_cache::Cache;
 
+use crate::registry::RegistryPath;
 use weaver_logger::Logger;
 use weaver_resolver::SchemaResolver;
-use weaver_schema::SemConvImport;
 use weaver_semconv::ResolverConfig;
 
 /// Specify the `resolve` command
@@ -68,7 +68,7 @@ pub fn command_resolve(log: impl Logger + Sync + Clone, command: &ResolveCommand
             let registry_id = "default";
             let mut registry = SchemaResolver::semconv_registry_from_imports(
                 registry_id,
-                &[SemConvImport::GitUrl {
+                &[weaver_semconv::path::RegistryPath::GitUrl {
                     git_url: command.registry.clone(),
                     path: command.path.clone(),
                 }],

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -2,6 +2,7 @@
 
 //! Command to generate a client SDK.
 
+use std::env::args;
 use std::io;
 use std::path::PathBuf;
 
@@ -26,6 +27,7 @@ use tantivy::schema::{Field, Schema, STORED, TEXT};
 use tantivy::{Index, IndexWriter, ReloadPolicy};
 use tui_textarea::TextArea;
 
+use crate::registry::{semconv_registry_path_from, RegistryPath};
 use theme::ThemeConfig;
 use weaver_cache::Cache;
 use weaver_logger::Logger;
@@ -82,7 +84,7 @@ pub struct SearchRegistry {
 #[derive(Debug, Args)]
 pub struct SearchRegistry2 {
     /// Git URL of the semantic convention registry
-    pub registry: String,
+    pub registry: RegistryPath,
 
     /// Optional path in the git repository where the semantic convention
     /// registry is located
@@ -216,8 +218,7 @@ fn search_registry_command2(
     let registry_id = "default";
     let semconv_specs = SchemaResolver::load_semconv_registry(
         registry_id,
-        registry_args.registry.clone(),
-        registry_args.path.clone(),
+        semconv_registry_path_from(&registry_args.registry, &registry_args.path),
         cache,
         log.clone(),
     )

--- a/tests/resolution_process.rs
+++ b/tests/resolution_process.rs
@@ -7,6 +7,7 @@ use weaver_logger::{Logger, TestLogger};
 use weaver_resolver::attribute::AttributeCatalog;
 use weaver_resolver::registry::resolve_semconv_registry;
 use weaver_resolver::SchemaResolver;
+use weaver_semconv::path::RegistryPath;
 
 /// The URL of the official semantic convention registry.
 const SEMCONV_REGISTRY_URL: &str = "https://github.com/open-telemetry/semantic-conventions.git";
@@ -33,8 +34,10 @@ fn test_semconv_registry_resolution() {
     // No parsing errors should be observed.
     let semconv_specs = SchemaResolver::load_semconv_registry(
         registry_id,
-        SEMCONV_REGISTRY_URL.to_owned(),
-        Some(SEMCONV_REGISTRY_MODEL.to_owned()),
+        RegistryPath::GitUrl {
+            git_url: SEMCONV_REGISTRY_URL.to_owned(),
+            path: Some(SEMCONV_REGISTRY_MODEL.to_owned()),
+        },
         &cache,
         log.clone(),
     )


### PR DESCRIPTION
With this PR, the parameters `-r` or `--registry` of the registry sub-commands now accept a Git URL or a local path.