### PR TITLE
Fix clippy issues.

### DIFF
--- a/crates/weaver_forge/src/extensions/case.rs
+++ b/crates/weaver_forge/src/extensions/case.rs
@@ -118,7 +118,7 @@ mod tests {
         add_filters(&mut env);
 
         assert_eq!(
-            env.render_str("{{ 'Hello World' | kebab_case }}", &ctx)
+            env.render_str("{{ 'Hello World' | kebab_case }}", ctx)
                 .unwrap(),
             "hello-world"
         );
@@ -132,7 +132,7 @@ mod tests {
         add_filters(&mut env);
 
         assert_eq!(
-            env.render_str("{{ 'Hello World' | lower_case }}", &ctx)
+            env.render_str("{{ 'Hello World' | lower_case }}", ctx)
                 .unwrap(),
             "hello world"
         );
@@ -190,7 +190,7 @@ mod tests {
         add_filters(&mut env);
 
         assert_eq!(
-            env.render_str("{{ 'Hello World' | title_case }}", &ctx)
+            env.render_str("{{ 'Hello World' | title_case }}", ctx)
                 .unwrap(),
             "Hello World"
         );

--- a/crates/weaver_forge/src/extensions/code.rs
+++ b/crates/weaver_forge/src/extensions/code.rs
@@ -54,6 +54,7 @@ pub(crate) fn comment_with_prefix(input: &Value, prefix: &str) -> String {
 }
 
 /// Generic comment filter reading its configuration from the `weaver.yaml` file.
+#[allow(clippy::assigning_clones)]
 pub(crate) fn comment(
     config: &WeaverConfig,
 ) -> Result<impl Fn(&Value, Kwargs) -> Result<String, minijinja::Error>, Error> {
@@ -98,7 +99,6 @@ pub(crate) fn comment(
             } else {
                 input.to_string()
             };
-
             if comment_format.trim {
                 comment = comment.trim().to_owned();
             }
@@ -349,7 +349,7 @@ it's RECOMMENDED to:
         // Test with an undefined field in the context
         let ctx = serde_json::json!({});
         let observed_comment = env
-            .render_str("{{ note | comment(format='java', indent=2) }}", &ctx)
+            .render_str("{{ note | comment(format='java', indent=2) }}", ctx)
             .unwrap();
         assert_eq!(observed_comment, "");
 
@@ -361,7 +361,7 @@ it's RECOMMENDED to:
         let observed_comment = env
             .render_str(
                 "{{ [brief,'Note: ', note, something_not_in_ctx] | comment(indent=2) }}",
-                &ctx,
+                ctx,
             )
             .unwrap();
         assert_eq!(

--- a/crates/weaver_forge/src/formats/html.rs
+++ b/crates/weaver_forge/src/formats/html.rs
@@ -146,7 +146,7 @@ impl<'source> HtmlRenderer<'source> {
             code: code.to_owned(),
         };
         self.env
-            .render_str(&options.inline_code_snippet, &ctx)
+            .render_str(&options.inline_code_snippet, ctx)
             .map_err(|e| InvalidCodeSnippet {
                 format: format.to_owned(),
                 mode: INLINE_CODE_SNIPPET_MODE.to_owned(),
@@ -170,7 +170,7 @@ impl<'source> HtmlRenderer<'source> {
             code: code.to_owned(),
         };
         self.env
-            .render_str(&options.block_code_snippet, &ctx)
+            .render_str(&options.block_code_snippet, ctx)
             .map_err(|e| InvalidCodeSnippet {
                 format: format.to_owned(),
                 mode: BLOCK_CODE_SNIPPET_MODE.to_owned(),

--- a/crates/weaver_forge/src/formats/markdown.rs
+++ b/crates/weaver_forge/src/formats/markdown.rs
@@ -84,7 +84,7 @@ impl RenderContext {
 
     /// Set the line prefix to add in front of each new line.
     fn set_line_prefix(&mut self, prefix: &str) {
-        self.line_prefix = prefix.to_owned();
+        prefix.clone_into(&mut self.line_prefix);
     }
 
     /// Skip the line prefix on the first line.
@@ -94,7 +94,7 @@ impl RenderContext {
 
     /// Reset the line prefix.
     fn reset_line_prefix(&mut self) {
-        self.line_prefix = "".to_owned();
+        "".clone_into(&mut self.line_prefix);
         self.skip_line_prefix_on_first_line = false;
     }
 
@@ -197,7 +197,7 @@ impl MarkdownRenderer {
             }
             Node::Text(text) => {
                 if options.escape_backslashes {
-                    ctx.add_text(&text.value.replace("\\", "\\\\"));
+                    ctx.add_text(&text.value.replace('\\', "\\\\"));
                 } else {
                     ctx.add_text(&text.value);
                 }

--- a/crates/weaver_forge/src/lib.rs
+++ b/crates/weaver_forge/src/lib.rs
@@ -792,7 +792,7 @@ mod tests {
 
         // Delete all the files in the observed_output/target directory
         // before generating the new files.
-        fs::remove_dir_all(&format!("observed_output/{}", target)).unwrap_or_default();
+        fs::remove_dir_all(format!("observed_output/{}", target)).unwrap_or_default();
 
         (
             TestLogger::default(),


### PR DESCRIPTION
It looks like some new checks/improvements are made of this variety:

- Use `y.clone_into(x)` instead of `x = y.to_owned()`
- Don't borrow unless you need to.
- Use character literals instead of string literals of size 1