### PR TITLE
Let policy flag accept directories.

### DIFF
--- a/crates/weaver_checker/data/multi-policies/otel_policies.rego
+++ b/crates/weaver_checker/data/multi-policies/otel_policies.rego
@@ -1,0 +1,79 @@
+package before_resolution
+
+# Conventions for OTel:
+# - `data` holds the current released semconv, which is known to be valid.
+# - `input` holds the new candidate semconv version, whose validity is unknown.
+#
+# Note: `data` and `input` are predefined variables in Rego.
+
+# ========= Violation rules applied on unresolved semconv files =========
+
+# A registry `attribute_group` containing at least one `ref` attribute is
+# considered invalid.
+deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
+    group := input.groups[_]
+    startswith(group.id, "registry.")
+    attr := group.attributes[_]
+    attr.ref != null
+}
+
+# An attribute whose stability is not `deprecated` but has the deprecated field
+# set to true is invalid.
+deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
+    group := input.groups[_]
+    attr := group.attributes[_]
+    attr.stability != "deprecaded"
+    attr.deprecated
+}
+
+# An attribute cannot be removed from a group that has already been released.
+deny[schema_evolution_violation("attr_removed", old_group.id, old_attr.id)] {
+    old_group := data.groups[_]
+    old_attr := old_group.attributes[_]
+    not attr_exists_in_new_group(old_group.id, old_attr.id)
+}
+
+
+# ========= Helper functions =========
+
+# Check if an attribute from the old group exists in the new
+# group's attributes
+attr_exists_in_new_group(group_id, attr_id) {
+    new_group := input.groups[_]
+    new_group.id == group_id
+    attr := new_group.attributes[_]
+    attr.id == attr_id
+}
+
+# Build an attribute registry violation
+attr_registry_violation(violation_id, group_id, attr_id) = violation {
+    violation := {
+        "id": violation_id,
+        "type": "semconv_attribute",
+        "category": "attrigute_registry",
+        "group": group_id,
+        "attr": attr_id,
+    }
+}
+
+# Build an attribute violation
+attr_violation(violation_id, group_id, attr_id) = violation {
+    violation := {
+        "id": violation_id,
+        "type": "semconv_attribute",
+        "category": "attrigute",
+        "group": group_id,
+        "attr": attr_id,
+    }
+}
+
+# Build a schema evolution violation
+schema_evolution_violation(violation_id, group_id, attr_id) = violation {
+    violation := {
+        "id": violation_id,
+        "type": "semconv_attribute",
+        "category": "schema_evolution",
+        "group": group_id,
+        "attr": attr_id,
+    }
+}

