### PR TITLE
Add `escape_square_brackets` into `comment_formats` markdown configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Next] - YYYY-MM-DD
+
+What's changed
+
+* Add `escape_square_brackets` into `comment_formats` markdown configuration. ([#XXX](...) by lquerel).
+
 ## [0.9.2] - 2024-09-09
 
 What's Changed

--- a/crates/weaver_forge/README.md
+++ b/crates/weaver_forge/README.md
@@ -579,6 +579,7 @@ comment_formats:           # optional
 
     # Fields specific to 'markdown' format
     escape_backslashes: <bool>            # Whether to escape backslashes in markdown (default: false).
+    escape_square_brackets: <bool>        # Whether to escape square brackets in markdown (default: false).
     shortcut_reference_links: <bool>      # Convert inlined links into shortcut reference links (default: false).
     indent_first_level_list_items: <bool> # Indent the first level of list items in markdown (default: false).
     default_block_code_language: <string> # Default language for block code snippets (default: "").

--- a/crates/weaver_forge/expected_output/comment_format/example.rs
+++ b/crates/weaver_forge/expected_output/comment_format/example.rs
@@ -96,7 +96,7 @@
   /// > Lorem ipsum dolor sit amet, consectetur adipiscing
   /// > elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
   /// 
-  /// > [!NOTE] Something very important here
+  /// > \[!NOTE\] Something very important here
   const ATTR: &str = "";
 
 

--- a/crates/weaver_forge/src/formats/markdown.rs
+++ b/crates/weaver_forge/src/formats/markdown.rs
@@ -17,8 +17,8 @@ pub struct MarkdownRenderOptions {
     #[serde(default)]
     pub(crate) escape_backslashes: bool,
     /// Whether to escape square brackets in the Markdown text. Valid links are not affected.
-    /// Default is false.
-    #[serde(default)]
+    /// Default is true.
+    #[serde(default = "default_bool::<true>")]
     pub(crate) escape_square_brackets: bool,
     /// Whether to indent the first level of list items in the markdown.
     /// Default is false.
@@ -32,6 +32,12 @@ pub struct MarkdownRenderOptions {
     /// The default language for code blocks.
     /// Default is None.
     pub(crate) default_block_code_language: Option<String>,
+}
+
+/// Used to set a default value for a boolean field in a struct.
+#[must_use]
+pub const fn default_bool<const V: bool>() -> bool {
+    V
 }
 
 pub(crate) struct ShortcutReferenceLink {
@@ -515,6 +521,8 @@ it's RECOMMENDED to:
                         }),
                         trim: true,
                         remove_trailing_dots: true,
+                        indent_type: Default::default(),
+                        enforce_trailing_dots: false,
                     },
                 )]
                 .into_iter()
@@ -553,6 +561,8 @@ The file \[extension\] extracted \[from] the `url.full`, excluding the leading d
                         }),
                         trim: true,
                         remove_trailing_dots: true,
+                        indent_type: Default::default(),
+                        enforce_trailing_dots: false,
                     },
                 )]
                 .into_iter()

--- a/crates/weaver_forge/templates/comment_format/weaver.yaml
+++ b/crates/weaver_forge/templates/comment_format/weaver.yaml
@@ -37,6 +37,7 @@ comment_formats:
     shortcut_reference_link: true
     trim: true
     remove_trailing_dots: true
+    escape_square_brackets: false
   python:
     format: markdown
     header: '"""'
@@ -44,6 +45,7 @@ comment_formats:
     escape_backslashes: true
     trim: true
     remove_trailing_dots: true
+    escape_square_brackets: false
 
 templates:
   - template: "example.java.j2"

--- a/docs/weaver-config.md
+++ b/docs/weaver-config.md
@@ -52,6 +52,7 @@ comment_formats:           # optional
 
     # The following fields are enabled only when format is set to 'markdown'
     escape_backslashes: <bool>            # Whether to escape backslashes in the markdown (default: false).
+    escape_square_brackets: <bool>        # Whether to escape square brackets in markdown (default: false).
     shortcut_reference_links: <bool>      # Use this to convert inlined links into shortcut reference links, similar to those in Go documentation (default: false).
     indent_first_level_list_items: <bool> # Whether to indent the first level of list items in the markdown (default: false).
     default_block_code_language: <string> # The default language for block code snippets (default: "").


### PR DESCRIPTION
The `cargo doc` command does not properly handle non-escaped text containing square brackets when these brackets are not intended to represent links (e.g., `This is a [text] with square brackets that doesn't represent a link`). This PR addresses the issue by introducing a new flag `escape_square_brackets` in the markdown configuration of the `comment_formats` section.

This new flag ensures that text with square brackets, which are not intended as links, is properly escaped in the generated documentation.

## Example:

### Input Text:
```text
In some cases, a [URL] may refer to an [IP](http://ip.com) and/or port directly.
The file \[extension\] is extracted \[from] the `url.full`, excluding the leading dot.
```

### Output Without the Flag:
Without the new flag, the following text is returned by the comment filter:
```text
In some cases, a [URL] may refer to an [IP](http://ip.com) and/or port directly.
The file \[extension\] is extracted \[from] the `url.full`, excluding the leading dot.
```

### Output With the Flag Enabled:
When the new flag is enabled, the output becomes:
```text
In some cases, a \[URL\] may refer to an [IP](http://ip.com) and/or port directly.
The file \[extension\] is extracted \[from\] the `url.full`, excluding the leading dot.
```

Closes #374 