### PR TITLE
fix(update-markdown): generate markdown if warnings without errors

### DIFF
--- a/crates/weaver_semconv_gen/src/lib.rs
+++ b/crates/weaver_semconv_gen/src/lib.rs
@@ -329,8 +329,8 @@ impl ResolvedSemconvRegistry {
         diag_msgs: &mut DiagnosticMessages,
     ) -> Result<ResolvedSemconvRegistry, Error> {
         let registry_id = "semantic_conventions";
-        let semconv_specs =
-            SchemaResolver::load_semconv_specs(registry_repo).capture_non_fatal_errors(diag_msgs)?;
+        let semconv_specs = SchemaResolver::load_semconv_specs(registry_repo)
+            .capture_non_fatal_errors(diag_msgs)?;
         let mut registry = SemConvRegistry::from_semconv_specs(registry_id, semconv_specs);
         let schema = SchemaResolver::resolve_semantic_convention_registry(&mut registry)?;
         let lookup = ResolvedSemconvRegistry {
@@ -382,7 +382,8 @@ mod tests {
         };
         let mut diag_msgs = DiagnosticMessages::empty();
         let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
-        let generator = SnippetGenerator::try_from_registry_repo(&registry_repo, template, &mut diag_msgs)?;
+        let generator =
+            SnippetGenerator::try_from_registry_repo(&registry_repo, template, &mut diag_msgs)?;
         let attribute_registry_url = "/docs/attributes-registry";
         // Now we should check a snippet.
         let test = "data/templates.md";

--- a/crates/weaver_semconv_gen/src/lib.rs
+++ b/crates/weaver_semconv_gen/src/lib.rs
@@ -306,8 +306,9 @@ impl SnippetGenerator {
     pub fn try_from_registry_repo(
         registry_repo: &RegistryRepo,
         template_engine: TemplateEngine,
+        diag_msgs: &mut DiagnosticMessages,
     ) -> Result<SnippetGenerator, Error> {
-        let registry = ResolvedSemconvRegistry::try_from_registry_repo(registry_repo)?;
+        let registry = ResolvedSemconvRegistry::try_from_registry_repo(registry_repo, diag_msgs)?;
         Ok(SnippetGenerator {
             lookup: registry,
             template_engine,
@@ -325,10 +326,11 @@ impl ResolvedSemconvRegistry {
     /// Resolve semconv registry (possibly from git), and make it available for rendering.
     fn try_from_registry_repo(
         registry_repo: &RegistryRepo,
+        diag_msgs: &mut DiagnosticMessages,
     ) -> Result<ResolvedSemconvRegistry, Error> {
         let registry_id = "semantic_conventions";
         let semconv_specs =
-            SchemaResolver::load_semconv_specs(registry_repo).into_result_failing_non_fatal()?;
+            SchemaResolver::load_semconv_specs(registry_repo).capture_non_fatal_errors(diag_msgs)?;
         let mut registry = SemConvRegistry::from_semconv_specs(registry_id, semconv_specs);
         let schema = SchemaResolver::resolve_semantic_convention_registry(&mut registry)?;
         let lookup = ResolvedSemconvRegistry {
@@ -356,6 +358,7 @@ impl ResolvedSemconvRegistry {
 mod tests {
     use weaver_cache::registry_path::RegistryPath;
     use weaver_cache::RegistryRepo;
+    use weaver_common::diagnostic::DiagnosticMessages;
     use weaver_forge::config::{Params, WeaverConfig};
     use weaver_forge::file_loader::FileSystemFileLoader;
     use weaver_forge::TemplateEngine;
@@ -377,8 +380,9 @@ mod tests {
         let registry_path = RegistryPath::LocalFolder {
             path: "data".to_owned(),
         };
+        let mut diag_msgs = DiagnosticMessages::empty();
         let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
-        let generator = SnippetGenerator::try_from_registry_repo(&registry_repo, template)?;
+        let generator = SnippetGenerator::try_from_registry_repo(&registry_repo, template, &mut diag_msgs)?;
         let attribute_registry_url = "/docs/attributes-registry";
         // Now we should check a snippet.
         let test = "data/templates.md";


### PR DESCRIPTION
This PR implements the following changes in the `registry update-markdown` command:
- If `--future` is present in the arguments, no generation will occur if there are warnings or errors, and the command will return a code of 1.
- If `--future` is not present in the arguments, the markdown generation will proceed only if there are no errors. In this case, warnings will be displayed (if any), markdown will be generated, and the command will return 0. If at least one error is detected, errors (and warnings, if present) will be displayed, no generation will occur, and the command will return a code of 1.

Closes: #434 