### PR TITLE
Define `indent_type` for comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Next] - YYYY-MM-DD
+
+What's changed
+
+* Add support for `indent_type` in both the comment filter and the `comment_formats` configuration. ([#XXX](...) by lquerel).
+
 ## [0.9.2] - 2024-09-09
 
 What's Changed

--- a/crates/weaver_forge/README.md
+++ b/crates/weaver_forge/README.md
@@ -574,6 +574,7 @@ comment_formats:           # optional
     header: <string>                  # The comment header line (e.g., `/**`)
     prefix: <string>                  # The comment line prefix (e.g., ` * `)
     footer: <string>                  # The comment line footer (e.g., ` */`)
+    indent_type: space | tab          # The type of indentation (default: space)
     trim: <bool>                      # Flag to trim the comment content (default: true). 
     remove_trailing_dots: <bool>      # Flag to remove trailing dots from the comment content (default: false).
 
@@ -838,6 +839,7 @@ The `comment` filter accepts the following optional parameters:
 - **`prefix`**: A custom prefix for each comment line.
 - **`footer`**: A custom footer for the comment block.
 - **`indent`**: Number of spaces to add before each comment line for indentation purposes.
+- **`indent_type`**: The type of indentation to use. Supported values are `space` (default) and `tab`.
 
 > Please open an issue if you have any suggestions for new formats or features.
 

--- a/crates/weaver_forge/src/config.rs
+++ b/crates/weaver_forge/src/config.rs
@@ -22,6 +22,7 @@
 #![allow(rustdoc::invalid_html_tags)]
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt::{Display, Formatter};
 use std::path::Path;
 use std::sync::OnceLock;
 
@@ -308,6 +309,9 @@ pub struct CommentFormat {
     pub(crate) prefix: Option<String>,
     /// A comment footer (e.g. in Java ` */`).
     pub(crate) footer: Option<String>,
+    /// The type of indentation to use for the comment (space by default).
+    #[serde(default)]
+    pub(crate) indent_type: IndentType,
 
     /// Flag to trim the comment content.
     #[serde(default = "default_bool::<true>")]
@@ -315,6 +319,25 @@ pub struct CommentFormat {
     /// Flag to remove trailing dots from the comment content.
     #[serde(default = "default_bool::<false>")]
     pub remove_trailing_dots: bool,
+}
+
+/// The type of indentation to use for the comment.
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+pub enum IndentType {
+    /// Use spaces for indentation.
+    #[default]
+    Space,
+    /// Use tabs for indentation.
+    Tab,
+}
+
+impl Display for IndentType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IndentType::Space => write!(f, "space"),
+            IndentType::Tab => write!(f, "tab"),
+        }
+    }
 }
 
 impl Default for CaseConvention {

--- a/crates/weaver_forge/src/extensions/code.rs
+++ b/crates/weaver_forge/src/extensions/code.rs
@@ -129,7 +129,21 @@ pub(crate) fn comment(
                         )
                     })?,
             };
-            let indent = " ".repeat(args.get("indent").map(|v: usize| v).unwrap_or(0));
+            let indent_arg = args.get("indent").map(|v: usize| v).unwrap_or(0);
+            let indent_type_arg = args
+                .get("indent_type")
+                .map(|v: String| v)
+                .unwrap_or(comment_format.indent_type.to_string());
+            let indent = match indent_type_arg.as_str() {
+                "space" => " ".repeat(indent_arg),
+                "tab" => "\t".repeat(indent_arg),
+                _ => {
+                    return Err(minijinja::Error::new(
+                        ErrorKind::InvalidOperation,
+                        "Invalid indent type, must be 'space' or 'tab'",
+                    ))
+                }
+            };
 
             let header = args
                 .get("header")
