### PR TITLE
(fix) Fix resolution of attribute ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4472,6 +4472,7 @@ dependencies = [
  "weaver_cache",
  "weaver_checker",
  "weaver_common",
+ "weaver_diff",
  "weaver_resolved_schema",
  "weaver_schema",
  "weaver_semconv",

--- a/crates/weaver_forge/expected_output/group/metric_jvm_memory_committed.md
+++ b/crates/weaver_forge/expected_output/group/metric_jvm_memory_committed.md
@@ -9,7 +9,23 @@ prefix:
 ## Attributes
 
 
-### Attribute `pool.name`
+### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+
+- Stability: Stable
+
+
+### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -23,22 +39,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-
-- Stability: Stable
-
-
-### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
 
 - Stability: Stable

--- a/crates/weaver_forge/expected_output/group/metric_jvm_memory_limit.md
+++ b/crates/weaver_forge/expected_output/group/metric_jvm_memory_limit.md
@@ -9,7 +9,23 @@ prefix:
 ## Attributes
 
 
-### Attribute `pool.name`
+### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+
+- Stability: Stable
+
+
+### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -23,22 +39,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-
-- Stability: Stable
-
-
-### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
 
 - Stability: Stable

--- a/crates/weaver_forge/expected_output/group/metric_jvm_memory_used.md
+++ b/crates/weaver_forge/expected_output/group/metric_jvm_memory_used.md
@@ -9,7 +9,23 @@ prefix:
 ## Attributes
 
 
-### Attribute `pool.name`
+### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+
+- Stability: Stable
+
+
+### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -23,22 +39,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-
-- Stability: Stable
-
-
-### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
 
 - Stability: Stable

--- a/crates/weaver_forge/expected_output/group/metric_jvm_memory_used_after_last_gc.md
+++ b/crates/weaver_forge/expected_output/group/metric_jvm_memory_used_after_last_gc.md
@@ -9,7 +9,23 @@ prefix:
 ## Attributes
 
 
-### Attribute `pool.name`
+### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+
+- Stability: Stable
+
+
+### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -23,22 +39,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-
-- Stability: Stable
-
-
-### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
 
 - Stability: Stable

--- a/crates/weaver_forge/expected_output/groups.md
+++ b/crates/weaver_forge/expected_output/groups.md
@@ -141,7 +141,23 @@ prefix:
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -155,22 +171,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable
@@ -188,7 +188,23 @@ prefix:
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -202,22 +218,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable
@@ -235,7 +235,23 @@ prefix:
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -249,22 +265,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable
@@ -282,7 +282,23 @@ prefix:
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -296,22 +312,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable

--- a/crates/weaver_forge/expected_output/metric/metric_jvm_memory_committed.md
+++ b/crates/weaver_forge/expected_output/metric/metric_jvm_memory_committed.md
@@ -15,7 +15,23 @@ Stability: Stable
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -29,22 +45,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable

--- a/crates/weaver_forge/expected_output/metric/metric_jvm_memory_limit.md
+++ b/crates/weaver_forge/expected_output/metric/metric_jvm_memory_limit.md
@@ -15,7 +15,23 @@ Stability: Stable
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -29,22 +45,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable

--- a/crates/weaver_forge/expected_output/metric/metric_jvm_memory_used.md
+++ b/crates/weaver_forge/expected_output/metric/metric_jvm_memory_used.md
@@ -15,7 +15,23 @@ Stability: Stable
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -29,22 +45,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable

--- a/crates/weaver_forge/expected_output/metric/metric_jvm_memory_used_after_last_gc.md
+++ b/crates/weaver_forge/expected_output/metric/metric_jvm_memory_used_after_last_gc.md
@@ -15,7 +15,23 @@ Stability: Stable
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -29,22 +45,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable

--- a/crates/weaver_forge/expected_output/metrics.md
+++ b/crates/weaver_forge/expected_output/metrics.md
@@ -18,7 +18,23 @@ Stability: Stable
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -32,22 +48,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable
@@ -71,7 +71,23 @@ Stability: Stable
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -85,22 +101,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable
@@ -124,7 +124,23 @@ Stability: Stable
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -138,22 +154,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable
@@ -177,7 +177,23 @@ Stability: Stable
 ### Attributes
 
 
-#### Attribute `pool.name`
+#### Attribute `jvm.memory.type`
+
+The type of memory.
+
+
+- Requirement Level: Recommended
+  
+- Type: Enum [heap, non_heap]
+- Examples: [
+    "heap",
+    "non_heap",
+]
+  
+- Stability: Stable
+  
+  
+#### Attribute `jvm.memory.pool.name`
 
 Name of the memory pool.
 
@@ -191,22 +207,6 @@ Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.
     "G1 Old Gen",
     "G1 Eden space",
     "G1 Survivor Space",
-]
-  
-- Stability: Stable
-  
-  
-#### Attribute `type`
-
-The type of memory.
-
-
-- Requirement Level: Recommended
-  
-- Type: Enum [heap, non_heap]
-- Examples: [
-    "heap",
-    "non_heap",
 ]
   
 - Stability: Stable

