### PR TITLE
(fix) Use id instead of value in enum table

### DIFF
--- a/crates/weaver_semconv_gen/src/gen.rs
+++ b/crates/weaver_semconv_gen/src/gen.rs
@@ -198,8 +198,8 @@ impl<'a> AttributeView<'a> {
                 if let Some(v) = m.brief.as_ref() {
                     write!(out, "{}", v.trim())?;
                 } else {
-                    // Use the value as the description if missing a brief.
-                    write!(out, "{}", m.value)?;
+                    // Use the id as the description if missing a brief.
+                    write!(out, "{}", m.id)?;
                 }
                 // Stability.
                 write!(out, " | ")?;


### PR DESCRIPTION
Unfortunately, my test case didn't distinguish the two with different values.

Context: https://github.com/open-telemetry/semantic-conventions/pull/917#discussion_r1576864303