### PR TITLE
Follow build tools case conversion rules 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "once_cell",
  "serde",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2796,9 +2796,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+dependencies = [
+ "zerocopy 0.6.6",
+]
 
 [[package]]
 name = "predicates"
@@ -4632,11 +4635,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/weaver_forge/expected_output/test/converter.md
+++ b/crates/weaver_forge/expected_output/test/converter.md
@@ -1,10 +1,10 @@
-this IS an ios device with a nice api!
-this is an ios device with a nice api!
-THIS IS AN iOS DEVICE WITH A NICE API!
-This Is An iOS Device With A Nice API!
-ThisIsAnIosDeviceWithANiceApi!
-thisIsAnIosDeviceWithANiceApi!
-this_is_an_ios_device_with_a_nice_api!
-THIS_IS_AN_IOS_DEVICE_WITH_A_NICE_API!
-this-is-an-iOS-device-with-a-nice-API!
-THIS-IS-AN-IOS-DEVICE-WITH-A-NICE-API!
+text                : this IS an ios device with a nice api!
+lower_case          : this is an ios device with a nice api!
+upper_case | acronym: THIS IS AN iOS DEVICE WITH A NICE API!
+title_case | acronym: This Is An iOS Device With A Nice API!
+pascal_case         : ThisIsAnIosDeviceWithANiceApi!
+camel_case          : thisIsAnIosDeviceWithANiceApi!
+snake_case          : this_is_an_ios_device_with_a_nice_api!
+screaming_snake_case: THIS_IS_AN_IOS_DEVICE_WITH_A_NICE_API!
+kebab_case | acronym: this-is-an-iOS-device-with-a-nice-API!
+screaming_kebab_case: THIS-IS-AN-IOS-DEVICE-WITH-A-NICE-API!

