### PR TITLE
Add `regex_replace` filter to support replacing text using regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 What's changed
 
 * Add support for `indent_type` in both the comment filter and the `comment_formats` configuration. ([#XXX](...) by lquerel).
+* Add `regex_replace` filter to support replacing text using regex. ([#XXX](...) by lquerel).
 
 ## [0.9.2] - 2024-09-09
 

--- a/crates/weaver_forge/README.md
+++ b/crates/weaver_forge/README.md
@@ -486,6 +486,9 @@ The following filters are available:
 - `acronym`: Replaces acronyms in the input string with the full name defined in the `acronyms` section of the
   `weaver.yaml` configuration file.
 - `split_id`: Splits a string by '.' creating a list of nested ids.
+- `regex_replace`: Replace all occurrences of a regex pattern (1st parameter) in the input string with the replacement
+  string (2nd parameter). Under the hood, this filter uses the `regex` crate (see
+  [regex](https://docs.rs/regex/latest/regex/index.html#traits) for more details) 
 - `comment_with_prefix(prefix)`: Outputs a multiline comment with the given prefix. This filter is deprecated, please use the more general `comment` filter.
 - `comment`: A generic comment formatter that uses the `comment_formats` section of the `weaver.yaml` configuration file (more details [here](#comment-filter)).
 - `flatten`: Converts a List of Lists into a single list with all elements.  


### PR DESCRIPTION
This PR introduces the `regex_replace` filter, which replaces all occurrences of a regex pattern (specified as the first parameter) in the input string with a replacement string (specified as the second parameter). This filter leverages the `regex` crate under the hood. For more details, see the [regex documentation](https://docs.rs/regex/latest/regex/index.html#traits).

Closes #203