### PR TITLE
Give a user home to weaver so we can use cache.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ LABEL maintainer="The OpenTelemetry Authors"
 RUN addgroup weaver \
   && adduser \
   --ingroup weaver \
-  --no-create-home \
   --disabled-password \
   weaver
-WORKDIR /weaver
+WORKDIR /home/weaver
 COPY --from=weaver-build /build/target/release/weaver /weaver/weaver
 USER weaver
+RUN mkdir /home/weaver/target
 ENTRYPOINT ["/weaver/weaver"]


### PR DESCRIPTION
This will require some more justification descirption, but now that we run as non-root, we can't stomp all over the local filesystem when users call us AND we need access to a directory in the container for writing cache.

Previously, I forgot to test where directories are not forcefully mounted, but I've tested this against semconv and it works.

Also, still working on pruning our instructions so we only mount writeable directories as a user where *we want weaver to write*.

Right now, that looks like:

```
	docker run --rm \
		-u $(id -u ${USER}):$(id -g ${USER}) \
		-v $(MY_YAML_FILES)l:/home/weaver/source \
		-v $(MY_DESTINATION_DIR)/docs:/home/weaver/target \
		-v $(MY_TEMPLATES)/templates:/home/weaver/templates \
		$(WEAVER_CONTAINER) registry generate \
		  --registry=/home/weaver/source \
		  --templates=/home/weaver/templates \
		  markdown \
		  /home/weaver/target/
```

Where we encourage developers to run the docker image as themselves to avoid having permissions beyond their own permissions.

cc @lmolkova as an FYI on the current docker images issues.