--- a/crates/weaver_forge/src/config.rs
+++ b/crates/weaver_forge/src/config.rs
@@ -225,6 +225,7 @@ impl CaseConvention {
         static LOWER_CASE: OnceLock<Converter> = OnceLock::new();
         static TITLE_CASE: OnceLock<Converter> = OnceLock::new();
         static KEBAB_CASE: OnceLock<Converter> = OnceLock::new();
+        static SNAKE_CASE: OnceLock<Converter> = OnceLock::new();
 
         let text = text.replace('.', "_");
         match self {
@@ -263,9 +264,9 @@ impl CaseConvention {
             CaseConvention::PascalCase => text.to_case(Case::Pascal),
             CaseConvention::CamelCase => text.to_case(Case::Camel),
             CaseConvention::SnakeCase => {
-                // Convert to title case but do not consider digits
+                // Convert to snake case but do not consider digits
                 // as boundaries.
-                let conv = TITLE_CASE.get_or_init(|| {
+                let conv = SNAKE_CASE.get_or_init(|| {
                     Converter::new()
                         .add_boundary(Underscore)
                         .remove_boundary(DigitLower)

--- a/crates/weaver_forge/src/extensions/case.rs
+++ b/crates/weaver_forge/src/extensions/case.rs
@@ -150,6 +150,36 @@ mod tests {
         add_filters(&mut env, &target_config);
 
         assert_eq!(
+            env.render_str("{{ 'v8js.heap.space.name' | upper_case }}", &ctx)
+                .unwrap(),
+            "V8JS HEAP SPACE NAME"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'k8s.job.name' | upper_case }}", &ctx)
+                .unwrap(),
+            "K8S JOB NAME"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'host.cpu.cache.l2.size' | upper_case }}", &ctx)
+                .unwrap(),
+            "HOST CPU CACHE L2 SIZE"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'nodejs.eventloop.delay.p99' | upper_case }}", &ctx)
+                .unwrap(),
+            "NODEJS EVENTLOOP DELAY P99"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'http.request.resend_count' | upper_case }}", &ctx)
+                .unwrap(),
+            "HTTP REQUEST RESEND COUNT"
+        );
+
+        assert_eq!(
             env.render_str("{{ 'Hello World' | upper_case }}", &ctx)
                 .unwrap(),
             "HELLO WORLD"
@@ -178,6 +208,36 @@ mod tests {
         let ctx = serde_json::Value::Null;
 
         add_filters(&mut env, &target_config);
+
+        assert_eq!(
+            env.render_str("{{ 'v8js.heap.space.name' | camel_case }}", &ctx)
+                .unwrap(),
+            "v8jsHeapSpaceName"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'k8s.job.name' | camel_case }}", &ctx)
+                .unwrap(),
+            "k8sJobName"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'host.cpu.cache.l2.size' | camel_case }}", &ctx)
+                .unwrap(),
+            "hostCpuCacheL2Size"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'nodejs.eventloop.delay.p99' | camel_case }}", &ctx)
+                .unwrap(),
+            "nodejsEventloopDelayP99"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'http.request.resend_count' | camel_case }}", &ctx)
+                .unwrap(),
+            "httpRequestResendCount"
+        );
 
         assert_eq!(
             env.render_str("{{ 'hello_world' | camel_case }}", &ctx)
@@ -225,6 +285,12 @@ mod tests {
         );
 
         assert_eq!(
+            env.render_str("{{ 'HTTP.request.resend_count' | pascal_case }}", &ctx)
+                .unwrap(),
+            "HttpRequestResendCount"
+        );
+
+        assert_eq!(
             env.render_str("{{ 'hello_world' | pascal_case }}", &ctx)
                 .unwrap(),
             "HelloWorld"
@@ -260,6 +326,45 @@ mod tests {
         add_filters(&mut env, &target_config);
 
         assert_eq!(
+            env.render_str("{{ 'v8js.heap.space.name' | screaming_snake_case }}", &ctx)
+                .unwrap(),
+            "V8JS_HEAP_SPACE_NAME"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'k8s.job.name' | screaming_snake_case }}", &ctx)
+                .unwrap(),
+            "K8S_JOB_NAME"
+        );
+
+        assert_eq!(
+            env.render_str(
+                "{{ 'host.cpu.cache.l2.size' | screaming_snake_case }}",
+                &ctx
+            )
+            .unwrap(),
+            "HOST_CPU_CACHE_L2_SIZE"
+        );
+
+        assert_eq!(
+            env.render_str(
+                "{{ 'nodejs.eventloop.delay.p99' | screaming_snake_case }}",
+                &ctx
+            )
+            .unwrap(),
+            "NODEJS_EVENTLOOP_DELAY_P99"
+        );
+
+        assert_eq!(
+            env.render_str(
+                "{{ 'http.request.resend_count' | screaming_snake_case }}",
+                &ctx
+            )
+            .unwrap(),
+            "HTTP_REQUEST_RESEND_COUNT"
+        );
+
+        assert_eq!(
             env.render_str("{{ 'Hello World' | screaming_snake_case }}", &ctx)
                 .unwrap(),
             "HELLO_WORLD"
@@ -273,6 +378,45 @@ mod tests {
         let ctx = serde_json::Value::Null;
 
         add_filters(&mut env, &target_config);
+
+        assert_eq!(
+            env.render_str("{{ 'v8js.heap.space.name' | screaming_kebab_case }}", &ctx)
+                .unwrap(),
+            "V8JS-HEAP-SPACE-NAME"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'k8s.job.name' | screaming_kebab_case }}", &ctx)
+                .unwrap(),
+            "K8S-JOB-NAME"
+        );
+
+        assert_eq!(
+            env.render_str(
+                "{{ 'host.cpu.cache.l2.size' | screaming_kebab_case }}",
+                &ctx
+            )
+            .unwrap(),
+            "HOST-CPU-CACHE-L2-SIZE"
+        );
+
+        assert_eq!(
+            env.render_str(
+                "{{ 'nodejs.eventloop.delay.p99' | screaming_kebab_case }}",
+                &ctx
+            )
+            .unwrap(),
+            "NODEJS-EVENTLOOP-DELAY-P99"
+        );
+
+        assert_eq!(
+            env.render_str(
+                "{{ 'http.request.resend_count' | screaming_kebab_case }}",
+                &ctx
+            )
+            .unwrap(),
+            "HTTP-REQUEST-RESEND-COUNT"
+        );
 
         assert_eq!(
             env.render_str("{{ 'Hello World' | screaming_kebab_case }}", &ctx)

--- a/crates/weaver_forge/src/extensions/case.rs
+++ b/crates/weaver_forge/src/extensions/case.rs
@@ -119,7 +119,6 @@ mod tests {
 
         add_filters(&mut env, &target_config);
 
-
         assert_eq!(
             env.render_str("{{ 'Hello World' | kebab_case }}", &ctx)
                 .unwrap(),
@@ -194,6 +193,36 @@ mod tests {
         let ctx = serde_json::Value::Null;
 
         add_filters(&mut env, &target_config);
+
+        assert_eq!(
+            env.render_str("{{ 'v8js.heap.space.name' | pascal_case }}", &ctx)
+                .unwrap(),
+            "V8jsHeapSpaceName"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'k8s.job.name' | pascal_case }}", &ctx)
+                .unwrap(),
+            "K8sJobName"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'host.cpu.cache.l2.size' | pascal_case }}", &ctx)
+                .unwrap(),
+            "HostCpuCacheL2Size"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'nodejs.eventloop.delay.p99' | pascal_case }}", &ctx)
+                .unwrap(),
+            "NodejsEventloopDelayP99"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'http.request.resend_count' | pascal_case }}", &ctx)
+                .unwrap(),
+            "HttpRequestResendCount"
+        );
 
         assert_eq!(
             env.render_str("{{ 'hello_world' | pascal_case }}", &ctx)
@@ -297,8 +326,11 @@ mod tests {
         );
 
         assert_eq!(
-            env.render_str("{{ 'this IS an ios device with a nice api!' | snake_case }}", &ctx)
-                .unwrap(),
+            env.render_str(
+                "{{ 'this IS an ios device with a nice api!' | snake_case }}",
+                &ctx
+            )
+            .unwrap(),
             "this_is_an_ios_device_with_a_nice_api!"
         );
     }