--- a/crates/weaver_checker/data/multi-policies/otel_policies_2.rego
+++ b/crates/weaver_checker/data/multi-policies/otel_policies_2.rego
@@ -1,0 +1,79 @@
+package before_resolution
+
+# Conventions for OTel:
+# - `data` holds the current released semconv, which is known to be valid.
+# - `input` holds the new candidate semconv version, whose validity is unknown.
+#
+# Note: `data` and `input` are predefined variables in Rego.
+
+# ========= Violation rules applied on unresolved semconv files =========
+
+# A registry `attribute_group` containing at least one `ref` attribute is
+# considered invalid.
+deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
+    group := input.groups[_]
+    startswith(group.id, "registry.")
+    attr := group.attributes[_]
+    attr.ref != null
+}
+
+# An attribute whose stability is not `deprecated` but has the deprecated field
+# set to true is invalid.
+deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
+    group := input.groups[_]
+    attr := group.attributes[_]
+    attr.stability != "deprecaded"
+    attr.deprecated
+}
+
+# An attribute cannot be removed from a group that has already been released.
+deny[schema_evolution_violation("attr_removed", old_group.id, old_attr.id)] {
+    old_group := data.groups[_]
+    old_attr := old_group.attributes[_]
+    not attr_exists_in_new_group(old_group.id, old_attr.id)
+}
+
+
+# ========= Helper functions =========
+
+# Check if an attribute from the old group exists in the new
+# group's attributes
+attr_exists_in_new_group(group_id, attr_id) {
+    new_group := input.groups[_]
+    new_group.id == group_id
+    attr := new_group.attributes[_]
+    attr.id == attr_id
+}
+
+# Build an attribute registry violation
+attr_registry_violation(violation_id, group_id, attr_id) = violation {
+    violation := {
+        "id": violation_id,
+        "type": "semconv_attribute",
+        "category": "attrigute_registry",
+        "group": group_id,
+        "attr": attr_id,
+    }
+}
+
+# Build an attribute violation
+attr_violation(violation_id, group_id, attr_id) = violation {
+    violation := {
+        "id": violation_id,
+        "type": "semconv_attribute",
+        "category": "attrigute",
+        "group": group_id,
+        "attr": attr_id,
+    }
+}
+
+# Build a schema evolution violation
+schema_evolution_violation(violation_id, group_id, attr_id) = violation {
+    violation := {
+        "id": violation_id,
+        "type": "semconv_attribute",
+        "category": "schema_evolution",
+        "group": group_id,
+        "attr": attr_id,
+    }
+}

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -54,7 +54,9 @@ pub enum Error {
 
     /// Unable to access policy path.
     #[error("Invalid policy path '{path}'")]
-    #[diagnostic(help("Verify that the specified path exists and has the appropriate permissions."))]
+    #[diagnostic(help(
+        "Verify that the specified path exists and has the appropriate permissions."
+    ))]
     AccessDenied {
         /// The path that caused the error.
         path: String,
@@ -615,10 +617,10 @@ mod tests {
     #[test]
     fn test_policy_from_file_or_dir() -> Result<(), Box<dyn std::error::Error>> {
         let mut engine = Engine::new();
-        _ = engine.add_policy_from_file_or_dir("data/policies/otel_policies.rego")?;
+        engine.add_policy_from_file_or_dir("data/policies/otel_policies.rego")?;
         assert_eq!(1, engine.policy_package_count);
 
-        _ = engine.add_policy_from_file_or_dir("data/multi-policies")?;
+        engine.add_policy_from_file_or_dir("data/multi-policies")?;
         // TODO: add_policies double counts the number of files it adds.
         assert_eq!(3, engine.policy_package_count);
         Ok(())

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -344,7 +344,6 @@ impl Engine {
 
         handle_errors(errors)?;
 
-        self.policy_package_count += added_policy_count;
         Ok(added_policy_count)
     }
 
@@ -621,7 +620,7 @@ mod tests {
 
         _ = engine.add_policy_from_file_or_dir("data/multi-policies")?;
         // TODO: add_policies double counts the number of files it adds.
-        assert_eq!(5, engine.policy_package_count);
+        assert_eq!(3, engine.policy_package_count);
         Ok(())
     }
 }

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -621,7 +621,6 @@ mod tests {
         assert_eq!(1, engine.policy_package_count);
 
         engine.add_policy_from_file_or_dir("data/multi-policies")?;
-        // TODO: add_policies double counts the number of files it adds.
         assert_eq!(3, engine.policy_package_count);
         Ok(())
     }

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -46,7 +46,7 @@ pub enum Error {
 
     /// An unsupported policy path.
     #[error("Invalid policy path '{path}'")]
-    #[diagnostic(help("Check the exists and is a valid policy file."))]
+    #[diagnostic(help("The specified path is neither a file nor a directory.”"))]
     UnsupportedPolicyPath {
         /// The path that caused the error.
         path: String,
@@ -54,7 +54,7 @@ pub enum Error {
 
     /// Unable to access policy path.
     #[error("Invalid policy path '{path}'")]
-    #[diagnostic(help("Check the exists and is a valid policy file."))]
+    #[diagnostic(help("Verify that the specified path exists and has the appropriate permissions."))]
     AccessDenied {
         /// The path that caused the error.
         path: String,

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
+use std::fs::metadata;
 use std::path::Path;
 
 use globset::Glob;
@@ -39,6 +40,24 @@ pub enum Error {
     InvalidPolicyFile {
         /// The file that caused the error.
         file: String,
+        /// The error that occurred.
+        error: String,
+    },
+
+    /// An unsupported policy path.
+    #[error("Invalid policy path '{path}'")]
+    #[diagnostic(help("Check the exists and is a valid policy file."))]
+    UnsupportedPolicyPath {
+        /// The path that caused the error.
+        path: String,
+    },
+
+    /// Unable to access policy path.
+    #[error("Invalid policy path '{path}'")]
+    #[diagnostic(help("Check the exists and is a valid policy file."))]
+    AccessDenied {
+        /// The path that caused the error.
+        path: String,
         /// The error that occurred.
         error: String,
     },
@@ -205,6 +224,41 @@ impl Engine {
         Ok(policy_package)
     }
 
+    /// Adds a policy files to the policy engine. If path is a directory it will add any file matching *.rego
+    /// A policy file is a `rego` file that contains the policies to be evaluated.
+    ///
+    /// # Arguments
+    ///
+    /// * `policy_path` - The path to the policy file or directory.
+    ///
+    /// # Returns
+    ///
+    /// The policy package name.
+    pub fn add_policy_from_file_or_dir<P: AsRef<Path>>(
+        &mut self,
+        policy_path: P,
+    ) -> Result<(), Error> {
+        let path = policy_path.as_ref();
+
+        let md = metadata(path).map_err(|err| Error::AccessDenied {
+            path: path.to_string_lossy().to_string(),
+            error: err.to_string(),
+        })?;
+        match (md.is_file(), md.is_dir()) {
+            (true, _) => {
+                _ = self.add_policy_from_file(path)?;
+            }
+            (false, true) => {
+                _ = self.add_policies(path, "*.rego")?;
+            }
+            _ => {
+                return Err(Error::UnsupportedPolicyPath {
+                    path: path.to_string_lossy().to_string(),
+                });
+            }
+        };
+        Ok(())
+    }
     /// Adds a policy file to the policy engine.
     /// A policy file is a `rego` file that contains the policies to be evaluated.
     ///
@@ -557,5 +611,17 @@ mod tests {
         } else {
             panic!("Expected a CompoundError");
         }
+    }
+
+    #[test]
+    fn test_policy_from_file_or_dir() -> Result<(), Box<dyn std::error::Error>> {
+        let mut engine = Engine::new();
+        _ = engine.add_policy_from_file_or_dir("data/policies/otel_policies.rego")?;
+        assert_eq!(1, engine.policy_package_count);
+
+        _ = engine.add_policy_from_file_or_dir("data/multi-policies")?;
+        // TODO: add_policies double counts the number of files it adds.
+        assert_eq!(5, engine.policy_package_count);
+        Ok(())
     }
 }

--- a/src/registry/check.rs
+++ b/src/registry/check.rs
@@ -32,8 +32,9 @@ pub struct RegistryCheckArgs {
     #[arg(long)]
     baseline_registry: Option<RegistryPath>,
 
-    /// Optional list of policy files to check against the files of the semantic
-    /// convention registry.
+    /// Optional list of policy files or directories to check against the files of the semantic
+    /// convention registry.  If a directory is provided all `.rego` files in the directory will be
+    /// loaded.
     #[arg(short = 'p', long = "policy")]
     pub policies: Vec<PathBuf>,
 

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -54,8 +54,9 @@ pub struct RegistryGenerateArgs {
     #[command(flatten)]
     registry: RegistryArgs,
 
-    /// Optional list of policy files to check against the files of the semantic
-    /// convention registry.
+    /// Optional list of policy files or directories to check against the files of the semantic
+    /// convention registry. If a directory is provided all `.rego` files in the directory will be
+    /// loaded.
     #[arg(short = 'p', long = "policy")]
     pub policies: Vec<PathBuf>,
 

--- a/src/registry/resolve.rs
+++ b/src/registry/resolve.rs
@@ -42,8 +42,9 @@ pub struct RegistryResolveArgs {
     #[arg(short, long, default_value = "yaml")]
     format: Format,
 
-    /// Optional list of policy files to check against the files of the semantic
-    /// convention registry.
+    /// Optional list of policy files or directories to check against the files of the semantic
+    /// convention registry. If a directory is provided all `.rego` files in the directory will be
+    /// loaded.
     #[arg(short = 'p', long = "policy")]
     pub policies: Vec<PathBuf>,
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -78,9 +78,8 @@ pub(crate) fn init_policy_engine(
 
     // Add policies from the command line
     for policy in policies {
-        _ = engine.add_policy_from_file(policy)?;
+        _ = engine.add_policy_from_file_or_dir(policy)?;
     }
-
     Ok(engine)
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -78,7 +78,7 @@ pub(crate) fn init_policy_engine(
 
     // Add policies from the command line
     for policy in policies {
-        _ = engine.add_policy_from_file_or_dir(policy)?;
+        engine.add_policy_from_file_or_dir(policy)?;
     }
     Ok(engine)
 }


### PR DESCRIPTION
fixes #259 

This change allows --policy flags to accept a directory and include any *.rego file found.  It does not recurse into sub directories.