### PR TITLE
Add a collection of new filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,9 +587,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -954,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180b130a4a41870edfbd36ce4169c7090bca70e195da783dea088dd973daa59c"
+checksum = "367ee9093b0c2b04fd04c5c7c8b6a1082713534eab537597ae343663a518fa99"
 dependencies = [
  "bstr",
  "itoa",
@@ -2015,6 +2015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "markdown"
+version = "1.0.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e27d6220ce21f80ce5c4201f23a37c6f1ad037c72c9d1ff215c2919605a5d6"
+dependencies = [
+ "unicode-id",
+]
+
+[[package]]
 name = "maybe-async"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -2209,11 +2218,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2878,18 +2886,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2909,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -3077,9 +3085,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.61"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3266,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3278,18 +3286,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.12"
+version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
 dependencies = [
  "indexmap",
  "serde",
@@ -3378,6 +3386,12 @@ name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
+name = "unicode-id"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b6def86329695390197b82c1e244a54a131ceb66c996f2088a3876e2ae083f"
 
 [[package]]
 name = "unicode-ident"
@@ -3674,6 +3688,7 @@ dependencies = [
  "jaq-interpret",
  "jaq-parse",
  "jaq-std",
+ "markdown",
  "minijinja",
  "opentelemetry",
  "opentelemetry-stdout",

--- a/crates/weaver_forge/Cargo.toml
+++ b/crates/weaver_forge/Cargo.toml
@@ -27,6 +27,7 @@ jaq-interpret = "1.2.1"
 jaq-parse = "1.0.2"
 indexmap = "2.2.6"
 regex = "1.10.4"
+markdown = "=1.0.0-alpha.17"
 
 itertools.workspace = true
 thiserror.workspace = true

--- a/crates/weaver_forge/README.md
+++ b/crates/weaver_forge/README.md
@@ -76,6 +76,20 @@ The configuration file `weaver.yaml` is optional. It allows configuring the
 following options:
 
 ```yaml
+# Uncomment this section to specify the configuration of the `text_map` filter.
+#text_maps:
+#  java_types:
+#    int: int
+#    double: double
+#    boolean: boolean
+#    string: String
+#  java_keys:
+#    int: intKey
+#    double: doubleKey
+#    boolean: booleanKey
+#    string: stringKey
+    
+# Deprecated, please use text_maps instead
 # Configuration of the type mapping. This is useful to generate code in a
 # specific language. This is optional.
 # Example: {{ attribute.type | type_mapping }} will be evaluated as int64
@@ -201,6 +215,8 @@ e.g. \[\[a,b\],\[c\]\] => \[a,b,c\]
 - `attribute_namespace`: Converts {namespace}.{attribute_id} to {namespace}.
 - `required`: Filters a list of `Attribute`s to include only the required attributes. The "conditionally_required" attributes are not returned by this filter.
 - `not_required`: Filters a list of `Attribute`s to only include non-required attributes. The "conditionally_required" attributes are returned by this filter.
+- `markdown_to_html`: Converts a markdown string to an HTML string.
+- `text_map`: Converts an input into a string based on the `text_maps` section of the `weaver.yaml` configuration file and a named text_map.
 
 > Please open an issue if you have any suggestions for new filters. They are easy to implement.
 

--- a/crates/weaver_forge/README.md
+++ b/crates/weaver_forge/README.md
@@ -217,6 +217,42 @@ e.g. \[\[a,b\],\[c\]\] => \[a,b,c\]
 - `not_required`: Filters a list of `Attribute`s to only include non-required attributes. The "conditionally_required" attributes are returned by this filter.
 - `markdown_to_html`: Converts a markdown string to an HTML string.
 - `text_map`: Converts an input into a string based on the `text_maps` section of the `weaver.yaml` configuration file and a named text_map.
+- `black`: Format a text using the black ansi code.
+- `red`: Format a text using the red ansi code.
+- `green`: Format a text using the green ansi code.
+- `yellow`: Format a text using the yellow ansi code.
+- `blue`: Format a text using the blue ansi code.
+- `magenta`: Format a text using the magenta ansi code.
+- `cyan`: Format a text using the cyan ansi code.
+- `white`: Format a text using the white ansi code.
+- `bright_black`: Format a text using the bright black ansi code.
+- `bright_red`: Format a text using the bright red ansi code.
+- `bright_green`: Format a text using the bright green ansi code.
+- `bright_yellow`: Format a text using the bright yellow ansi code.
+- `bright_blue`: Format a text using the bright blue ansi code.
+- `bright_magenta`: Format a text using the bright magenta ansi code.
+- `bright_cyan`: Format a text using the bright cyan ansi code.
+- `bright_white`: Format a text using the bright white ansi code.
+- `bg_black`: Format a text using the black background ansi code.
+- `bg_red`: Format a text using the red background ansi code.
+- `bg_green`: Format a text using the green background ansi code.
+- `bg_yellow`: Format a text using the yellow background ansi code.
+- `bg_blue`: Format a text using the blue background ansi code.
+- `bg_magenta`: Format a text using the magenta background ansi code.
+- `bg_cyan`: Format a text using the cyan background ansi code.
+- `bg_white`: Format a text using the white background ansi code.
+- `bg_bright_black`: Format a text using the bright black background ansi code.
+- `bg_bright_red`: Format a text using the bright red background ansi code.
+- `bg_bright_green`: Format a text using the bright green background ansi code.
+- `bg_bright_yellow`: Format a text using the bright yellow background ansi code.
+- `bg_bright_blue`: Format a text using the bright blue background ansi code.
+- `bg_bright_magenta`: Format a text using the bright magenta background ansi code.
+- `bg_bright_cyan`: Format a text using the bright cyan background ansi code.
+- `bg_bright_white`: Format a text using the bright white background ansi code.
+- `bold`: Format a text using the bold ansi code.
+- `italic`: Format a text using the italic ansi code.
+- `underline`: Format a text using the underline ansi code.
+- `strikethrough`: Format a text using the strikethrough ansi code.
 
 > Please open an issue if you have any suggestions for new filters. They are easy to implement.
 

--- a/crates/weaver_forge/README.md
+++ b/crates/weaver_forge/README.md
@@ -217,42 +217,42 @@ e.g. \[\[a,b\],\[c\]\] => \[a,b,c\]
 - `not_required`: Filters a list of `Attribute`s to only include non-required attributes. The "conditionally_required" attributes are returned by this filter.
 - `markdown_to_html`: Converts a markdown string to an HTML string.
 - `text_map`: Converts an input into a string based on the `text_maps` section of the `weaver.yaml` configuration file and a named text_map.
-- `black`: Format a text using the black ansi code.
-- `red`: Format a text using the red ansi code.
-- `green`: Format a text using the green ansi code.
-- `yellow`: Format a text using the yellow ansi code.
-- `blue`: Format a text using the blue ansi code.
-- `magenta`: Format a text using the magenta ansi code.
-- `cyan`: Format a text using the cyan ansi code.
-- `white`: Format a text using the white ansi code.
-- `bright_black`: Format a text using the bright black ansi code.
-- `bright_red`: Format a text using the bright red ansi code.
-- `bright_green`: Format a text using the bright green ansi code.
-- `bright_yellow`: Format a text using the bright yellow ansi code.
-- `bright_blue`: Format a text using the bright blue ansi code.
-- `bright_magenta`: Format a text using the bright magenta ansi code.
-- `bright_cyan`: Format a text using the bright cyan ansi code.
-- `bright_white`: Format a text using the bright white ansi code.
-- `bg_black`: Format a text using the black background ansi code.
-- `bg_red`: Format a text using the red background ansi code.
-- `bg_green`: Format a text using the green background ansi code.
-- `bg_yellow`: Format a text using the yellow background ansi code.
-- `bg_blue`: Format a text using the blue background ansi code.
-- `bg_magenta`: Format a text using the magenta background ansi code.
-- `bg_cyan`: Format a text using the cyan background ansi code.
-- `bg_white`: Format a text using the white background ansi code.
-- `bg_bright_black`: Format a text using the bright black background ansi code.
-- `bg_bright_red`: Format a text using the bright red background ansi code.
-- `bg_bright_green`: Format a text using the bright green background ansi code.
-- `bg_bright_yellow`: Format a text using the bright yellow background ansi code.
-- `bg_bright_blue`: Format a text using the bright blue background ansi code.
-- `bg_bright_magenta`: Format a text using the bright magenta background ansi code.
-- `bg_bright_cyan`: Format a text using the bright cyan background ansi code.
-- `bg_bright_white`: Format a text using the bright white background ansi code.
-- `bold`: Format a text using the bold ansi code.
-- `italic`: Format a text using the italic ansi code.
-- `underline`: Format a text using the underline ansi code.
-- `strikethrough`: Format a text using the strikethrough ansi code.
+- `ansi_black`: Format a text using the black ansi code.
+- `ansi_red`: Format a text using the red ansi code.
+- `ansi_green`: Format a text using the green ansi code.
+- `ansi_yellow`: Format a text using the yellow ansi code.
+- `ansi_blue`: Format a text using the blue ansi code.
+- `ansi_magenta`: Format a text using the magenta ansi code.
+- `ansi_cyan`: Format a text using the cyan ansi code.
+- `ansi_white`: Format a text using the white ansi code.
+- `ansi_bright_black`: Format a text using the bright black ansi code.
+- `ansi_bright_red`: Format a text using the bright red ansi code.
+- `ansi_bright_green`: Format a text using the bright green ansi code.
+- `ansi_bright_yellow`: Format a text using the bright yellow ansi code.
+- `ansi_bright_blue`: Format a text using the bright blue ansi code.
+- `ansi_bright_magenta`: Format a text using the bright magenta ansi code.
+- `ansi_bright_cyan`: Format a text using the bright cyan ansi code.
+- `ansi_bright_white`: Format a text using the bright white ansi code.
+- `ansi_bg_black`: Format a text using the black background ansi code.
+- `ansi_bg_red`: Format a text using the red background ansi code.
+- `ansi_bg_green`: Format a text using the green background ansi code.
+- `ansi_bg_yellow`: Format a text using the yellow background ansi code.
+- `ansi_bg_blue`: Format a text using the blue background ansi code.
+- `ansi_bg_magenta`: Format a text using the magenta background ansi code.
+- `ansi_bg_cyan`: Format a text using the cyan background ansi code.
+- `ansi_bg_white`: Format a text using the white background ansi code.
+- `ansi_bg_bright_black`: Format a text using the bright black background ansi code.
+- `ansi_bg_bright_red`: Format a text using the bright red background ansi code.
+- `ansi_bg_bright_green`: Format a text using the bright green background ansi code.
+- `ansi_bg_bright_yellow`: Format a text using the bright yellow background ansi code.
+- `ansi_bg_bright_blue`: Format a text using the bright blue background ansi code.
+- `ansi_bg_bright_magenta`: Format a text using the bright magenta background ansi code.
+- `ansi_bg_bright_cyan`: Format a text using the bright cyan background ansi code.
+- `ansi_bg_bright_white`: Format a text using the bright white background ansi code.
+- `ansi_bold`: Format a text using the bold ansi code.
+- `ansi_italic`: Format a text using the italic ansi code.
+- `ansi_underline`: Format a text using the underline ansi code.
+- `ansi_strikethrough`: Format a text using the strikethrough ansi code.
 
 > Please open an issue if you have any suggestions for new filters. They are easy to implement.
 

--- a/crates/weaver_forge/src/config.rs
+++ b/crates/weaver_forge/src/config.rs
@@ -59,11 +59,11 @@ pub struct TargetConfig {
     #[serde(default)]
     pub field_name: CaseConvention,
     /// Type mapping for target specific types (OTel types -> Target language types).
-    #[allow(dead_code)] // will be used later in the project
     #[serde(default)]
-    #[allow(dead_code)]
-    // ToDo create a Jinja macro to generate the mapping semconv -> target language
     pub type_mapping: HashMap<String, String>,
+    /// Configuration of the `text_map` filter.
+    #[serde(default)]
+    pub text_maps: HashMap<String, HashMap<String, String>>,
     /// Configuration for the template syntax.
     #[serde(default)]
     pub template_syntax: TemplateSyntax,

--- a/crates/weaver_forge/src/extensions/ansi.rs
+++ b/crates/weaver_forge/src/extensions/ansi.rs
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Set of filters used to add style and color to the console.
+
+use minijinja::Value;
+
+/// Converts the input value into a text with a black foreground color.
+#[must_use]
+pub(crate) fn black(input: &Value) -> String {
+    format!("\x1b[30m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a red foreground color.
+#[must_use]
+pub(crate) fn red(input: &Value) -> String {
+    format!("\x1b[31m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a green foreground color.
+#[must_use]
+pub(crate) fn green(input: &Value) -> String {
+    format!("\x1b[32m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a yellow foreground color.
+#[must_use]
+pub(crate) fn yellow(input: &Value) -> String {
+    format!("\x1b[33m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a blue foreground color.
+#[must_use]
+pub(crate) fn blue(input: &Value) -> String {
+    format!("\x1b[34m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a magenta foreground color.
+#[must_use]
+pub(crate) fn magenta(input: &Value) -> String {
+    format!("\x1b[35m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a cyan foreground color.
+#[must_use]
+pub(crate) fn cyan(input: &Value) -> String {
+    format!("\x1b[36m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a white foreground color.
+#[must_use]
+pub(crate) fn white(input: &Value) -> String {
+    format!("\x1b[37m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright black foreground color.
+#[must_use]
+pub(crate) fn bright_black(input: &Value) -> String {
+    format!("\x1b[90m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright red foreground color.
+#[must_use]
+pub(crate) fn bright_red(input: &Value) -> String {
+    format!("\x1b[91m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright green foreground color.
+#[must_use]
+pub(crate) fn bright_green(input: &Value) -> String {
+    format!("\x1b[92m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright yellow foreground color.
+#[must_use]
+pub(crate) fn bright_yellow(input: &Value) -> String {
+    format!("\x1b[93m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright blue foreground color.
+#[must_use]
+pub(crate) fn bright_blue(input: &Value) -> String {
+    format!("\x1b[94m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright magenta foreground color.
+#[must_use]
+pub(crate) fn bright_magenta(input: &Value) -> String {
+    format!("\x1b[95m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright cyan foreground color.
+#[must_use]
+pub(crate) fn bright_cyan(input: &Value) -> String {
+    format!("\x1b[96m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright white foreground color.
+#[must_use]
+pub(crate) fn bright_white(input: &Value) -> String {
+    format!("\x1b[97m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a black background color.
+#[must_use]
+pub(crate) fn bg_black(input: &Value) -> String {
+    format!("\x1b[40m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a red background color.
+#[must_use]
+pub(crate) fn bg_red(input: &Value) -> String {
+    format!("\x1b[41m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a green background color.
+#[must_use]
+pub(crate) fn bg_green(input: &Value) -> String {
+    format!("\x1b[42m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a yellow background color.
+#[must_use]
+pub(crate) fn bg_yellow(input: &Value) -> String {
+    format!("\x1b[43m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a blue background color.
+#[must_use]
+pub(crate) fn bg_blue(input: &Value) -> String {
+    format!("\x1b[44m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a magenta background color.
+#[must_use]
+pub(crate) fn bg_magenta(input: &Value) -> String {
+    format!("\x1b[45m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a cyan background color.
+#[must_use]
+pub(crate) fn bg_cyan(input: &Value) -> String {
+    format!("\x1b[46m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a white background color.
+#[must_use]
+pub(crate) fn bg_white(input: &Value) -> String {
+    format!("\x1b[47m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright black background color.
+#[must_use]
+pub(crate) fn bg_bright_black(input: &Value) -> String {
+    format!("\x1b[100m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright red background color.
+#[must_use]
+pub(crate) fn bg_bright_red(input: &Value) -> String {
+    format!("\x1b[101m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright green background color.
+#[must_use]
+pub(crate) fn bg_bright_green(input: &Value) -> String {
+    format!("\x1b[102m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright yellow background color.
+#[must_use]
+pub(crate) fn bg_bright_yellow(input: &Value) -> String {
+    format!("\x1b[103m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright blue background color.
+#[must_use]
+pub(crate) fn bg_bright_blue(input: &Value) -> String {
+    format!("\x1b[104m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright magenta background color.
+#[must_use]
+pub(crate) fn bg_bright_magenta(input: &Value) -> String {
+    format!("\x1b[105m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright cyan background color.
+#[must_use]
+pub(crate) fn bg_bright_cyan(input: &Value) -> String {
+    format!("\x1b[106m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bright white background color.
+#[must_use]
+pub(crate) fn bg_bright_white(input: &Value) -> String {
+    format!("\x1b[107m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a bold style.
+#[must_use]
+pub(crate) fn bold(input: &Value) -> String {
+    format!("\x1b[1m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with an italic style.
+#[must_use]
+pub(crate) fn italic(input: &Value) -> String {
+    format!("\x1b[3m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with an underline style.
+#[must_use]
+pub(crate) fn underline(input: &Value) -> String {
+    format!("\x1b[4m{}\x1b[0m", input)
+}
+
+/// Converts the input value into a text with a strikethrough style.
+#[must_use]
+pub(crate) fn strikethrough(input: &Value) -> String {
+    format!("\x1b[9m{}\x1b[0m", input)
+}
+
+/// Adds all the ANSI filters to the given environment.
+pub(crate) fn add_filters(env: &mut minijinja::Environment<'_>) {
+    env.add_filter("black", black);
+    env.add_filter("red", red);
+    env.add_filter("green", green);
+    env.add_filter("yellow", yellow);
+    env.add_filter("blue", blue);
+    env.add_filter("magenta", magenta);
+    env.add_filter("cyan", cyan);
+    env.add_filter("white", white);
+
+    env.add_filter("bright_black", bright_black);
+    env.add_filter("bright_red", bright_red);
+    env.add_filter("bright_green", bright_green);
+    env.add_filter("bright_yellow", bright_yellow);
+    env.add_filter("bright_blue", bright_blue);
+    env.add_filter("bright_magenta", bright_magenta);
+    env.add_filter("bright_cyan", bright_cyan);
+    env.add_filter("bright_white", bright_white);
+
+    env.add_filter("bg_black", bg_black);
+    env.add_filter("bg_red", bg_red);
+    env.add_filter("bg_green", bg_green);
+    env.add_filter("bg_yellow", bg_yellow);
+    env.add_filter("bg_blue", bg_blue);
+    env.add_filter("bg_magenta", bg_magenta);
+    env.add_filter("bg_cyan", bg_cyan);
+    env.add_filter("bg_white", bg_white);
+
+    env.add_filter("bg_bright_black", bg_bright_black);
+    env.add_filter("bg_bright_red", bg_bright_red);
+    env.add_filter("bg_bright_green", bg_bright_green);
+    env.add_filter("bg_bright_yellow", bg_bright_yellow);
+    env.add_filter("bg_bright_blue", bg_bright_blue);
+    env.add_filter("bg_bright_magenta", bg_bright_magenta);
+    env.add_filter("bg_bright_cyan", bg_bright_cyan);
+    env.add_filter("bg_bright_white", bg_bright_white);
+
+    env.add_filter("bold", bold);
+    env.add_filter("italic", italic);
+    env.add_filter("underline", underline);
+    env.add_filter("strikethrough", strikethrough);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::extensions::ansi::add_filters;
+    use minijinja::Environment;
+
+    #[test]
+    fn test_ansi_filters() {
+        let mut env = Environment::new();
+        let ctx = serde_json::Value::Null;
+
+        add_filters(&mut env);
+
+        assert_eq!(
+            env.render_str("{{ 'test' | black }}", &ctx).unwrap(),
+            "\x1b[30mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | red }}", &ctx).unwrap(),
+            "\x1b[31mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | green }}", &ctx).unwrap(),
+            "\x1b[32mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | yellow }}", &ctx).unwrap(),
+            "\x1b[33mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | blue }}", &ctx).unwrap(),
+            "\x1b[34mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | magenta }}", &ctx).unwrap(),
+            "\x1b[35mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | cyan }}", &ctx).unwrap(),
+            "\x1b[36mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | white }}", &ctx).unwrap(),
+            "\x1b[37mtest\x1b[0m"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'test' | bright_black }}", &ctx).unwrap(),
+            "\x1b[90mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bright_red }}", &ctx).unwrap(),
+            "\x1b[91mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bright_green }}", &ctx).unwrap(),
+            "\x1b[92mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bright_yellow }}", &ctx)
+                .unwrap(),
+            "\x1b[93mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bright_blue }}", &ctx).unwrap(),
+            "\x1b[94mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bright_magenta }}", &ctx)
+                .unwrap(),
+            "\x1b[95mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bright_cyan }}", &ctx).unwrap(),
+            "\x1b[96mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bright_white }}", &ctx).unwrap(),
+            "\x1b[97mtest\x1b[0m"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_black }}", &ctx).unwrap(),
+            "\x1b[40mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_red }}", &ctx).unwrap(),
+            "\x1b[41mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_green }}", &ctx).unwrap(),
+            "\x1b[42mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_yellow }}", &ctx).unwrap(),
+            "\x1b[43mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_blue }}", &ctx).unwrap(),
+            "\x1b[44mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_magenta }}", &ctx).unwrap(),
+            "\x1b[45mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_cyan }}", &ctx).unwrap(),
+            "\x1b[46mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_white }}", &ctx).unwrap(),
+            "\x1b[47mtest\x1b[0m"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_bright_black }}", &ctx)
+                .unwrap(),
+            "\x1b[100mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_bright_red }}", &ctx)
+                .unwrap(),
+            "\x1b[101mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_bright_green }}", &ctx)
+                .unwrap(),
+            "\x1b[102mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_bright_yellow }}", &ctx)
+                .unwrap(),
+            "\x1b[103mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_bright_blue }}", &ctx)
+                .unwrap(),
+            "\x1b[104mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_bright_magenta }}", &ctx)
+                .unwrap(),
+            "\x1b[105mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_bright_cyan }}", &ctx)
+                .unwrap(),
+            "\x1b[106mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | bg_bright_white }}", &ctx)
+                .unwrap(),
+            "\x1b[107mtest\x1b[0m"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'test' | bold }}", &ctx).unwrap(),
+            "\x1b[1mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | italic }}", &ctx).unwrap(),
+            "\x1b[3mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | underline }}", &ctx).unwrap(),
+            "\x1b[4mtest\x1b[0m"
+        );
+        assert_eq!(
+            env.render_str("{{ 'test' | strikethrough }}", &ctx)
+                .unwrap(),
+            "\x1b[9mtest\x1b[0m"
+        );
+
+        assert_eq!(env.render_str("{{ 'test' | black | bg_white | bold | italic | underline | strikethrough }}", &ctx).unwrap(), "\u{1b}[9m\u{1b}[4m\u{1b}[3m\u{1b}[1m\u{1b}[47m\u{1b}[30mtest\u{1b}[0m\u{1b}[0m\u{1b}[0m\u{1b}[0m\u{1b}[0m\u{1b}[0m");
+    }
+}

--- a/crates/weaver_forge/src/extensions/ansi.rs
+++ b/crates/weaver_forge/src/extensions/ansi.rs
@@ -310,15 +310,18 @@ mod tests {
         );
 
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bright_black }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_black }}", &ctx)
+                .unwrap(),
             "\x1b[90mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bright_red }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_red }}", &ctx)
+                .unwrap(),
             "\x1b[91mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bright_green }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_green }}", &ctx)
+                .unwrap(),
             "\x1b[92mtest\x1b[0m"
         );
         assert_eq!(
@@ -327,7 +330,8 @@ mod tests {
             "\x1b[93mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bright_blue }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_blue }}", &ctx)
+                .unwrap(),
             "\x1b[94mtest\x1b[0m"
         );
         assert_eq!(
@@ -336,16 +340,19 @@ mod tests {
             "\x1b[95mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bright_cyan }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_cyan }}", &ctx)
+                .unwrap(),
             "\x1b[96mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bright_white }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_white }}", &ctx)
+                .unwrap(),
             "\x1b[97mtest\x1b[0m"
         );
 
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bg_black }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_black }}", &ctx)
+                .unwrap(),
             "\x1b[40mtest\x1b[0m"
         );
         assert_eq!(
@@ -353,11 +360,13 @@ mod tests {
             "\x1b[41mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bg_green }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_green }}", &ctx)
+                .unwrap(),
             "\x1b[42mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bg_yellow }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_yellow }}", &ctx)
+                .unwrap(),
             "\x1b[43mtest\x1b[0m"
         );
         assert_eq!(
@@ -365,7 +374,8 @@ mod tests {
             "\x1b[44mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bg_magenta }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_magenta }}", &ctx)
+                .unwrap(),
             "\x1b[45mtest\x1b[0m"
         );
         assert_eq!(
@@ -373,7 +383,8 @@ mod tests {
             "\x1b[46mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_bg_white }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_white }}", &ctx)
+                .unwrap(),
             "\x1b[47mtest\x1b[0m"
         );
 
@@ -427,7 +438,8 @@ mod tests {
             "\x1b[3mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | ansi_underline }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_underline }}", &ctx)
+                .unwrap(),
             "\x1b[4mtest\x1b[0m"
         );
         assert_eq!(

--- a/crates/weaver_forge/src/extensions/ansi.rs
+++ b/crates/weaver_forge/src/extensions/ansi.rs
@@ -222,46 +222,46 @@ pub(crate) fn strikethrough(input: &Value) -> String {
 
 /// Adds all the ANSI filters to the given environment.
 pub(crate) fn add_filters(env: &mut minijinja::Environment<'_>) {
-    env.add_filter("black", black);
-    env.add_filter("red", red);
-    env.add_filter("green", green);
-    env.add_filter("yellow", yellow);
-    env.add_filter("blue", blue);
-    env.add_filter("magenta", magenta);
-    env.add_filter("cyan", cyan);
-    env.add_filter("white", white);
+    env.add_filter("ansi_black", black);
+    env.add_filter("ansi_red", red);
+    env.add_filter("ansi_green", green);
+    env.add_filter("ansi_yellow", yellow);
+    env.add_filter("ansi_blue", blue);
+    env.add_filter("ansi_magenta", magenta);
+    env.add_filter("ansi_cyan", cyan);
+    env.add_filter("ansi_white", white);
 
-    env.add_filter("bright_black", bright_black);
-    env.add_filter("bright_red", bright_red);
-    env.add_filter("bright_green", bright_green);
-    env.add_filter("bright_yellow", bright_yellow);
-    env.add_filter("bright_blue", bright_blue);
-    env.add_filter("bright_magenta", bright_magenta);
-    env.add_filter("bright_cyan", bright_cyan);
-    env.add_filter("bright_white", bright_white);
+    env.add_filter("ansi_bright_black", bright_black);
+    env.add_filter("ansi_bright_red", bright_red);
+    env.add_filter("ansi_bright_green", bright_green);
+    env.add_filter("ansi_bright_yellow", bright_yellow);
+    env.add_filter("ansi_bright_blue", bright_blue);
+    env.add_filter("ansi_bright_magenta", bright_magenta);
+    env.add_filter("ansi_bright_cyan", bright_cyan);
+    env.add_filter("ansi_bright_white", bright_white);
 
-    env.add_filter("bg_black", bg_black);
-    env.add_filter("bg_red", bg_red);
-    env.add_filter("bg_green", bg_green);
-    env.add_filter("bg_yellow", bg_yellow);
-    env.add_filter("bg_blue", bg_blue);
-    env.add_filter("bg_magenta", bg_magenta);
-    env.add_filter("bg_cyan", bg_cyan);
-    env.add_filter("bg_white", bg_white);
+    env.add_filter("ansi_bg_black", bg_black);
+    env.add_filter("ansi_bg_red", bg_red);
+    env.add_filter("ansi_bg_green", bg_green);
+    env.add_filter("ansi_bg_yellow", bg_yellow);
+    env.add_filter("ansi_bg_blue", bg_blue);
+    env.add_filter("ansi_bg_magenta", bg_magenta);
+    env.add_filter("ansi_bg_cyan", bg_cyan);
+    env.add_filter("ansi_bg_white", bg_white);
 
-    env.add_filter("bg_bright_black", bg_bright_black);
-    env.add_filter("bg_bright_red", bg_bright_red);
-    env.add_filter("bg_bright_green", bg_bright_green);
-    env.add_filter("bg_bright_yellow", bg_bright_yellow);
-    env.add_filter("bg_bright_blue", bg_bright_blue);
-    env.add_filter("bg_bright_magenta", bg_bright_magenta);
-    env.add_filter("bg_bright_cyan", bg_bright_cyan);
-    env.add_filter("bg_bright_white", bg_bright_white);
+    env.add_filter("ansi_bg_bright_black", bg_bright_black);
+    env.add_filter("ansi_bg_bright_red", bg_bright_red);
+    env.add_filter("ansi_bg_bright_green", bg_bright_green);
+    env.add_filter("ansi_bg_bright_yellow", bg_bright_yellow);
+    env.add_filter("ansi_bg_bright_blue", bg_bright_blue);
+    env.add_filter("ansi_bg_bright_magenta", bg_bright_magenta);
+    env.add_filter("ansi_bg_bright_cyan", bg_bright_cyan);
+    env.add_filter("ansi_bg_bright_white", bg_bright_white);
 
-    env.add_filter("bold", bold);
-    env.add_filter("italic", italic);
-    env.add_filter("underline", underline);
-    env.add_filter("strikethrough", strikethrough);
+    env.add_filter("ansi_bold", bold);
+    env.add_filter("ansi_italic", italic);
+    env.add_filter("ansi_underline", underline);
+    env.add_filter("ansi_strikethrough", strikethrough);
 }
 
 #[cfg(test)]
@@ -277,165 +277,165 @@ mod tests {
         add_filters(&mut env);
 
         assert_eq!(
-            env.render_str("{{ 'test' | black }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_black }}", &ctx).unwrap(),
             "\x1b[30mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | red }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_red }}", &ctx).unwrap(),
             "\x1b[31mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | green }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_green }}", &ctx).unwrap(),
             "\x1b[32mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | yellow }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_yellow }}", &ctx).unwrap(),
             "\x1b[33mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | blue }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_blue }}", &ctx).unwrap(),
             "\x1b[34mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | magenta }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_magenta }}", &ctx).unwrap(),
             "\x1b[35mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | cyan }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_cyan }}", &ctx).unwrap(),
             "\x1b[36mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | white }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_white }}", &ctx).unwrap(),
             "\x1b[37mtest\x1b[0m"
         );
 
         assert_eq!(
-            env.render_str("{{ 'test' | bright_black }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_black }}", &ctx).unwrap(),
             "\x1b[90mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bright_red }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_red }}", &ctx).unwrap(),
             "\x1b[91mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bright_green }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_green }}", &ctx).unwrap(),
             "\x1b[92mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bright_yellow }}", &ctx)
+            env.render_str("{{ 'test' | ansi_bright_yellow }}", &ctx)
                 .unwrap(),
             "\x1b[93mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bright_blue }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_blue }}", &ctx).unwrap(),
             "\x1b[94mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bright_magenta }}", &ctx)
+            env.render_str("{{ 'test' | ansi_bright_magenta }}", &ctx)
                 .unwrap(),
             "\x1b[95mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bright_cyan }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_cyan }}", &ctx).unwrap(),
             "\x1b[96mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bright_white }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bright_white }}", &ctx).unwrap(),
             "\x1b[97mtest\x1b[0m"
         );
 
         assert_eq!(
-            env.render_str("{{ 'test' | bg_black }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_black }}", &ctx).unwrap(),
             "\x1b[40mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_red }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_red }}", &ctx).unwrap(),
             "\x1b[41mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_green }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_green }}", &ctx).unwrap(),
             "\x1b[42mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_yellow }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_yellow }}", &ctx).unwrap(),
             "\x1b[43mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_blue }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_blue }}", &ctx).unwrap(),
             "\x1b[44mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_magenta }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_magenta }}", &ctx).unwrap(),
             "\x1b[45mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_cyan }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_cyan }}", &ctx).unwrap(),
             "\x1b[46mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_white }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bg_white }}", &ctx).unwrap(),
             "\x1b[47mtest\x1b[0m"
         );
 
         assert_eq!(
-            env.render_str("{{ 'test' | bg_bright_black }}", &ctx)
+            env.render_str("{{ 'test' | ansi_bg_bright_black }}", &ctx)
                 .unwrap(),
             "\x1b[100mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_bright_red }}", &ctx)
+            env.render_str("{{ 'test' | ansi_bg_bright_red }}", &ctx)
                 .unwrap(),
             "\x1b[101mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_bright_green }}", &ctx)
+            env.render_str("{{ 'test' | ansi_bg_bright_green }}", &ctx)
                 .unwrap(),
             "\x1b[102mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_bright_yellow }}", &ctx)
+            env.render_str("{{ 'test' | ansi_bg_bright_yellow }}", &ctx)
                 .unwrap(),
             "\x1b[103mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_bright_blue }}", &ctx)
+            env.render_str("{{ 'test' | ansi_bg_bright_blue }}", &ctx)
                 .unwrap(),
             "\x1b[104mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_bright_magenta }}", &ctx)
+            env.render_str("{{ 'test' | ansi_bg_bright_magenta }}", &ctx)
                 .unwrap(),
             "\x1b[105mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_bright_cyan }}", &ctx)
+            env.render_str("{{ 'test' | ansi_bg_bright_cyan }}", &ctx)
                 .unwrap(),
             "\x1b[106mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | bg_bright_white }}", &ctx)
+            env.render_str("{{ 'test' | ansi_bg_bright_white }}", &ctx)
                 .unwrap(),
             "\x1b[107mtest\x1b[0m"
         );
 
         assert_eq!(
-            env.render_str("{{ 'test' | bold }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_bold }}", &ctx).unwrap(),
             "\x1b[1mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | italic }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_italic }}", &ctx).unwrap(),
             "\x1b[3mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | underline }}", &ctx).unwrap(),
+            env.render_str("{{ 'test' | ansi_underline }}", &ctx).unwrap(),
             "\x1b[4mtest\x1b[0m"
         );
         assert_eq!(
-            env.render_str("{{ 'test' | strikethrough }}", &ctx)
+            env.render_str("{{ 'test' | ansi_strikethrough }}", &ctx)
                 .unwrap(),
             "\x1b[9mtest\x1b[0m"
         );
 
-        assert_eq!(env.render_str("{{ 'test' | black | bg_white | bold | italic | underline | strikethrough }}", &ctx).unwrap(), "\u{1b}[9m\u{1b}[4m\u{1b}[3m\u{1b}[1m\u{1b}[47m\u{1b}[30mtest\u{1b}[0m\u{1b}[0m\u{1b}[0m\u{1b}[0m\u{1b}[0m\u{1b}[0m");
+        assert_eq!(env.render_str("{{ 'test' | ansi_black | ansi_bg_white | ansi_bold | ansi_italic | ansi_underline | ansi_strikethrough }}", &ctx).unwrap(), "\u{1b}[9m\u{1b}[4m\u{1b}[3m\u{1b}[1m\u{1b}[47m\u{1b}[30mtest\u{1b}[0m\u{1b}[0m\u{1b}[0m\u{1b}[0m\u{1b}[0m\u{1b}[0m");
     }
 }

--- a/crates/weaver_forge/src/extensions/mod.rs
+++ b/crates/weaver_forge/src/extensions/mod.rs
@@ -2,6 +2,7 @@
 
 //! Custom filters used by the template engine.
 pub mod acronym;
+pub mod ansi;
 pub mod case_converter;
 pub mod code;
 pub mod otel;

--- a/crates/weaver_forge/src/lib.rs
+++ b/crates/weaver_forge/src/lib.rs
@@ -29,7 +29,7 @@ use crate::debug::error_summary;
 use crate::error::Error::InvalidConfigFile;
 use crate::extensions::acronym::acronym;
 use crate::extensions::case_converter::case_converter;
-use crate::extensions::code;
+use crate::extensions::{ansi, code};
 use crate::registry::{TemplateGroup, TemplateRegistry};
 
 mod config;
@@ -394,12 +394,10 @@ impl TemplateEngine {
         env.set_loader(cross_platform_loader(&self.path));
         env.set_syntax(syntax);
 
-        // Register code-oriented filters
-        env.add_filter("comment_with_prefix", code::comment_with_prefix);
-        env.add_filter(
-            "type_mapping",
-            code::type_mapping(self.target_config.type_mapping.clone()),
-        );
+        code::add_filters(&mut env, &self.target_config);
+        ansi::add_filters(&mut env);
+
+        // ToDo These filters are now deprecated and should be removed soon.
         env.add_filter(
             "file_name",
             case_converter(self.target_config.file_name.clone()),
@@ -466,14 +464,6 @@ impl TemplateEngine {
         env.add_test("experimental", extensions::otel::is_experimental);
         env.add_test("deprecated", extensions::otel::is_deprecated);
         // ToDo Implement more tests: required, not_required
-
-        // env.add_filter("unique_attributes", extensions::unique_attributes);
-        // env.add_filter("instrument", extensions::instrument);
-        // env.add_filter("value", extensions::value);
-        // env.add_filter("with_value", extensions::with_value);
-        // env.add_filter("without_value", extensions::without_value);
-        // env.add_filter("with_enum", extensions::with_enum);
-        // env.add_filter("without_enum", extensions::without_enum);
 
         Ok(env)
     }


### PR DESCRIPTION
Filters:
- `markdown_to_html`: Converts a markdown string to an HTML string.
- `text_map`: Converts an input into a string based on the `text_maps` section of the `weaver.yaml` configuration file and a named text_map.
- `red`: Format a text using the red ansi code.
- `green`: Format a text using the green ansi code.
- `yellow`: Format a text using the yellow ansi code.
- `blue`: Format a text using the blue ansi code.
- `magenta`: Format a text using the magenta ansi code.
- `cyan`: Format a text using the cyan ansi code.
- `white`: Format a text using the white ansi code.
- `bright_black`: Format a text using the bright black ansi code.
- `bright_red`: Format a text using the bright red ansi code.
- `bright_green`: Format a text using the bright green ansi code.
- `bright_yellow`: Format a text using the bright yellow ansi code.
- `bright_blue`: Format a text using the bright blue ansi code.
- `bright_magenta`: Format a text using the bright magenta ansi code.
- `bright_cyan`: Format a text using the bright cyan ansi code.
- `bright_white`: Format a text using the bright white ansi code.
- `bg_black`: Format a text using the black background ansi code.
- `bg_red`: Format a text using the red background ansi code.
- `bg_green`: Format a text using the green background ansi code.
- `bg_yellow`: Format a text using the yellow background ansi code.
- `bg_blue`: Format a text using the blue background ansi code.
- `bg_magenta`: Format a text using the magenta background ansi code.
- `bg_cyan`: Format a text using the cyan background ansi code.
- `bg_white`: Format a text using the white background ansi code.
- `bg_bright_black`: Format a text using the bright black background ansi code.
- `bg_bright_red`: Format a text using the bright red background ansi code.
- `bg_bright_green`: Format a text using the bright green background ansi code.
- `bg_bright_yellow`: Format a text using the bright yellow background ansi code.
- `bg_bright_blue`: Format a text using the bright blue background ansi code.
- `bg_bright_magenta`: Format a text using the bright magenta background ansi code.
- `bg_bright_cyan`: Format a text using the bright cyan background ansi code.
- `bg_bright_white`: Format a text using the bright white background ansi code.
- `bold`: Format a text using the bold ansi code.
- `italic`: Format a text using the italic ansi code.
- `underline`: Format a text using the underline ansi code.
- `strikethrough`: Format a text using the strikethrough ansi code.
 
Note: `type_mapping` is now deprecated (use text_map instead).