--- a/crates/weaver_forge/src/extensions/case.rs
+++ b/crates/weaver_forge/src/extensions/case.rs
@@ -2,8 +2,9 @@
 
 //! Case converter filters used by the template engine.
 
-use crate::config::{CaseConvention, WeaverConfig};
 use minijinja::Environment;
+
+use crate::config::{CaseConvention, WeaverConfig};
 
 /// Add case converter filters to the environment.
 pub(crate) fn add_filters(env: &mut Environment<'_>, _: &WeaverConfig) {
@@ -105,12 +106,29 @@ pub(crate) fn capitalize_first(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::WeaverConfig;
-    use crate::extensions::case::add_filters;
     use minijinja::Environment;
 
+    use crate::config::WeaverConfig;
+    use crate::extensions::case::add_filters;
+
     #[test]
-    fn test_case_converter() {
+    fn test_kebab_case() {
+        let target_config = WeaverConfig::default();
+        let mut env = Environment::new();
+        let ctx = serde_json::Value::Null;
+
+        add_filters(&mut env, &target_config);
+
+
+        assert_eq!(
+            env.render_str("{{ 'Hello World' | kebab_case }}", &ctx)
+                .unwrap(),
+            "hello-world"
+        );
+    }
+
+    #[test]
+    fn test_lower_case() {
         let target_config = WeaverConfig::default();
         let mut env = Environment::new();
         let ctx = serde_json::Value::Null;
@@ -122,41 +140,76 @@ mod tests {
                 .unwrap(),
             "hello world"
         );
+    }
+
+    #[test]
+    fn test_upper_case() {
+        let target_config = WeaverConfig::default();
+        let mut env = Environment::new();
+        let ctx = serde_json::Value::Null;
+
+        add_filters(&mut env, &target_config);
+
         assert_eq!(
             env.render_str("{{ 'Hello World' | upper_case }}", &ctx)
                 .unwrap(),
             "HELLO WORLD"
         );
+    }
+
+    #[test]
+    fn test_title_case() {
+        let target_config = WeaverConfig::default();
+        let mut env = Environment::new();
+        let ctx = serde_json::Value::Null;
+
+        add_filters(&mut env, &target_config);
+
         assert_eq!(
             env.render_str("{{ 'Hello World' | title_case }}", &ctx)
                 .unwrap(),
             "Hello World"
         );
+    }
+
+    #[test]
+    fn test_camel_case() {
+        let target_config = WeaverConfig::default();
+        let mut env = Environment::new();
+        let ctx = serde_json::Value::Null;
+
+        add_filters(&mut env, &target_config);
+
         assert_eq!(
             env.render_str("{{ 'hello_world' | camel_case }}", &ctx)
                 .unwrap(),
             "helloWorld"
         );
+    }
+
+    #[test]
+    fn test_pascal_case() {
+        let target_config = WeaverConfig::default();
+        let mut env = Environment::new();
+        let ctx = serde_json::Value::Null;
+
+        add_filters(&mut env, &target_config);
+
         assert_eq!(
             env.render_str("{{ 'hello_world' | pascal_case }}", &ctx)
                 .unwrap(),
             "HelloWorld"
         );
-        assert_eq!(
-            env.render_str("{{ 'Hello World' | screaming_snake_case }}", &ctx)
-                .unwrap(),
-            "HELLO_WORLD"
-        );
-        assert_eq!(
-            env.render_str("{{ 'Hello World' | kebab_case }}", &ctx)
-                .unwrap(),
-            "hello-world"
-        );
-        assert_eq!(
-            env.render_str("{{ 'Hello World' | screaming_kebab_case }}", &ctx)
-                .unwrap(),
-            "HELLO-WORLD"
-        );
+    }
+
+    #[test]
+    fn test_capitalize_first_case() {
+        let target_config = WeaverConfig::default();
+        let mut env = Environment::new();
+        let ctx = serde_json::Value::Null;
+
+        add_filters(&mut env, &target_config);
+
         assert_eq!(
             env.render_str("{{ 'hello world' | capitalize_first }}", &ctx)
                 .unwrap(),
@@ -166,6 +219,36 @@ mod tests {
             env.render_str("{{ 'Hello WORLD' | capitalize_first }}", &ctx)
                 .unwrap(),
             "Hello WORLD"
+        );
+    }
+
+    #[test]
+    fn test_screaming_snake_case() {
+        let target_config = WeaverConfig::default();
+        let mut env = Environment::new();
+        let ctx = serde_json::Value::Null;
+
+        add_filters(&mut env, &target_config);
+
+        assert_eq!(
+            env.render_str("{{ 'Hello World' | screaming_snake_case }}", &ctx)
+                .unwrap(),
+            "HELLO_WORLD"
+        );
+    }
+
+    #[test]
+    fn test_screaming_kebab_case() {
+        let target_config = WeaverConfig::default();
+        let mut env = Environment::new();
+        let ctx = serde_json::Value::Null;
+
+        add_filters(&mut env, &target_config);
+
+        assert_eq!(
+            env.render_str("{{ 'Hello World' | screaming_kebab_case }}", &ctx)
+                .unwrap(),
+            "HELLO-WORLD"
         );
     }
 
@@ -211,6 +294,12 @@ mod tests {
             env.render_str("{{ 'Hello World!' | snake_case }}", &ctx)
                 .unwrap(),
             "hello_world!"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'this IS an ios device with a nice api!' | snake_case }}", &ctx)
+                .unwrap(),
+            "this_is_an_ios_device_with_a_nice_api!"
         );
     }
 }