@@ -228,7 +242,7 @@ pub(crate) fn map_text(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::CommentFormat;
+    use crate::config::{CommentFormat, IndentType};
     use crate::extensions::code;
     use crate::formats::html::HtmlRenderOptions;
 
@@ -243,6 +257,7 @@ mod tests {
                         header: Some("/**".to_owned()),
                         prefix: Some(" * ".to_owned()),
                         footer: Some(" */".to_owned()),
+                        indent_type: IndentType::Space,
                         format: RenderFormat::Html(HtmlRenderOptions {
                             old_style_paragraph: true,
                             omit_closing_li: true,
@@ -346,6 +361,97 @@ it's RECOMMENDED to:
    */"##
         );
 
+        // Test with indent_type=`space`
+        let observed_comment = env
+            .render_str("{{ note | comment(indent=2, indent_type='space') }}", &ctx)
+            .unwrap();
+        assert_eq!(
+            observed_comment,
+            r##"/**
+   * The {@code error.type} SHOULD be predictable, and SHOULD have low cardinality.
+   * <p>
+   * When {@code error.type} is set to a type (e.g., an exception type), its
+   * canonical class name identifying the type within the artifact SHOULD be used.
+   * <p>
+   * Instrumentations SHOULD document the list of errors they report.
+   * <p>
+   * The cardinality of {@code error.type} within one instrumentation library SHOULD be low.
+   * Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+   * should be prepared for {@code error.type} to have high cardinality at query time when no
+   * additional filters are applied.
+   * <p>
+   * If the operation has completed successfully, instrumentations SHOULD NOT set {@code error.type}.
+   * <p>
+   * If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes),
+   * it's RECOMMENDED to:
+   * <p>
+   * <ul>
+   *   <li>Use a domain-specific attribute
+   *   <li>Set {@code error.type} to capture all errors, regardless of whether they are defined within the domain-specific set or not
+   * </ul>
+   */"##
+        );
+
+        // Test with indent_type=`tab`
+        let observed_comment = env
+            .render_str("{{ note | comment(indent=2, indent_type='tab') }}", &ctx)
+            .unwrap();
+        assert_eq!(
+            observed_comment,
+            r##"/**
+		 * The {@code error.type} SHOULD be predictable, and SHOULD have low cardinality.
+		 * <p>
+		 * When {@code error.type} is set to a type (e.g., an exception type), its
+		 * canonical class name identifying the type within the artifact SHOULD be used.
+		 * <p>
+		 * Instrumentations SHOULD document the list of errors they report.
+		 * <p>
+		 * The cardinality of {@code error.type} within one instrumentation library SHOULD be low.
+		 * Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+		 * should be prepared for {@code error.type} to have high cardinality at query time when no
+		 * additional filters are applied.
+		 * <p>
+		 * If the operation has completed successfully, instrumentations SHOULD NOT set {@code error.type}.
+		 * <p>
+		 * If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes),
+		 * it's RECOMMENDED to:
+		 * <p>
+		 * <ul>
+		 *   <li>Use a domain-specific attribute
+		 *   <li>Set {@code error.type} to capture all errors, regardless of whether they are defined within the domain-specific set or not
+		 * </ul>
+		 */"##
+        );
+
+        // New configuration with `indent_type='tab'`
+        let mut env = Environment::new();
+        let config = WeaverConfig {
+            comment_formats: Some(
+                vec![(
+                    "java".to_owned(),
+                    CommentFormat {
+                        header: Some("/**".to_owned()),
+                        prefix: Some(" * ".to_owned()),
+                        footer: Some(" */".to_owned()),
+                        indent_type: IndentType::Tab,
+                        format: RenderFormat::Html(HtmlRenderOptions {
+                            old_style_paragraph: true,
+                            omit_closing_li: true,
+                            inline_code_snippet: "{@code {{code}}}".to_owned(),
+                            block_code_snippet: "<pre>{@code {{code}}}</pre>".to_owned(),
+                        }),
+                        trim: true,
+                        remove_trailing_dots: true,
+                    },
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            default_comment_format: Some("java".to_owned()),
+            ..Default::default()
+        };
+        add_filters(&mut env, &config, true)?;
+
         // Test with an undefined field in the context
         let ctx = serde_json::json!({});
         let observed_comment = env
@@ -361,16 +467,16 @@ it's RECOMMENDED to:
         let observed_comment = env
             .render_str(
                 "{{ [brief,'Note: ', note, something_not_in_ctx] | comment(indent=2) }}",
-                ctx,
+                &ctx,
             )
             .unwrap();
         assert_eq!(
             observed_comment,
             r##"/**
-   * This is a brief description.
-   * Note:
-   * This is a note
-   */"##
+		 * This is a brief description.
+		 * Note:
+		 * This is a note
+		 */"##
         );
 
         Ok(())

--- a/crates/weaver_forge/src/formats/html.rs
+++ b/crates/weaver_forge/src/formats/html.rs
@@ -327,7 +327,7 @@ impl<'source> HtmlRenderer<'source> {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{CommentFormat, RenderFormat, WeaverConfig};
+    use crate::config::{CommentFormat, IndentType, RenderFormat, WeaverConfig};
     use crate::error::Error;
     use crate::formats::html::{HtmlRenderOptions, HtmlRenderer};
 
@@ -341,6 +341,7 @@ mod tests {
                         header: Some("/**".to_owned()),
                         prefix: Some(" * ".to_owned()),
                         footer: Some(" */".to_owned()),
+                        indent_type: IndentType::Space,
                         format: RenderFormat::Html(HtmlRenderOptions {
                             old_style_paragraph: true,
                             omit_closing_li: true,

--- a/crates/weaver_forge/src/formats/markdown.rs
+++ b/crates/weaver_forge/src/formats/markdown.rs
@@ -358,7 +358,7 @@ impl MarkdownRenderer {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{CommentFormat, RenderFormat, WeaverConfig};
+    use crate::config::{CommentFormat, IndentType, RenderFormat, WeaverConfig};
     use crate::error::Error;
     use crate::formats::markdown::{MarkdownRenderOptions, MarkdownRenderer};
 
@@ -372,6 +372,7 @@ mod tests {
                         header: None,
                         prefix: Some("// ".to_owned()),
                         footer: None,
+                        indent_type: IndentType::Space,
                         format: RenderFormat::Markdown(MarkdownRenderOptions {
                             escape_backslashes: false,
                             indent_first_level_list_items: true,

--- a/docs/weaver-config.md
+++ b/docs/weaver-config.md
@@ -47,6 +47,7 @@ comment_formats:           # optional
     header: <string>                  # The comment header line (e.g., `/**`)
     prefix: <string>                  # The comment line prefix (e.g., ` * `)
     footer: <string>                  # The comment line footer (e.g., ` */`)
+    indent_type: space|tab            # The type of indentation (default: space)
     trim: <bool>                      # Flag to trim the comment content (default: true). 
     remove_trailing_dots: <bool>      # Flag to remove trailing dots from the comment content (default: false).
 


### PR DESCRIPTION
Add support for `indent_type` in both the comment filter and the `comment_formats` configuration

Closes #352