### PR TITLE
feat(template): Add more filters around case conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -2065,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08474e32172238f2827bd160c67871cdb2801430f65c3979184dc362e3ca118"
+checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
 dependencies = [
  "libc",
 ]

--- a/crates/weaver_forge/src/config.rs
+++ b/crates/weaver_forge/src/config.rs
@@ -22,6 +22,8 @@ pub enum CaseConvention {
     LowerCase,
     #[serde(rename = "UPPERCASE")]
     UpperCase,
+    #[serde(rename = "TitleCase")]
+    TitleCase,
     #[serde(rename = "PascalCase")]
     PascalCase,
     #[serde(rename = "camelCase")]
@@ -297,6 +299,7 @@ impl CaseConvention {
         match self {
             CaseConvention::LowerCase => text.to_case(Case::Lower),
             CaseConvention::UpperCase => text.to_case(Case::Upper),
+            CaseConvention::TitleCase => text.to_case(Case::Title),
             CaseConvention::PascalCase => text.to_case(Case::Pascal),
             CaseConvention::CamelCase => text.to_case(Case::Camel),
             CaseConvention::SnakeCase => text.to_case(Case::Snake),

--- a/crates/weaver_forge/src/extensions/case_converter.rs
+++ b/crates/weaver_forge/src/extensions/case_converter.rs
@@ -8,6 +8,7 @@ pub fn case_converter(case_convention: CaseConvention) -> fn(&str) -> String {
     match case_convention {
         CaseConvention::LowerCase => lower_case,
         CaseConvention::UpperCase => upper_case,
+        CaseConvention::TitleCase => title_case,
         CaseConvention::CamelCase => camel_case,
         CaseConvention::PascalCase => pascal_case,
         CaseConvention::SnakeCase => snake_case,
@@ -25,6 +26,11 @@ fn lower_case(input: &str) -> String {
 /// Converts input string to upper case
 fn upper_case(input: &str) -> String {
     CaseConvention::UpperCase.convert(input)
+}
+
+/// Converts input string to title case
+fn title_case(input: &str) -> String {
+    CaseConvention::TitleCase.convert(input)
 }
 
 /// Converts input string to camel case

--- a/docs/template-engine.md
+++ b/docs/template-engine.md
@@ -192,6 +192,15 @@ The following filters are available:
 - `struct_name`: Converts a string to a struct name.
 - `field_name`: Converts a string to a field name.
 - `type_mapping`: Converts a semantic convention type to a language type.
+- `lowercase`: Converts a string to lowercase.
+- `UPPERCASE`: Converts a string to UPPERCASE.
+- `TitleCase`: Converts a string to TitleCase.
+- `PascalCase`: Converts a string to PascalCase.
+- `camelCase`: Converts a string to camelCase.
+- `snake_case`: Converts a string to snake_case.
+- `SCREAMING_SNAKE_CASE`: Converts a string to SCREAMING_SNAKE_CASE.
+- `kebab-case`: Converts a string to kebab-case.
+- `SCREAMING-KEBAB-CASE`: Converts a string to SCREAMING-KEBAB-CASE.
 
 > Note: Other filters might be introduced in the future.
 


### PR DESCRIPTION
New custom filters:
- `lowercase`: Converts a string to lowercase.
- `UPPERCASE`: Converts a string to UPPERCASE.
- `TitleCase`: Converts a string to TitleCase.
- `PascalCase`: Converts a string to PascalCase.
- `camelCase`: Converts a string to camelCase.
- `snake_case`: Converts a string to snake_case.
- `SCREAMING_SNAKE_CASE`: Converts a string to SCREAMING_SNAKE_CASE.
- `kebab-case`: Converts a string to kebab-case.
- `SCREAMING-KEBAB-CASE`: Converts a string to SCREAMING-KEBAB-CASE.