### PR TITLE
Allow adding a description when using `opt_in` requirement level

### DIFF
--- a/crates/weaver_resolved_schema/src/catalog.rs
+++ b/crates/weaver_resolved_schema/src/catalog.rs
@@ -87,6 +87,7 @@ impl Catalog {
                         RequirementLevel::Basic(BasicRequirementLevelSpec::Optional) => "optional",
                         RequirementLevel::Recommended { .. } => "recommended",
                         RequirementLevel::ConditionallyRequired { .. } => "conditionally_required",
+                        RequirementLevel::OptIn { .. } => "opt_in",
                     };
                     (requirement_level.to_owned(), 1)
                 })

--- a/crates/weaver_semconv/README.md
+++ b/crates/weaver_semconv/README.md
@@ -12,7 +12,7 @@ documentation.
 
 For a formal definition of the allowed syntax, see the [build-tools JSON schema](https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/semconv.schema.json).
 
-# Design Principles
+## Design Principles
 
 - Collect as many warnings and errors as possible. Do not stop at the first error; this approach helps the user fix
   multiple issues at once.

--- a/crates/weaver_semconv/src/attribute.rs
+++ b/crates/weaver_semconv/src/attribute.rs
@@ -579,6 +579,12 @@ pub enum RequirementLevel {
         #[serde(rename = "recommended")]
         text: String,
     },
+    /// An opt in requirement level.
+    OptIn {
+        /// The description of the recommendation.
+        #[serde(rename = "opt_in")]
+        text: String,
+    },
 }
 
 /// Implements a human readable display for RequirementLevel.
@@ -590,6 +596,7 @@ impl Display for RequirementLevel {
                 write!(f, "conditionally required (condition: {})", text)
             }
             RequirementLevel::Recommended { text } => write!(f, "recommended ({})", text),
+            RequirementLevel::OptIn { text } => write!(f, "opt in ({})", text),
         }
     }
 }
@@ -693,6 +700,15 @@ mod tests {
                 }
             ),
             "recommended (recommendation)"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                RequirementLevel::OptIn {
+                    text: "recommendation".to_owned()
+                }
+            ),
+            "opt in (recommendation)"
         );
     }
 

--- a/schemas/semconv.schema.json
+++ b/schemas/semconv.schema.json
@@ -231,7 +231,23 @@
 							]
 						},
 						{
-							"const": "opt_in"
+							"oneOf": [
+								{
+									"const": "opt_in"
+								},
+								{
+									"type": "object",
+									"additionalProperties": false,
+									"required": [
+										"opt_in"
+									],
+									"properties": {
+										"opt_in": {
+											"type": "string"
+										}
+									}
+								}
+							]
 						}
 					]
 				},
@@ -428,7 +444,7 @@
 				},
 				"type": {
 					"$ref": "#/$defs/AttributeType"
-				}					
+				}
 			}
 		},
 		"AttributeReference": {


### PR DESCRIPTION
I bumped into this while working on https://github.com/open-telemetry/semantic-conventions/issues/474. I want to change a requirement level to `opt_in` and add a description to it, but I can't because the schema doesn't allow it. 