### PR TITLE
[WIP] Add symlink parameter

### DIFF
--- a/crates/weaver_codegen_test/build.rs
+++ b/crates/weaver_codegen_test/build.rs
@@ -22,10 +22,12 @@ use weaver_forge::{OutputDirective, TemplateEngine, SEMCONV_JQ};
 use weaver_resolver::SchemaResolver;
 use weaver_semconv::registry::SemConvRegistry;
 
+
 const SEMCONV_REGISTRY_PATH: &str = "./semconv_registry/";
 const TEMPLATES_PATH: &str = "./templates/registry/";
 const REGISTRY_ID: &str = "test";
 const TARGET: &str = "rust";
+const FOLLOW_SYMLINKS: bool = false;
 
 fn main() {
     // Tell Cargo when to rerun this build script
@@ -45,7 +47,7 @@ fn main() {
     };
     let registry_repo =
         RegistryRepo::try_new("main", &registry_path).unwrap_or_else(|e| process_error(&logger, e));
-    let semconv_specs = SchemaResolver::load_semconv_specs(&registry_repo)
+    let semconv_specs = SchemaResolver::load_semconv_specs(&registry_repo,FOLLOW_SYMLINKS)
         .ignore(|e| matches!(e.severity(), Some(miette::Severity::Warning)))
         .into_result_failing_non_fatal()
         .unwrap_or_else(|e| process_error(&logger, e));

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -238,10 +238,12 @@ impl SchemaResolver {
     /// * `registry_repo` - The registry repository containing the semantic convention files.
     pub fn load_semconv_specs(
         registry_repo: &RegistryRepo,
+        follow_symlinks: bool,
     ) -> WResult<Vec<(String, SemConvSpec)>, weaver_semconv::Error> {
         Self::load_semconv_from_local_path(
             registry_repo.path().to_path_buf(),
             registry_repo.registry_path_repr(),
+            follow_symlinks,
         )
     }
 
@@ -255,6 +257,7 @@ impl SchemaResolver {
     fn load_semconv_from_local_path(
         local_path: PathBuf,
         registry_path_repr: &str,
+        follow_symlinks: bool,
     ) -> WResult<Vec<(String, SemConvSpec)>, weaver_semconv::Error> {
         fn is_hidden(entry: &DirEntry) -> bool {
             entry
@@ -276,6 +279,7 @@ impl SchemaResolver {
         // All yaml files are recursively loaded and parsed in parallel from
         // the given path.
         let result = walkdir::WalkDir::new(local_path.clone())
+            .follow_links(follow_symlinks)
             .into_iter()
             .filter_entry(|e| !is_hidden(e))
             .par_bridge()

--- a/crates/weaver_semconv_gen/src/lib.rs
+++ b/crates/weaver_semconv_gen/src/lib.rs
@@ -307,8 +307,9 @@ impl SnippetGenerator {
         registry_repo: &RegistryRepo,
         template_engine: TemplateEngine,
         diag_msgs: &mut DiagnosticMessages,
+        follow_symlinks: bool,
     ) -> Result<SnippetGenerator, Error> {
-        let registry = ResolvedSemconvRegistry::try_from_registry_repo(registry_repo, diag_msgs)?;
+        let registry = ResolvedSemconvRegistry::try_from_registry_repo(registry_repo, diag_msgs, follow_symlinks)?;
         Ok(SnippetGenerator {
             lookup: registry,
             template_engine,
@@ -327,9 +328,10 @@ impl ResolvedSemconvRegistry {
     fn try_from_registry_repo(
         registry_repo: &RegistryRepo,
         diag_msgs: &mut DiagnosticMessages,
+        follow_symlinks: bool,
     ) -> Result<ResolvedSemconvRegistry, Error> {
         let registry_id = "semantic_conventions";
-        let semconv_specs = SchemaResolver::load_semconv_specs(registry_repo)
+        let semconv_specs = SchemaResolver::load_semconv_specs(registry_repo, follow_symlinks)
             .capture_non_fatal_errors(diag_msgs)?;
         let mut registry = SemConvRegistry::from_semconv_specs(registry_id, semconv_specs);
         let schema = SchemaResolver::resolve_semantic_convention_registry(&mut registry)?;
@@ -383,7 +385,7 @@ mod tests {
         let mut diag_msgs = DiagnosticMessages::empty();
         let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
         let generator =
-            SnippetGenerator::try_from_registry_repo(&registry_repo, template, &mut diag_msgs)?;
+            SnippetGenerator::try_from_registry_repo(&registry_repo, template, &mut diag_msgs, false)?;
         let attribute_registry_url = "/docs/attributes-registry";
         // Now we should check a snippet.
         let test = "data/templates.md";

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,18 @@ impl Default for DiagnosticArgs {
     }
 }
 
+/// Set of Parameters used to specify the extra options for the `weaver` command.
+/// The WeaverArgs will be shared across all commands. So only the general options should be
+/// included here.
+#[derive(Args, Debug)]
+pub struct WeaverArgs {
+   /// Boolean flag to specify whether to follow symlinks when loading the registry.
+   /// Default is false.
+    #[arg(short, long)]
+    pub(crate) follow_symlinks: bool,
+   
+}
+
 /// Result of a command execution.
 #[derive(Debug)]
 pub(crate) struct CmdResult {

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -19,7 +19,7 @@ use weaver_semconv::registry::SemConvRegistry;
 
 use crate::registry::{Error, RegistryArgs};
 use crate::util::{check_policy, init_policy_engine, load_semconv_specs, resolve_semconv_specs};
-use crate::{registry, DiagnosticArgs, ExitDirectives};
+use crate::{registry, DiagnosticArgs, ExitDirectives, WeaverArgs};
 
 /// Parameters for the `registry generate` sub-command
 #[derive(Debug, Args)]
@@ -73,6 +73,10 @@ pub struct RegistryGenerateArgs {
     /// Parameters to specify the diagnostic format.
     #[command(flatten)]
     pub diagnostic: DiagnosticArgs,
+
+    /// Weaver parameters
+    #[command(flatten)]
+    pub weaver_args: WeaverArgs,
 }
 
 /// Utility function to parse key-value pairs from the command line.
@@ -114,7 +118,7 @@ pub(crate) fn command(
     let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
 
     // Load the semantic convention registry into a local cache.
-    let semconv_specs = load_semconv_specs(&registry_repo, logger.clone())
+    let semconv_specs = load_semconv_specs(&registry_repo, logger.clone(),args.weaver_args.follow_symlinks)
         .ignore(|e| matches!(e.severity(), Some(miette::Severity::Warning)))
         .into_result_failing_non_fatal()?;
 
@@ -210,7 +214,7 @@ mod tests {
     use crate::cli::{Cli, Commands};
     use crate::registry::generate::RegistryGenerateArgs;
     use crate::registry::{RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand};
-    use crate::run_command;
+    use crate::{run_command, WeaverArgs};
 
     #[test]
     fn test_registry_generate() {
@@ -240,6 +244,9 @@ mod tests {
                     skip_policies: true,
                     future: false,
                     diagnostic: Default::default(),
+                    weaver_args: WeaverArgs {
+                        follow_symlinks: false,
+                    },
                 }),
             })),
         };
@@ -312,6 +319,9 @@ mod tests {
                     skip_policies: false,
                     future: false,
                     diagnostic: Default::default(),
+                    weaver_args: WeaverArgs {
+                        follow_symlinks: false,
+                    },
                 }),
             })),
         };
@@ -356,6 +366,9 @@ mod tests {
                     skip_policies: true,
                     future: false,
                     diagnostic: Default::default(),
+                    weaver_args: WeaverArgs {
+                        follow_symlinks: false,
+                    },
                 }),
             })),
         };

