### PR TITLE
(fix) Expand id parsing

### DIFF
--- a/crates/weaver_semconv_gen/src/parser.rs
+++ b/crates/weaver_semconv_gen/src/parser.rs
@@ -72,7 +72,10 @@ fn parse_markdown_gen_parameters(input: &str) -> IResult<&str, Vec<MarkdownGenPa
 
 /// nom parser for semconv ids.
 fn parse_id(input: &str) -> IResult<&str, &str> {
-    recognize(many0_count(alt((alpha1, tag("."), tag("_"), tag("-")))))(input)
+    recognize(pair(
+        alpha1, // First character must be alpha, then anything is accepted.
+        many0_count(alt((alphanumeric1, tag("."), tag("_"), tag("-")))),
+    ))(input)
 }
 
 /// nom parser for <!-- semconv {id}({args}) -->
@@ -133,6 +136,9 @@ mod tests {
     fn recognizes_header() {
         assert!(is_markdown_snippet_directive(
             "<!-- semconv registry.user_agent -->"
+        ));
+        assert!(is_markdown_snippet_directive(
+            "<!-- semconv registry.user_agent.p99 -->"
         ));
         assert!(is_markdown_snippet_directive(
             "<!-- semconv my.id(full) -->"


### PR DESCRIPTION
Current parsing is a bit inflexible, improve parsing to include more.

Fixes #151 


This is a fast update.  Longer term, we should have a very "loose" parsing grammar for recognizing tags where we can issue errors if the tags don't match our current parser, due, e.g. to poor tag syntax.