### PR TITLE
Fix check external types dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           # cargo check-external-types is only available on this specific nightly
-          toolchain: nightly-2024-05-01
+          toolchain: nightly-2024-06-30
       - uses: Swatinem/rust-cache@v2
       - name: check-external-types
         run: |

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ install:
     cargo install cargo-machete
     cargo install cargo-depgraph
     cargo install cargo-edit
-    rustup install nightly-2024-05-01   # used by cargo-check-external-types
+    rustup install nightly-2024-06-30   # used by cargo-check-external-types
     cargo install cargo-check-external-types
     cargo install git-cliff
     cargo install cargo-tarpaulin

--- a/scripts/check_external_types.sh
+++ b/scripts/check_external_types.sh
@@ -13,7 +13,7 @@ for dir in crates/*/; do
   
   # Check if the public API is compliant with the allowed-external-types.toml
   echo "Checking the public API of $dir"
-  cargo +nightly-2024-05-01 check-external-types --all-features --manifest-path "$dir/Cargo.toml" --config "$dir/allowed-external-types.toml" || exit 1
+  cargo +nightly-2024-06-30 check-external-types --all-features --manifest-path "$dir/Cargo.toml" --config "$dir/allowed-external-types.toml" || exit 1
 done
 
 echo "The Cargo workspace is compliant with the 'allowed external types' policies."


### PR DESCRIPTION
The latest Rust toolchain requires to update the [cargo-check-external-types](https://github.com/awslabs/cargo-check-external-types) dependencies.