### PR TITLE
feat(forge): Add `semconv_const` filter to support semantic convention namespacing rules.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4147,9 +4147,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c52728401e1dc672a56e81e593e912aa54c78f40246869f78359a2bf24d29d"
+checksum = "41ff33f391015ecab21cd092389215eb265ef9496a9a07b6bee7d3529831deda"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
 dependencies = [
  "anstream",
  "anstyle",
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "clru"
@@ -4147,9 +4147,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ff33f391015ecab21cd092389215eb265ef9496a9a07b6bee7d3529831deda"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]

--- a/crates/weaver_forge/README.md
+++ b/crates/weaver_forge/README.md
@@ -146,6 +146,7 @@ The following filters are available:
 - `kebab_case`: Converts a string to kebab-case.
 - `screaming_kebab_case`: Converts a string to SCREAMING-KEBAB-CASE.
 - `capitalize_first`: Capitalizes the first letter of a string.
+- `semconv_const(case)`: Follows the semantic convention for constants. Underscores are removed and the string is converted to the case provided.
 - `acronym`: Replaces acronyms in the input string with the full name defined in the `acronyms` section of the `weaver.yaml` configuration file.
 - `split_ids`: Splits a string by '.' creating a list of nested ids.
 - `type_mapping`: Converts a semantic convention type to a target type (see weaver.yaml section `type_mapping`).

--- a/crates/weaver_forge/README.md
+++ b/crates/weaver_forge/README.md
@@ -146,7 +146,11 @@ The following filters are available:
 - `kebab_case`: Converts a string to kebab-case.
 - `screaming_kebab_case`: Converts a string to SCREAMING-KEBAB-CASE.
 - `capitalize_first`: Capitalizes the first letter of a string.
-- `semconv_const(case)`: Follows the semantic convention for constants. Underscores are removed and the string is converted to the case provided.
+- `kebab_case_const`: Generates kebab-case constants which follow semantic convention namespacing rules (underscores are ignored, but . is meaningful). 
+- `pascal_case_const`: Generates PascalCase constants which follow semantic convention namespacing rules (underscores are ignored, but . is meaningful).
+- `camel_case_const`: Generates camelCase constants which follow semantic convention namespacing rules (underscores are ignored, but . is meaningful).
+- `snake_case_const`: Generates snake_case constants which follow semantic convention namespacing rules (underscores are ignored, but . is meaningful).
+- `screaming_snake_case_const`: Generates SCREAMING_SNAKE_CASE constants which follow semantic convention namespacing rules (underscores are ignored, but . is meaningful).
 - `acronym`: Replaces acronyms in the input string with the full name defined in the `acronyms` section of the `weaver.yaml` configuration file.
 - `split_ids`: Splits a string by '.' creating a list of nested ids.
 - `type_mapping`: Converts a semantic convention type to a target type (see weaver.yaml section `type_mapping`).

--- a/crates/weaver_forge/src/error.rs
+++ b/crates/weaver_forge/src/error.rs
@@ -145,6 +145,13 @@ pub enum Error {
         error: String,
     },
 
+    /// Invalid case convention.
+    #[error("`{case}` is not a valid case convention. Valid case conventions are: lower_case, upper_case, title_case, snake_case, kebab_case, camel_case, pascal_case, screaming_snake_case, and screaming_kebab_case.")]
+    InvalidCaseConvention {
+        /// The invalid case
+        case: String,
+    },
+
     /// A generic container for multiple errors.
     #[error("Errors:\n{0:#?}")]
     CompoundError(Vec<Error>),

--- a/crates/weaver_forge/src/extensions/case.rs
+++ b/crates/weaver_forge/src/extensions/case.rs
@@ -3,6 +3,7 @@
 //! Case converter filters used by the template engine.
 
 use crate::config::{CaseConvention, TargetConfig};
+use crate::error::Error;
 use minijinja::Environment;
 
 /// Add case converter filters to the environment.
@@ -41,7 +42,8 @@ pub(crate) fn add_filters(env: &mut Environment<'_>, target_config: &TargetConfi
     );
 }
 
