### PR TITLE
Upgrade otel API used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,20 +2825,6 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opentelemetry"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
@@ -4721,7 +4707,7 @@ version = "0.10.0"
 dependencies = [
  "dirs",
  "miette",
- "opentelemetry 0.23.0",
+ "opentelemetry 0.26.0",
  "walkdir",
  "weaver_cache",
  "weaver_common",
@@ -4770,7 +4756,7 @@ dependencies = [
  "miette",
  "minijinja",
  "minijinja-contrib",
- "opentelemetry 0.23.0",
+ "opentelemetry 0.26.0",
  "opentelemetry-stdout",
  "opentelemetry_sdk 0.27.0",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ tempdir = "0.3.7"
 schemars = "0.8.21"
 dirs = "5.0.1"
 once_cell = "1.20.2"
-opentelemetry = { version = "0.23.0", features = ["trace", "metrics", "logs", "otel_unstable"] }
+opentelemetry = { version = "0.26.0", features = ["trace", "metrics", "logs", "otel_unstable"] }
 rouille = "3.6.2"
 
 # Features definition =========================================================

--- a/crates/weaver_codegen_test/templates/registry/rust/metrics/mod.rs.j2
+++ b/crates/weaver_codegen_test/templates/registry/rust/metrics/mod.rs.j2
@@ -27,7 +27,7 @@ impl HistogramProvider<u64> for opentelemetry::metrics::Meter {
     fn create_histogram(&self, name: &'static str, description: &'static str, unit: &'static str) -> opentelemetry::metrics::Histogram<u64> {
         self.u64_histogram(name)
             .with_description(description)
-            .with_unit(opentelemetry::metrics::Unit::new(unit))
+            .with_unit(unit)
             .init()
     }
 }
@@ -38,7 +38,7 @@ impl HistogramProvider<f64> for opentelemetry::metrics::Meter {
     fn create_histogram(&self, name: &'static str, description: &'static str, unit: &'static str) -> opentelemetry::metrics::Histogram<f64> {
         self.f64_histogram(name)
             .with_description(description)
-            .with_unit(opentelemetry::metrics::Unit::new(unit))
+            .with_unit(unit)
             .init()
     }
 }
@@ -55,7 +55,7 @@ impl UpDownCounterProvider<i64> for opentelemetry::metrics::Meter {
     fn create_up_down_counter(&self, name: &'static str, description: &'static str, unit: &'static str) -> opentelemetry::metrics::UpDownCounter<i64> {
         self.i64_up_down_counter(name)
             .with_description(description)
-            .with_unit(opentelemetry::metrics::Unit::new(unit))
+            .with_unit(unit)
             .init()
     }
 }
@@ -66,7 +66,7 @@ impl UpDownCounterProvider<f64> for opentelemetry::metrics::Meter {
     fn create_up_down_counter(&self, name: &'static str, description: &'static str, unit: &'static str) -> opentelemetry::metrics::UpDownCounter<f64> {
         self.f64_up_down_counter(name)
             .with_description(description)
-            .with_unit(opentelemetry::metrics::Unit::new(unit))
+            .with_unit(unit)
             .init()
     }
 }
@@ -83,7 +83,7 @@ impl CounterProvider<u64> for opentelemetry::metrics::Meter {
     fn create_counter(&self, name: &'static str, description: &'static str, unit: &'static str) -> opentelemetry::metrics::Counter<u64> {
         self.u64_counter(name)
             .with_description(description)
-            .with_unit(opentelemetry::metrics::Unit::new(unit))
+            .with_unit(unit)
             .init()
     }
 }
@@ -94,7 +94,7 @@ impl CounterProvider<f64> for opentelemetry::metrics::Meter {
     fn create_counter(&self, name: &'static str, description: &'static str, unit: &'static str) -> opentelemetry::metrics::Counter<f64> {
         self.f64_counter(name)
             .with_description(description)
-            .with_unit(opentelemetry::metrics::Unit::new(unit))
+            .with_unit(unit)
             .init()
     }
 }
@@ -111,7 +111,7 @@ impl GaugeProvider<u64> for opentelemetry::metrics::Meter {
     fn create_gauge(&self, name: &'static str, description: &'static str, unit: &'static str) -> opentelemetry::metrics::Gauge<u64> {
         self.u64_gauge(name)
             .with_description(description)
-            .with_unit(opentelemetry::metrics::Unit::new(unit))
+            .with_unit(unit)
             .init()
     }
 }
@@ -122,7 +122,7 @@ impl GaugeProvider<i64> for opentelemetry::metrics::Meter {
     fn create_gauge(&self, name: &'static str, description: &'static str, unit: &'static str) -> opentelemetry::metrics::Gauge<i64> {
         self.i64_gauge(name)
             .with_description(description)
-            .with_unit(opentelemetry::metrics::Unit::new(unit))
+            .with_unit(unit)
             .init()
     }
 }
@@ -133,7 +133,7 @@ impl GaugeProvider<f64> for opentelemetry::metrics::Meter {
     fn create_gauge(&self, name: &'static str, description: &'static str, unit: &'static str) -> opentelemetry::metrics::Gauge<f64> {
         self.f64_gauge(name)
             .with_description(description)
-            .with_unit(opentelemetry::metrics::Unit::new(unit))
+            .with_unit(unit)
             .init()
     }
 }


### PR DESCRIPTION
the `Unit` type in otel metrics was removed for a `Cow`

Replaces #402 