--- a/crates/weaver_resolver/Cargo.toml
+++ b/crates/weaver_resolver/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 weaver_common = {  path = "../weaver_common" }
+weaver_diff = { path = "../weaver_diff" }
 weaver_semconv = { path = "../weaver_semconv" }
 weaver_schema = { path = "../weaver_schema" }
 weaver_version = { path = "../weaver_version" }

--- a/crates/weaver_resolver/data/registry-test-9-metric-extends/README.md
+++ b/crates/weaver_resolver/data/registry-test-9-metric-extends/README.md
@@ -1,0 +1,1 @@
+Addresses a bug found where the `prefix` attribute a group was not being used with attribute names when a `metric` extends an `attribute_group`.

--- a/crates/weaver_resolver/data/registry-test-9-metric-extends/expected-attribute-catalog.json
+++ b/crates/weaver_resolver/data/registry-test-9-metric-extends/expected-attribute-catalog.json
@@ -1,0 +1,44 @@
+[
+    {
+      "name": "jvm.memory.type",
+      "type": {
+        "allow_custom_values": false,
+        "members": [
+          {
+            "id": "heap",
+            "value": "heap",
+            "brief": "Heap memory.",
+            "note": null,
+            "stability": "stable"
+          },
+          {
+            "id": "non_heap",
+            "value": "non_heap",
+            "brief": "Non-heap memory",
+            "note": null,
+            "stability": "stable"
+          }
+        ]
+      },
+      "brief": "The type of memory.",
+      "examples": [
+        "heap",
+        "non_heap"
+      ],
+      "requirement_level": "recommended",
+      "stability": "stable"
+    },
+    {
+      "name": "jvm.memory.pool.name",
+      "type": "string",
+      "brief": "Name of the memory pool.",
+      "examples": [
+        "G1 Old Gen",
+        "G1 Eden space",
+        "G1 Survivor Space"
+      ],
+      "requirement_level": "recommended",
+      "note": "Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).\n",
+      "stability": "stable"
+    }
+  ]

