### PR TITLE
Update weaver to understand deprecated enum values.

### DIFF
--- a/crates/weaver_semconv/src/attribute.rs
+++ b/crates/weaver_semconv/src/attribute.rs
@@ -321,6 +321,8 @@ pub struct EnumEntriesSpec {
     pub note: Option<String>,
     /// Stability of this enum value.
     pub stability: Option<Stability>,
+    /// Deprecation note.
+    pub deprecated: Option<String>,
 }
 
 /// Implements a human readable display for EnumEntries.
@@ -625,6 +627,7 @@ mod tests {
                         brief: Some("brief".to_owned()),
                         note: Some("note".to_owned()),
                         stability: None,
+                        deprecated: None,
                     }]
                 }
             ),
@@ -679,6 +682,7 @@ mod tests {
             brief: Some("brief".to_owned()),
             note: Some("note".to_owned()),
             stability: None,
+            deprecated: None,
         };
         assert_eq!(format!("{}", entries), "id=id, type=42");
     }

--- a/crates/weaver_semconv/src/group.rs
+++ b/crates/weaver_semconv/src/group.rs
@@ -152,9 +152,7 @@ impl GroupSpec {
             // will result in an error.
             match attribute {
                 AttributeSpec::Id {
-                    brief,
-                    deprecated,
-                    ..
+                    brief, deprecated, ..
                 } => {
                     if brief.is_none() && deprecated.is_none() {
                         errors.push(Error::InvalidAttribute {
@@ -340,37 +338,40 @@ mod tests {
         // Span kind is set but the type is not span.
         group.r#type = GroupType::Metric;
         let result = group.validate("<test>");
-        assert_eq!(Err(
-            CompoundError(
-                vec![
-                    InvalidGroup {
-                        path_or_url: "<test>".to_owned(),
-                        group_id: "test".to_owned(),
-                        error: "This group contains a span_kind field but the type is not set to span.".to_owned(),
-                    },
-                    InvalidGroup {
-                        path_or_url: "<test>".to_owned(),
-                        group_id: "test".to_owned(),
-                        error: "This group contains an events field but the type is not set to span.".to_owned(),
-                    },
-                    InvalidMetric {
-                        path_or_url: "<test>".to_owned(),
-                        group_id: "test".to_owned(),
-                        error: "This group contains a metric type but the metric_name is not set.".to_owned(),
-                    },
-                    InvalidMetric {
-                        path_or_url: "<test>".to_owned(),
-                        group_id: "test".to_owned(),
-                        error: "This group contains a metric type but the instrument is not set.".to_owned(),
-                    },
-                    InvalidMetric {
-                        path_or_url: "<test>".to_owned(),
-                        group_id: "test".to_owned(),
-                        error: "This group contains a metric type but the unit is not set.".to_owned(),
-                    },
-                ],
-            ),
-        ), result);
+        assert_eq!(
+            Err(CompoundError(vec![
+                InvalidGroup {
+                    path_or_url: "<test>".to_owned(),
+                    group_id: "test".to_owned(),
+                    error: "This group contains a span_kind field but the type is not set to span."
+                        .to_owned(),
+                },
+                InvalidGroup {
+                    path_or_url: "<test>".to_owned(),
+                    group_id: "test".to_owned(),
+                    error: "This group contains an events field but the type is not set to span."
+                        .to_owned(),
+                },
+                InvalidMetric {
+                    path_or_url: "<test>".to_owned(),
+                    group_id: "test".to_owned(),
+                    error: "This group contains a metric type but the metric_name is not set."
+                        .to_owned(),
+                },
+                InvalidMetric {
+                    path_or_url: "<test>".to_owned(),
+                    group_id: "test".to_owned(),
+                    error: "This group contains a metric type but the instrument is not set."
+                        .to_owned(),
+                },
+                InvalidMetric {
+                    path_or_url: "<test>".to_owned(),
+                    group_id: "test".to_owned(),
+                    error: "This group contains a metric type but the unit is not set.".to_owned(),
+                },
+            ],),),
+            result
+        );
 
         // Field name is required if prefix is empty and if type is event.
         group.r#type = GroupType::Event;

--- a/crates/weaver_semconv/src/semconv.rs
+++ b/crates/weaver_semconv/src/semconv.rs
@@ -186,12 +186,6 @@ mod tests {
         assert!(semconv_spec.is_err());
         assert!(matches!(semconv_spec.unwrap_err(), RegistryNotFound { .. }));
 
-        // Invalid group semantic (marked as deprecated but stability is not deprecated)
-        let path = PathBuf::from("data/invalid-stability.yaml");
-        let semconv_spec = SemConvSpec::from_file(path);
-        assert!(semconv_spec.is_err());
-        assert!(matches!(semconv_spec.unwrap_err(), InvalidAttribute { .. }));
-
         // Invalid file structure
         let path = PathBuf::from("data/invalid-semconv.yaml");
         let semconv_spec = SemConvSpec::from_file(path);

--- a/crates/weaver_semconv_gen/legacy_tests/stability/stability.yaml
+++ b/crates/weaver_semconv_gen/legacy_tests/stability/stability.yaml
@@ -1,0 +1,91 @@
+groups:
+  - id: test
+    type: span
+    brief: 'test'
+    prefix: test
+    stability: deprecated
+    attributes:
+      - id: exp_attr
+        type: boolean
+        requirement_level: required
+        stability: experimental
+        brief: ""
+      - id: stable_attr
+        type: boolean
+        requirement_level: required
+        stability: stable
+        brief: ""
+      - id: deprecated_stable_attr
+        type: boolean
+        requirement_level: required
+        stability: stable
+        deprecated: "Removed."
+        brief: ""
+      - id: deprecated_experimental_attr
+        type: boolean
+        requirement_level: required
+        stability: experimental
+        deprecated: "Removed."
+        brief: ""
+      - id: stable_enum_attr
+        brief: ""
+        stability: stable
+        type:
+          members:
+            - id: one
+              value: "one"
+              brief: 'member one'
+              stability: stable
+            - id: two
+              value: "two"
+              stability: experimental
+              brief: 'member two'
+            - id: three
+              value: "three"
+              stability: experimental
+              deprecated: "Removed."
+              brief: 'member three'
+            - id: four
+              value: "four"
+              stability: stable
+              deprecated: "Removed."
+              brief: 'member four'
+  - id: ref_test
+    brief: 'ref_test'
+    attributes:
+      - ref: test.exp_attr
+      - ref: test.stable_attr
+      - ref: test.deprecated_stable_attr
+      - ref: test.deprecated_experimental_attr
+      - ref: test.stable_enum_attr
+  - id: extends_test
+    brief: 'extends_test'
+    extends: test
+  - id: stable_metric
+    type: metric
+    brief: 'stable_metric'
+    stability: stable
+    metric_name: stable_metric
+    instrument: histogram
+    unit: "s"
+    attributes:
+      - ref: test.stable_attr
+  - id: experimental_metric
+    type: metric
+    brief: 'experimental_metric'
+    stability: experimental
+    metric_name: experimental_metric
+    instrument: counter
+    unit: "{e}"
+    attributes:
+      - ref: test.exp_attr
+  - id: deprecated_metric
+    type: metric
+    brief: 'deprecated_metric'
+    stability: stable
+    deprecated: "Removed."
+    metric_name: deprecated_metric
+    instrument: updowncounter
+    unit: "{d}"
+    attributes:
+      - ref: test.deprecated_experimental_attr

--- a/crates/weaver_semconv_gen/legacy_tests/stability/test.md
+++ b/crates/weaver_semconv_gen/legacy_tests/stability/test.md
@@ -1,0 +1,74 @@
+<!-- semconv test -->
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
+|---|---|---|---|---|---|
+| test.deprecated_experimental_attr | boolean |  |  | `Required` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+| test.deprecated_stable_attr | boolean |  |  | `Required` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+| test.exp_attr | boolean |  |  | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| test.stable_attr | boolean |  |  | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| test.stable_enum_attr | string |  | `one`; `two`; `three` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+
+`test.stable_enum_attr` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `one` | member one | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `two` | member two | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `three` | member three | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+| `four` | member four | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+<!-- endsemconv -->
+
+<!-- semconv ref_test -->
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
+|---|---|---|---|---|---|
+| test.deprecated_experimental_attr | boolean |  |  | `Required` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+| test.deprecated_stable_attr | boolean |  |  | `Required` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+| test.exp_attr | boolean |  |  | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| test.stable_attr | boolean |  |  | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| test.stable_enum_attr | string |  | `one`; `two`; `three` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+
+`test.stable_enum_attr` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `one` | member one | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `two` | member two | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `three` | member three | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+| `four` | member four | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+<!-- endsemconv -->
+
+<!-- semconv extends_test(full) -->
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
+|---|---|---|---|---|---|
+| test.deprecated_experimental_attr | boolean |  |  | `Required` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+| test.deprecated_stable_attr | boolean |  |  | `Required` | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+| test.exp_attr | boolean |  |  | `Required` | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| test.stable_attr | boolean |  |  | `Required` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| test.stable_enum_attr | string |  | `one`; `two`; `three` | `Recommended` | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+
+`test.stable_enum_attr` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `one` | member one | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+| `two` | member two | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+| `three` | member three | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+| `four` | member four | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+<!-- endsemconv -->
+
+<!-- semconv stable_metric(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
+| -------- | --------------- | ----------- | -------------- | --------- |
+| `stable_metric` | Histogram | `s` | stable_metric | ![Stable](https://img.shields.io/badge/-stable-lightgreen) |
+<!-- endsemconv -->
+
+<!-- semconv experimental_metric(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
+| -------- | --------------- | ----------- | -------------- | --------- |
+| `experimental_metric` | Counter | `{e}` | experimental_metric | ![Experimental](https://img.shields.io/badge/-experimental-blue) |
+<!-- endsemconv -->
+
+<!-- semconv deprecated_metric(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
+| -------- | --------------- | ----------- | -------------- | --------- |
+| `deprecated_metric` | UpDownCounter | `{d}` | deprecated_metric | ![Deprecated](https://img.shields.io/badge/-deprecated-red)<br>Removed. |
+<!-- endsemconv -->

--- a/crates/weaver_semconv_gen/src/gen.rs
+++ b/crates/weaver_semconv_gen/src/gen.rs
@@ -195,9 +195,7 @@ impl<'a> AttributeView<'a> {
                 write!(out, "| ")?;
                 write_enum_value_string(out, &m.value)?;
                 write!(out, " | ")?;
-                if let Some(note) = m.deprecated.as_ref() {
-                    write!(out, "{}", note.trim())?;
-                } else if let Some(v) = m.brief.as_ref() {
+                if let Some(v) = m.brief.as_ref() {
                     write!(out, "{}", v.trim())?;
                 } else {
                     // Use the id as the description if missing a brief.
@@ -205,8 +203,9 @@ impl<'a> AttributeView<'a> {
                 }
                 // Stability.
                 write!(out, " | ")?;
-                if m.deprecated.is_some() {
+                if let Some(note) = m.deprecated.as_ref() {
                     write_stability_badge(out, &Some(Stability::Deprecated))?;
+                    write!(out, "<br>{}", note.trim())?;
                 } else {
                     write_stability_badge(out, &m.stability)?;
                 }
@@ -314,7 +313,13 @@ impl<'a> AttributeView<'a> {
     }
 
     fn write_stability<Out: Write>(&self, out: &mut Out) -> Result<(), Error> {
-        write_stability_badge(out, &self.attribute.stability)
+        if let Some(note) = self.attribute.deprecated.as_ref() {
+            write_stability_badge(out, &Some(Stability::Deprecated))?;
+            write!(out, "<br>{}", note.trim())?;
+        } else {
+            write_stability_badge(out, &self.attribute.stability)?;
+        }
+        Ok(())
     }
 }
 
@@ -529,7 +534,13 @@ impl<'a> MetricView<'a> {
         Ok(())
     }
     fn write_stability<Out: Write>(&self, out: &mut Out) -> Result<(), Error> {
-        write_stability_badge(out, &self.group.stability)
+        if let Some(note) = self.group.deprecated.as_ref() {
+            write_stability_badge(out, &Some(Stability::Deprecated))?;
+            write!(out, "<br>{}", note.trim())?;
+        } else {
+            write_stability_badge(out, &self.group.stability)?;
+        }
+        Ok(())
     }
     pub fn generate_markdown<Out: Write>(
         &self,

--- a/crates/weaver_semconv_gen/src/gen.rs
+++ b/crates/weaver_semconv_gen/src/gen.rs
@@ -195,7 +195,9 @@ impl<'a> AttributeView<'a> {
                 write!(out, "| ")?;
                 write_enum_value_string(out, &m.value)?;
                 write!(out, " | ")?;
-                if let Some(v) = m.brief.as_ref() {
+                if let Some(note) = m.deprecated.as_ref() {
+                    write!(out, "{}", note.trim())?;
+                } else if let Some(v) = m.brief.as_ref() {
                     write!(out, "{}", v.trim())?;
                 } else {
                     // Use the id as the description if missing a brief.
@@ -203,7 +205,11 @@ impl<'a> AttributeView<'a> {
                 }
                 // Stability.
                 write!(out, " | ")?;
-                write_stability_badge(out, &m.stability)?;
+                if m.deprecated.is_some() {
+                    write_stability_badge(out, &Some(Stability::Deprecated))?;
+                } else {
+                    write_stability_badge(out, &m.stability)?;
+                }
                 writeln!(out, " |")?;
             }
         }


### PR DESCRIPTION
Besides the stability marker, we now have a deprecation note we allow.