--- a/crates/weaver_forge/src/extensions/case.rs
+++ b/crates/weaver_forge/src/extensions/case.rs
@@ -143,11 +143,6 @@ mod tests {
             "HelloWorld"
         );
         assert_eq!(
-            env.render_str("{{ 'Hello World' | snake_case }}", &ctx)
-                .unwrap(),
-            "hello_world"
-        );
-        assert_eq!(
             env.render_str("{{ 'Hello World' | screaming_snake_case }}", &ctx)
                 .unwrap(),
             "HELLO_WORLD"
@@ -171,6 +166,51 @@ mod tests {
             env.render_str("{{ 'Hello WORLD' | capitalize_first }}", &ctx)
                 .unwrap(),
             "Hello WORLD"
+        );
+    }
+
+    #[test]
+    fn test_snake_case() {
+        let target_config = WeaverConfig::default();
+        let mut env = Environment::new();
+        let ctx = serde_json::Value::Null;
+
+        add_filters(&mut env, &target_config);
+
+        assert_eq!(
+            env.render_str("{{ 'v8js.heap.space.name' | snake_case }}", &ctx)
+                .unwrap(),
+            "v8js_heap_space_name"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'k8s.job.name' | snake_case }}", &ctx)
+                .unwrap(),
+            "k8s_job_name"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'host.cpu.cache.l2.size' | snake_case }}", &ctx)
+                .unwrap(),
+            "host_cpu_cache_l2_size"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'nodejs.eventloop.delay.p99' | snake_case }}", &ctx)
+                .unwrap(),
+            "nodejs_eventloop_delay_p99"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'http.request.resend_count' | snake_case }}", &ctx)
+                .unwrap(),
+            "http_request_resend_count"
+        );
+
+        assert_eq!(
+            env.render_str("{{ 'Hello World!' | snake_case }}", &ctx)
+                .unwrap(),
+            "hello_world!"
         );
     }
 }

--- a/crates/weaver_forge/templates/test/converter.md
+++ b/crates/weaver_forge/templates/test/converter.md
@@ -1,11 +1,11 @@
 {%- set text = "this IS an ios device with a nice api!" -%}
-{{ text }}
-{{ text | lower_case }}
-{{ text | upper_case | acronym }}
-{{ text | title_case | acronym }}
-{{ text | pascal_case }}
-{{ text | camel_case }}
-{{ text | snake_case }}
-{{ text | screaming_snake_case }}
-{{ text | kebab_case | acronym }}
-{{ text | screaming_kebab_case }}
+text                : {{ text }}
+lower_case          : {{ text | lower_case }}
+upper_case | acronym: {{ text | upper_case | acronym }}
+title_case | acronym: {{ text | title_case | acronym }}
+pascal_case         : {{ text | pascal_case }}
+camel_case          : {{ text | camel_case }}
+snake_case          : {{ text | snake_case }}
+screaming_snake_case: {{ text | screaming_snake_case }}
+kebab_case | acronym: {{ text | kebab_case | acronym }}
+screaming_kebab_case: {{ text | screaming_kebab_case }}

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,7 @@ allow = [
     "OpenSSL",
     "Zlib",
     "BSL-1.0", # BOSL license used by https://crates.io/crates/lockfree-object-pool
+    "BSD-2-Clause",
 ]
 
 # List of explicitly disallowed licenses


### PR DESCRIPTION
Weaver considers numbers as word splitters, whereas build-tools doesn't. This results in invalid case conversion for acronyms such as k8s, s3, etc.

Closes #260, closes #265 