--- a/crates/weaver_resolver/data/registry-test-9-metric-extends/expected-registry.json
+++ b/crates/weaver_resolver/data/registry-test-9-metric-extends/expected-registry.json
@@ -1,0 +1,56 @@
+{
+    "registry_url": "https://127.0.0.1",
+    "groups": [
+      {
+        "id": "attributes.jvm.memory",
+        "type": "attribute_group",
+        "brief": "Describes JVM memory metric attributes.",
+        "prefix": "jvm.memory",
+        "attributes": [
+          0,
+          1
+        ],
+        "lineage": {
+          "source_file": "data/registry-test-9-metric-extends/registry/jvm-metrics.yaml"
+        }
+      },
+      {
+        "id": "metric.jvm.memory.used",
+        "type": "metric",
+        "brief": "Measure of memory used.",
+        "stability": "stable",
+        "attributes": [
+          0,
+          1
+        ],
+        "metric_name": "jvm.memory.used",
+        "instrument": "updowncounter",
+        "unit": "By",
+        "lineage": {
+          "source_file": "data/registry-test-9-metric-extends/registry/jvm-metrics.yaml",
+          "attributes": {
+            "jvm.memory.pool.name": {
+              "source_group": "attributes.jvm.memory",
+              "inherited_fields": [
+                "brief",
+                "examples",
+                "note",
+                "requirement_level",
+                "stability"
+              ]
+            },
+            "jvm.memory.type": {
+              "source_group": "attributes.jvm.memory",
+              "inherited_fields": [
+                "brief",
+                "examples",
+                "note",
+                "requirement_level",
+                "stability"
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }

--- a/crates/weaver_resolver/data/registry-test-9-metric-extends/registry/jvm-metrics.yaml
+++ b/crates/weaver_resolver/data/registry-test-9-metric-extends/registry/jvm-metrics.yaml
@@ -1,0 +1,40 @@
+groups:
+  - id: attributes.jvm.memory
+    type: attribute_group
+    brief: "Describes JVM memory metric attributes."
+    prefix: jvm.memory
+    attributes:
+      - id: type
+        stability: stable
+        type:
+          allow_custom_values: false
+          members:
+            - id: heap
+              value: 'heap'
+              brief: 'Heap memory.'
+              stability: stable
+            - id: non_heap
+              value: 'non_heap'
+              brief: 'Non-heap memory'
+              stability: stable
+        requirement_level: recommended
+        brief: The type of memory.
+        examples: ["heap", "non_heap"]
+      - id: pool.name
+        stability: stable
+        type: string
+        requirement_level: recommended
+        brief: Name of the memory pool.
+        examples: ["G1 Old Gen", "G1 Eden space", "G1 Survivor Space"]
+        note: >
+          Pool names are generally obtained via
+          [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
+
+  - id: metric.jvm.memory.used
+    type: metric
+    metric_name: jvm.memory.used
+    extends: attributes.jvm.memory
+    brief: "Measure of memory used."
+    instrument: updowncounter
+    unit: "By"
+    stability: stable

--- a/crates/weaver_resolver/src/attribute.rs
+++ b/crates/weaver_resolver/src/attribute.rs
@@ -143,7 +143,6 @@ impl AttributeCatalog {
                 stability,
                 deprecated,
             } => {
-
                 // Create a fully resolved attribute from an attribute spec (id),
                 // and check if it already exists in the catalog.
                 // If it does, return the reference to the existing attribute.

--- a/crates/weaver_resolver/src/attribute.rs
+++ b/crates/weaver_resolver/src/attribute.rs
@@ -73,7 +73,6 @@ impl AttributeCatalog {
     pub fn resolve(
         &mut self,
         group_id: &str,
-        prefix: &str,
         attr: &AttributeSpec,
         lineage: Option<&mut GroupLineage>,
     ) -> Option<AttributeRef> {
@@ -144,18 +143,13 @@ impl AttributeCatalog {
                 stability,
                 deprecated,
             } => {
-                let root_attr_id = if prefix.is_empty() {
-                    id.clone()
-                } else {
-                    format!("{}.{}", prefix, id)
-                };
 
                 // Create a fully resolved attribute from an attribute spec (id),
                 // and check if it already exists in the catalog.
                 // If it does, return the reference to the existing attribute.
                 // If it does not, add it to the catalog and return a new reference.
                 let attr = attribute::Attribute {
-                    name: root_attr_id.clone(),
+                    name: id.clone(),
                     r#type: r#type.clone(),
                     brief: brief.clone().unwrap_or_default(),
                     examples: examples.clone(),
@@ -170,7 +164,7 @@ impl AttributeCatalog {
                 };
 
                 _ = self.root_attributes.insert(
-                    root_attr_id,
+                    id.to_owned(),
                     AttributeWithGroupId {
                         attribute: attr.clone(),
                         group_id: group_id.to_owned(),

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -70,7 +70,9 @@ pub fn resolve_semconv_registry(
     registry_url: &str,
     registry: &SemConvRegistry,
 ) -> Result<Registry, Error> {
-    let mut ureg = unresolved_registry_from_specs(registry_url, registry);
+    let mut ureg = unresolved_registry_from_specs(registry_url, registry); 
+
+    resolve_prefix_on_attributes(&mut ureg)?;
 
     resolve_extends_references(&mut ureg)?;
 
@@ -266,6 +268,23 @@ fn group_from_spec(group: GroupSpecWithProvenance) -> UnresolvedGroup {
     }
 }
 
+/// This takes all attributes and ensures that their id is fully fleshed out with
+/// the group prefix before continuing resolution.
+/// 
+/// This should be the *only* method that updates attribute ids.
+fn resolve_prefix_on_attributes(ureg: &mut UnresolvedRegistry) -> Result<(), Error> {
+    for unresolved_group in ureg.groups.iter_mut() {
+        if !unresolved_group.group.prefix.is_empty() {
+            for attribute in unresolved_group.attributes.iter_mut() {
+                if let AttributeSpec::Id { id, .. } = &mut attribute.spec {
+                    *id = format!("{}.{}", unresolved_group.group.prefix, id);
+                }    
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Resolves attribute references in the given registry.
 /// The resolution process is iterative. The process stops when all the
 /// attribute references are resolved or when no attribute reference could
@@ -296,7 +315,6 @@ fn resolve_attribute_references(
                 .filter_map(|attr| {
                     let attr_ref = attr_catalog.resolve(
                         &unresolved_group.group.id,
-                        &unresolved_group.group.prefix,
                         &attr.spec,
                         unresolved_group.group.lineage.as_mut(),
                     );
@@ -735,13 +753,14 @@ mod tests {
 
             assert_eq!(
                 observed_attr_catalog, expected_attr_catalog,
-                "Observed and expected attribute catalogs don't match for `{}`.\nExpected catalog:\n{}\nObserved catalog:\n{}",
-                test_dir, to_json(&expected_attr_catalog), to_json(&observed_attr_catalog)
-            );
+                "Observed and expected attribute catalogs don't match for `{}`.\nExpected catalog:\n{}\nObserved catalog:\n{}\nDiff from expected:\n{}",
+                test_dir, to_json(&expected_attr_catalog), to_json(&observed_attr_catalog), weaver_diff::diff_output(&to_json(&expected_attr_catalog), &to_json(&observed_attr_catalog))
+            );            
 
             // let yaml = serde_yaml::to_string(&observed_attr_catalog).unwrap();
-            // println!("{}", yaml);
-            // println!("Observed registry:\n{}", to_json(&observed_registry));
+            //println!("{}", yaml);
+            // println!("Observed attribute catalog:\n{}", to_json(&observed_attr_catalog));
+            
 
             // Check that the resolved registry matches the expected registry.
             let expected_registry: Registry = serde_json::from_reader(
@@ -752,8 +771,8 @@ mod tests {
 
             assert_eq!(
                 observed_registry, expected_registry,
-                "Expected and observed registry don't match for `{}`.\nObserved registry:\n{}\nExpected registry:\n{}",
-                test_dir, to_json(&observed_registry), to_json(&expected_registry)
+                "Expected and observed registry don't match for `{}`.\nObserved registry:\n{}\nExpected registry:\n{}\nDiff from expected:\n{}",
+                test_dir, to_json(&observed_registry), to_json(&expected_registry), weaver_diff::diff_output(&to_json(&expected_registry), &to_json(&observed_registry))
             );
 
             // let yaml = serde_yaml::to_string(&observed_registry).unwrap();

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -70,7 +70,7 @@ pub fn resolve_semconv_registry(
     registry_url: &str,
     registry: &SemConvRegistry,
 ) -> Result<Registry, Error> {
-    let mut ureg = unresolved_registry_from_specs(registry_url, registry); 
+    let mut ureg = unresolved_registry_from_specs(registry_url, registry);
 
     resolve_prefix_on_attributes(&mut ureg)?;
 
@@ -270,7 +270,7 @@ fn group_from_spec(group: GroupSpecWithProvenance) -> UnresolvedGroup {
 
 /// This takes all attributes and ensures that their id is fully fleshed out with
 /// the group prefix before continuing resolution.
-/// 
+///
 /// This should be the *only* method that updates attribute ids.
 fn resolve_prefix_on_attributes(ureg: &mut UnresolvedRegistry) -> Result<(), Error> {
     for unresolved_group in ureg.groups.iter_mut() {
@@ -278,7 +278,7 @@ fn resolve_prefix_on_attributes(ureg: &mut UnresolvedRegistry) -> Result<(), Err
             for attribute in unresolved_group.attributes.iter_mut() {
                 if let AttributeSpec::Id { id, .. } = &mut attribute.spec {
                     *id = format!("{}.{}", unresolved_group.group.prefix, id);
-                }    
+                }
             }
         }
     }
@@ -755,12 +755,11 @@ mod tests {
                 observed_attr_catalog, expected_attr_catalog,
                 "Observed and expected attribute catalogs don't match for `{}`.\nExpected catalog:\n{}\nObserved catalog:\n{}\nDiff from expected:\n{}",
                 test_dir, to_json(&expected_attr_catalog), to_json(&observed_attr_catalog), weaver_diff::diff_output(&to_json(&expected_attr_catalog), &to_json(&observed_attr_catalog))
-            );            
+            );
 
             // let yaml = serde_yaml::to_string(&observed_attr_catalog).unwrap();
             //println!("{}", yaml);
             // println!("Observed attribute catalog:\n{}", to_json(&observed_attr_catalog));
-            
 
             // Check that the resolved registry matches the expected registry.
             let expected_registry: Registry = serde_json::from_reader(


### PR DESCRIPTION
Attributes would ONLY have prefix applied when being extended in certain scenarios.   This lead to an issue where unresolved attribute ids were cloned *before* prefix would be applied.  This PR fixes that by introducing a new step in resolution.

- Adds new resolution step to resolve all attribute ids to "full" id before continuing any other resolution.
- Update all the (actually broken) generated templates that were using the wrong attributes for JVM metrics (stripping prefix).
- Add a  specific test case for the attribute id + extends case that was broken.
- Update weaver_resolver tests to output colored diff on failure

See https://github.com/open-telemetry/semantic-conventions/pull/917#discussion_r1566611724 for context