--- a/src/registry/resolve.rs
+++ b/src/registry/resolve.rs
@@ -15,7 +15,7 @@ use weaver_semconv::registry::SemConvRegistry;
 use crate::format::{apply_format, Format};
 use crate::registry::RegistryArgs;
 use crate::util::{check_policy, init_policy_engine, load_semconv_specs, resolve_semconv_specs};
-use crate::{registry, DiagnosticArgs, ExitDirectives};
+use crate::{registry, DiagnosticArgs, ExitDirectives, WeaverArgs};
 use miette::Diagnostic;
 
 /// Parameters for the `registry resolve` sub-command
@@ -56,6 +56,10 @@ pub struct RegistryResolveArgs {
     /// Parameters to specify the diagnostic format.
     #[command(flatten)]
     pub diagnostic: DiagnosticArgs,
+
+    // Weaver parameters
+    #[command(flatten)]
+    pub weaver_args: WeaverArgs,
 }
 
 /// Resolve a semantic convention registry and write the resolved schema to a
@@ -82,7 +86,7 @@ pub(crate) fn command(
     let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
 
     // Load the semantic convention registry into a local cache.
-    let semconv_specs = load_semconv_specs(&registry_repo, logger.clone())
+    let semconv_specs = load_semconv_specs(&registry_repo, logger.clone(), args.weaver_args.follow_symlinks)
         .ignore(|e| matches!(e.severity(), Some(miette::Severity::Warning)))
         .into_result_failing_non_fatal()?;
 
@@ -151,7 +155,7 @@ mod tests {
     use crate::format::Format;
     use crate::registry::resolve::RegistryResolveArgs;
     use crate::registry::{RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand};
-    use crate::run_command;
+    use crate::{run_command, WeaverArgs};
 
     #[test]
     fn test_registry_resolve() {
@@ -174,6 +178,9 @@ mod tests {
                     policies: vec![],
                     skip_policies: true,
                     diagnostic: Default::default(),
+                    weaver_args: WeaverArgs {
+                        follow_symlinks: false,
+                    },
                 }),
             })),
         };
