### PR TITLE
chore(deps): bump markdown from 1.0.0-alpha.20 to 1.0.0-alpha.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.20"
+version = "1.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a8325e6fb87b89890cd4529a2ab34c2669c026279e61c26b7140a3d821ccb"
+checksum = "a6491e6c702bf7e3b24e769d800746d5f2c06a6c6a2db7992612e0f429029e81"
 dependencies = [
  "unicode-id",
 ]

--- a/crates/weaver_forge/Cargo.toml
+++ b/crates/weaver_forge/Cargo.toml
@@ -28,7 +28,7 @@ jaq-parse = "1.0.3"
 jaq-syn = "1.1.0"
 indexmap = "2.6.0"
 regex = "1.11.0"
-markdown = "=1.0.0-alpha.20"
+markdown = "=1.0.0-alpha.21"
 
 itertools.workspace = true
 thiserror.workspace = true

--- a/crates/weaver_forge/src/formats/html.rs
+++ b/crates/weaver_forge/src/formats/html.rs
@@ -257,7 +257,7 @@ impl<'source> HtmlRenderer<'source> {
                         .as_str(),
                 );
             }
-            Node::BlockQuote(block_quote) => {
+            Node::Blockquote(block_quote) => {
                 ctx.html.push_str("<blockquote>\n");
                 for child in &block_quote.children {
                     self.write_html_to(ctx, indent, child, format, options)?;

--- a/crates/weaver_forge/src/formats/markdown.rs
+++ b/crates/weaver_forge/src/formats/markdown.rs
@@ -300,7 +300,7 @@ impl MarkdownRenderer {
                 ctx.markdown
                     .push_str(&format!("```{}\n{}\n```\n", lang, code.value));
             }
-            Node::BlockQuote(block_quote) => {
+            Node::Blockquote(block_quote) => {
                 ctx.add_cond_blank_line();
                 ctx.set_line_prefix("> ");
                 for child in &block_quote.children {

--- a/crates/weaver_forge/src/lib.rs
+++ b/crates/weaver_forge/src/lib.rs
@@ -927,6 +927,10 @@ mod tests {
 
     #[test]
     fn test_template_engine() {
+        // we need to first clean "observed_output/test" of previous runs
+        // We ignore failures because the directory may not exist yet.
+        let _ = fs::remove_dir_all("observed_output/test");
+
         let logger = TestLogger::default();
         let loader = FileSystemFileLoader::try_new("templates".into(), "test")
             .expect("Failed to create file system loader");


### PR DESCRIPTION
Replaces #386 