-/// Converts input string to the specified case convention.
+/// Converts a `CaseConvention` to a function that converts a string to the specified case
+/// convention.
 #[must_use]
 pub fn case_converter(case_convention: CaseConvention) -> fn(&str) -> String {
     match case_convention {
@@ -54,6 +56,30 @@ pub fn case_converter(case_convention: CaseConvention) -> fn(&str) -> String {
         CaseConvention::ScreamingSnakeCase => screaming_snake_case,
         CaseConvention::KebabCase => kebab_case,
         CaseConvention::ScreamingKebabCase => screaming_kebab_case,
+    }
+}
+
+/// Converts a "string" case convention to a function that converts a string to the specified case
+/// convention.
+///
+/// # Returns
+///
+/// Returns an error if the case convention is not recognized or a function that converts a string
+/// to the specified case convention.
+pub fn str_to_case_converter(case_convention: &str) -> Result<fn(&str) -> String, Error> {
+    match case_convention {
+        "lower_case" => Ok(lower_case),
+        "upper_case" => Ok(upper_case),
+        "title_case" => Ok(title_case),
+        "camel_case" => Ok(camel_case),
+        "pascal_case" => Ok(pascal_case),
+        "snake_case" => Ok(snake_case),
+        "screaming_snake_case" => Ok(screaming_snake_case),
+        "kebab_case" => Ok(kebab_case),
+        "screaming_kebab_case" => Ok(screaming_kebab_case),
+        _ => Err(Error::InvalidCaseConvention {
+            case: case_convention.to_owned(),
+        }),
     }
 }
 

--- a/crates/weaver_forge/src/extensions/case.rs
+++ b/crates/weaver_forge/src/extensions/case.rs
@@ -3,7 +3,6 @@
 //! Case converter filters used by the template engine.
 
 use crate::config::{CaseConvention, TargetConfig};
-use crate::error::Error;
 use minijinja::Environment;
 
 /// Add case converter filters to the environment.
@@ -59,77 +58,53 @@ pub fn case_converter(case_convention: CaseConvention) -> fn(&str) -> String {
     }
 }
 
-/// Converts a "string" case convention to a function that converts a string to the specified case
-/// convention.
-///
-/// # Returns
-///
-/// Returns an error if the case convention is not recognized or a function that converts a string
-/// to the specified case convention.
-pub fn str_to_case_converter(case_convention: &str) -> Result<fn(&str) -> String, Error> {
-    match case_convention {
-        "lower_case" => Ok(lower_case),
-        "upper_case" => Ok(upper_case),
-        "title_case" => Ok(title_case),
-        "camel_case" => Ok(camel_case),
-        "pascal_case" => Ok(pascal_case),
-        "snake_case" => Ok(snake_case),
-        "screaming_snake_case" => Ok(screaming_snake_case),
-        "kebab_case" => Ok(kebab_case),
-        "screaming_kebab_case" => Ok(screaming_kebab_case),
-        _ => Err(Error::InvalidCaseConvention {
-            case: case_convention.to_owned(),
-        }),
-    }
-}
-
 /// Converts input string to lower case
-fn lower_case(input: &str) -> String {
+pub(crate) fn lower_case(input: &str) -> String {
     CaseConvention::LowerCase.convert(input)
 }
 
 /// Converts input string to upper case
-fn upper_case(input: &str) -> String {
+pub(crate) fn upper_case(input: &str) -> String {
     CaseConvention::UpperCase.convert(input)
 }
 
 /// Converts input string to title case
-fn title_case(input: &str) -> String {
+pub(crate) fn title_case(input: &str) -> String {
     CaseConvention::TitleCase.convert(input)
 }
 
 /// Converts input string to camel case
-fn camel_case(input: &str) -> String {
+pub(crate) fn camel_case(input: &str) -> String {
     CaseConvention::CamelCase.convert(input)
 }
 
 /// Converts input string to pascal case
-fn pascal_case(input: &str) -> String {
+pub(crate) fn pascal_case(input: &str) -> String {
     CaseConvention::PascalCase.convert(input)
 }
 
 /// Converts input string to snake case
-fn snake_case(input: &str) -> String {
+pub(crate) fn snake_case(input: &str) -> String {
     CaseConvention::SnakeCase.convert(input)
 }
 
 /// Converts input string to screaming snake case
-fn screaming_snake_case(input: &str) -> String {
+pub(crate) fn screaming_snake_case(input: &str) -> String {
     CaseConvention::ScreamingSnakeCase.convert(input)
 }
 
 /// Converts input string to kebab case
-fn kebab_case(input: &str) -> String {
+pub(crate) fn kebab_case(input: &str) -> String {
     CaseConvention::KebabCase.convert(input)
 }
 
 /// Converts input string to screaming kebab case
-fn screaming_kebab_case(input: &str) -> String {
+pub(crate) fn screaming_kebab_case(input: &str) -> String {
     CaseConvention::ScreamingKebabCase.convert(input)
 }
 
 /// Capitalize the first character of a string.
-fn capitalize_first(input: &str) -> String {
+pub(crate) fn capitalize_first(input: &str) -> String {
     let mut chars = input.chars();
     let mut result = String::with_capacity(input.len());
 


### PR DESCRIPTION
See https://github.com/open-telemetry/semantic-conventions/issues/1118
And https://github.com/open-telemetry/weaver/issues/198

Closing: https://github.com/open-telemetry/weaver/issues/198