### PR TITLE
chore(deps): bump to otel 0.27.x.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,20 +2875,6 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opentelemetry"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f3cebff57f7dbd1255b44d8bddc2cebeb0ea677dbaa2e25a3070a91b318f660"
@@ -2910,7 +2896,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures-util",
- "opentelemetry 0.27.0",
+ "opentelemetry",
  "opentelemetry_sdk",
  "ordered-float",
  "serde",
@@ -2930,7 +2916,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.27.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
@@ -4733,7 +4719,7 @@ version = "0.10.0"
 dependencies = [
  "dirs",
  "miette",
- "opentelemetry 0.26.0",
+ "opentelemetry",
  "walkdir",
  "weaver_cache",
  "weaver_common",
@@ -4783,7 +4769,7 @@ dependencies = [
  "miette",
  "minijinja",
  "minijinja-contrib",
- "opentelemetry 0.26.0",
+ "opentelemetry",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ tempdir = "0.3.7"
 schemars = "0.8.21"
 dirs = "5.0.1"
 once_cell = "1.20.2"
-opentelemetry = { version = "0.26.0", features = ["trace", "metrics", "logs", "otel_unstable"] }
+opentelemetry = { version = "0.27.0", features = ["trace", "metrics", "logs", "otel_unstable"] }
 rouille = "3.6.2"
 
 # Features definition =========================================================

--- a/crates/weaver_codegen_test/templates/registry/rust/metrics/mod.rs.j2
+++ b/crates/weaver_codegen_test/templates/registry/rust/metrics/mod.rs.j2
@@ -28,7 +28,7 @@ impl HistogramProvider<u64> for opentelemetry::metrics::Meter {
         self.u64_histogram(name)
             .with_description(description)
             .with_unit(unit)
-            .init()
+            .build()
     }
 }
 
@@ -39,7 +39,7 @@ impl HistogramProvider<f64> for opentelemetry::metrics::Meter {
         self.f64_histogram(name)
             .with_description(description)
             .with_unit(unit)
-            .init()
+            .build()
     }
 }
 
@@ -56,7 +56,7 @@ impl UpDownCounterProvider<i64> for opentelemetry::metrics::Meter {
         self.i64_up_down_counter(name)
             .with_description(description)
             .with_unit(unit)
-            .init()
+            .build()
     }
 }
 
@@ -67,7 +67,7 @@ impl UpDownCounterProvider<f64> for opentelemetry::metrics::Meter {
         self.f64_up_down_counter(name)
             .with_description(description)
             .with_unit(unit)
-            .init()
+            .build()
     }
 }
 
@@ -84,7 +84,7 @@ impl CounterProvider<u64> for opentelemetry::metrics::Meter {
         self.u64_counter(name)
             .with_description(description)
             .with_unit(unit)
-            .init()
+            .build()
     }
 }
 
@@ -95,7 +95,7 @@ impl CounterProvider<f64> for opentelemetry::metrics::Meter {
         self.f64_counter(name)
             .with_description(description)
             .with_unit(unit)
-            .init()
+            .build()
     }
 }
 
@@ -112,7 +112,7 @@ impl GaugeProvider<u64> for opentelemetry::metrics::Meter {
         self.u64_gauge(name)
             .with_description(description)
             .with_unit(unit)
-            .init()
+            .build()
     }
 }
 
@@ -123,7 +123,7 @@ impl GaugeProvider<i64> for opentelemetry::metrics::Meter {
         self.i64_gauge(name)
             .with_description(description)
             .with_unit(unit)
-            .init()
+            .build()
     }
 }
 
@@ -134,6 +134,6 @@ impl GaugeProvider<f64> for opentelemetry::metrics::Meter {
         self.f64_gauge(name)
             .with_description(description)
             .with_unit(unit)
-            .init()
+            .build()
     }
 }


### PR DESCRIPTION
Otel metrics had a breaking change: init() => build()

Replaces #465 