### PR TITLE
Update rust builder image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 # The build image
-FROM rust:1.78.0-alpine3.18 AS weaver-build
+FROM rust:1.82.0-alpine3.20 AS weaver-build
 RUN apk add musl-dev
 WORKDIR /build
 


### PR DESCRIPTION
Looks like dependabot cannnot find updates to rust given we're using the alpine tag and not a simpler version tag.