@@ -201,6 +208,9 @@ mod tests {
                     policies: vec![],
                     skip_policies: false,
                     diagnostic: Default::default(),
+                    weaver_args: WeaverArgs {
+                        follow_symlinks: false,
+                    },
                 }),
             })),
         };

--- a/src/registry/search.rs
+++ b/src/registry/search.rs
@@ -15,7 +15,7 @@ use crate::{
     registry,
     registry::RegistryArgs,
     util::{load_semconv_specs, resolve_semconv_specs},
-    DiagnosticArgs, ExitDirectives,
+    DiagnosticArgs, ExitDirectives, WeaverArgs
 };
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
@@ -52,6 +52,10 @@ pub struct RegistrySearchArgs {
     /// An (optional) search string to use.  If specified, will return matching values on the command line.
     /// Otherwise, runs an interactive terminal UI.
     pub search_string: Option<String>,
+
+    /// Weaver parameters
+    #[command(flatten)]
+    pub weaver_args: WeaverArgs,
 }
 
 #[derive(thiserror::Error, Debug, serde::Serialize, Diagnostic)]
@@ -388,7 +392,7 @@ pub(crate) fn command(
     let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
 
     // Load the semantic convention registry into a local cache.
-    let semconv_specs = load_semconv_specs(&registry_repo, logger.clone())
+    let semconv_specs = load_semconv_specs(&registry_repo, logger.clone(), args.weaver_args.follow_symlinks)
         .ignore(|e| matches!(e.severity(), Some(miette::Severity::Warning)))
         .into_result_failing_non_fatal()?;
     let mut registry = SemConvRegistry::from_semconv_specs(registry_id, semconv_specs);

--- a/src/registry/stats.rs
+++ b/src/registry/stats.rs
@@ -4,7 +4,7 @@
 
 use crate::registry::RegistryArgs;
 use crate::util::{load_semconv_specs, resolve_semconv_specs};
-use crate::{registry, DiagnosticArgs, ExitDirectives};
+use crate::{registry, DiagnosticArgs, ExitDirectives, WeaverArgs};
 use clap::Args;
 use miette::Diagnostic;
 use weaver_cache::RegistryRepo;
@@ -25,6 +25,10 @@ pub struct RegistryStatsArgs {
     /// Parameters to specify the diagnostic format.
     #[command(flatten)]
     pub diagnostic: DiagnosticArgs,
+
+    /// Weaver parameters
+    #[command(flatten)]
+    pub weaver_args: WeaverArgs,
 }
 
 /// Compute stats on a semantic convention registry.
@@ -48,7 +52,7 @@ pub(crate) fn command(
     let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
 
     // Load the semantic convention registry into a local cache.
-    let semconv_specs = load_semconv_specs(&registry_repo, logger.clone())
+    let semconv_specs = load_semconv_specs(&registry_repo, logger.clone(),args.weaver_args.follow_symlinks)
         .ignore(|e| matches!(e.severity(), Some(miette::Severity::Warning)))
         .into_result_failing_non_fatal()?;
     let mut registry = SemConvRegistry::from_semconv_specs(registry_id, semconv_specs);

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -4,7 +4,7 @@
 //! update the specified sections.
 
 use crate::registry::RegistryArgs;
-use crate::{registry, DiagnosticArgs, ExitDirectives};
+use crate::{registry, DiagnosticArgs, ExitDirectives, WeaverArgs};
 use clap::Args;
 use weaver_cache::RegistryRepo;
 use weaver_common::diagnostic::{is_future_mode_enabled, DiagnosticMessages};
@@ -49,6 +49,10 @@ pub struct RegistryUpdateMarkdownArgs {
     /// Parameters to specify the diagnostic format.
     #[command(flatten)]
     pub diagnostic: DiagnosticArgs,
+
+    /// Weaver parameters
+    #[command(flatten)]
+    pub weaver_args: WeaverArgs,
 }
 
 /// Update markdown files.
@@ -85,7 +89,7 @@ pub(crate) fn command(
     }
     let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
     let generator =
-        SnippetGenerator::try_from_registry_repo(&registry_repo, generator, &mut diag_msgs)?;
+        SnippetGenerator::try_from_registry_repo(&registry_repo, generator, &mut diag_msgs, args.weaver_args.follow_symlinks)?;
 
     if is_future_mode_enabled() && !diag_msgs.is_empty() {
         // If we are in future mode and there are diagnostics, return them
@@ -139,7 +143,7 @@ mod tests {
     use crate::cli::{Cli, Commands};
     use crate::registry::update_markdown::RegistryUpdateMarkdownArgs;
     use crate::registry::{RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand};
-    use crate::run_command;
+    use crate::{run_command, WeaverArgs};
 
     #[test]
     fn test_registry_update_markdown() {
@@ -162,6 +166,9 @@ mod tests {
                     templates: "data/update_markdown/templates".to_owned(),
                     diagnostic: Default::default(),
                     target: "markdown".to_owned(),
+                    weaver_args: WeaverArgs {
+                        follow_symlinks: false,
+                    },
                 }),
             })),
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -33,7 +33,7 @@ pub(crate) fn load_semconv_specs(
     log: impl Logger + Sync + Clone,
     follow_symlinks: bool,
 ) -> WResult<Vec<(String, SemConvSpec)>, weaver_semconv::Error> {
-    SchemaResolver::load_semconv_specs(registry_repo,).inspect(|semconv_specs, _| {
+    SchemaResolver::load_semconv_specs(registry_repo,follow_symlinks).inspect(|semconv_specs, _| {
         log.success(&format!(
             "`{}` semconv registry `{}` loaded ({} files)",
             registry_repo.id(),

--- a/src/util.rs
+++ b/src/util.rs
@@ -31,8 +31,9 @@ use weaver_semconv::semconv::SemConvSpec;
 pub(crate) fn load_semconv_specs(
     registry_repo: &RegistryRepo,
     log: impl Logger + Sync + Clone,
+    follow_symlinks: bool,
 ) -> WResult<Vec<(String, SemConvSpec)>, weaver_semconv::Error> {
-    SchemaResolver::load_semconv_specs(registry_repo).inspect(|semconv_specs, _| {
+    SchemaResolver::load_semconv_specs(registry_repo,).inspect(|semconv_specs, _| {
         log.success(&format!(
             "`{}` semconv registry `{}` loaded ({} files)",
             registry_repo.id(),

--- a/tests/resolution_process.rs
+++ b/tests/resolution_process.rs
@@ -17,6 +17,7 @@ const SEMCONV_REGISTRY_URL: &str = "https://github.com/open-telemetry/semantic-c
 /// The directory name of the official semantic convention registry.
 const SEMCONV_REGISTRY_MODEL: &str = "model";
 
+
 /// This test checks the CLI interface for the registry generate command.
 /// This test doesn't count for the coverage report as it runs a separate process.
 ///
@@ -41,7 +42,7 @@ fn test_cli_interface() {
     let registry_repo = RegistryRepo::try_new("main", &registry_path).unwrap_or_else(|e| {
         panic!("Failed to create the registry repo, error: {e}");
     });
-    let semconv_specs = SchemaResolver::load_semconv_specs(&registry_repo)
+    let semconv_specs = SchemaResolver::load_semconv_specs(&registry_repo, false)
         .ignore(|e| matches!(e.severity(), Some(miette::Severity::Warning)))
         .into_result_failing_non_fatal()
         .unwrap_or_else(|e| {


### PR DESCRIPTION
fixes #441 

**Summary of the change I have made:**
Added an option to follow symbolic links when loading the registry in various parts of the codebase. The primary change is the addition of a `follow_symlinks` parameter, which is passed through multiple functions and structures to control this behavior.

Key changes include:

- Added `follow_symlinks` param as `WeaverArg`  across `SchemaResolver`, `SnippetGenerator`, and `ResolvedSemconvRegistry` to enable optional symbolic link following during registry operations.
-The `WeaverArgs` struct impacted various commands (`check`, `generate`, `resolve`, `update-markdown`, `stats`) to include and handle the `follow_symlinks` option.
- Modified `SchemaResolver` to configure `walkdir::WalkDir` with the `follow_symlinks` parameter and use the `follow_links function`.
- Modified the existing tests so that they will default to use `follow_symlinks` = false.

**The ideal outcome would be:**
After running the command
```
weaver registry generate -r ./semantic-conventions/model -t ./semantic-conventions/templates markdown -f
```
weaver will read symbolic linked folders under `sementic-conventions/model` and generate the artifacts.


PS: I try to raise this PR first to get some early feedback. As I am new to Rust and Otel, I am open to suggestions and feedback.