### PR TITLE
Ensure docker image is built on every pull request to main.

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -7,11 +7,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - .github/workflows/publish-docker.yml
-      - 'src/**'
-      - 'crates/**'
-      - Dockerfile
 env:
   TEST_WEAVER_TAG: otel/weaver:test
 jobs:


### PR DESCRIPTION
This is so we can enforce docker image builds successfully on PRs.

Given Docker is a primary mechanism of distributing weaver, we should guarantee it builds on PRs.