### PR TITLE
prepare for 0.11.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,20 @@ All notable changes to this project will be documented in this file.
 
 What's changed
 
+## [0.11.0] - 2024-12-05
+
+What's changed
+
 * Detect duplicate group ids, group names, and metric names. ([#382](https://github.com/open-telemetry/weaver/pull/382) by lquerel).
 * Add support for Maps `map[]` to the definition of an `AnyValue`. ([#396](https://github.com/open-telemetry/weaver/pull/396) by @MSNev).
 * Update semconv schema, syntax doc and validity check to correctly define `stability` as optional for attribute groups. ([#467](https://github.com/open-telemetry/weaver/pull/467) by @jerbly).
 * Fix issue [#405](https://github.com/open-telemetry/weaver/issues/405) - Updated the EBNF and JSON schema to define the `extends` or `attributes` requirement mandatory for all group types except `metric` and `event`. Added a group validity check as a warning. ([#494](https://github.com/open-telemetry/weaver/pull/494) by @jerbly).
+* Allow adding a description when using opt_in requirement level ([#392](https://github.com/open-telemetry/weaver/pull/392) by @joaopgrassi)
+* Add warning that issues when using prefix on groups ([#407](https://github.com/open-telemetry/weaver/pull/407) by @jsuereth)
+* Update comment filter to remove trailing spaces ([#453](https://github.com/open-telemetry/weaver/pull/453) by @jsuereth)
+* Metrics and Events don't require attributes ([#494](https://github.com/open-telemetry/weaver/pull/494) by @jerbly)
+* Added an option to follow symbolic links when loading the registry in various parts of the codebase. ([#468](https://github.com/open-telemetry/weaver/pull/468) by @leo6leo)
+* Provide max line-length in comment filter. ([#454](https://github.com/open-telemetry/weaver/pull/454) by @jsuereth)
 
 ## [0.10.0] - 2024-09-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4648,7 +4648,7 @@ dependencies = [
 
 [[package]]
 name = "weaver"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4679,7 +4679,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_cache"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "dirs",
  "flate2",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_checker"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "globset",
  "miette",
@@ -4715,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_codegen_test"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "dirs",
  "miette",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_common"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "miette",
  "paris",
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_diff"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde_json",
  "similar",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_forge"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "convert_case",
  "dirs",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_resolved_schema"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ordered-float",
  "schemars",
@@ -4803,7 +4803,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_resolver"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "glob",
  "itertools 0.13.0",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_semconv"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "glob",
  "miette",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_semconv_gen"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "miette",
  "nom",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_version"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "schemars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver"
-version = "0.10.0"
+version.workspace = true
 authors = ["OpenTelemetry"]
 edition = "2021"
 repository = "https://github.com/open-telemetry/weaver"
@@ -28,6 +28,7 @@ members = [
 ]
 
 [workspace.package]
+version = "0.11.0"
 authors = ["OpenTelemetry"]
 edition = "2021"
 repository = "https://github.com/open-telemetry/weaver"

--- a/crates/weaver_cache/Cargo.toml
+++ b/crates/weaver_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_cache"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/weaver_checker/Cargo.toml
+++ b/crates/weaver_checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_checker"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/weaver_codegen_test/Cargo.toml
+++ b/crates/weaver_codegen_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_codegen_test"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/weaver_common/Cargo.toml
+++ b/crates/weaver_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_common"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/weaver_diff/Cargo.toml
+++ b/crates/weaver_diff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_diff"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/weaver_forge/Cargo.toml
+++ b/crates/weaver_forge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_forge"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/weaver_resolved_schema/Cargo.toml
+++ b/crates/weaver_resolved_schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_resolved_schema"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/weaver_resolver/Cargo.toml
+++ b/crates/weaver_resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_resolver"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/weaver_semconv/Cargo.toml
+++ b/crates/weaver_semconv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_semconv"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/weaver_semconv_gen/Cargo.toml
+++ b/crates/weaver_semconv_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_semconv_gen"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/weaver_version/Cargo.toml
+++ b/crates/weaver_version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weaver_version"
-version = "0.10.0"
+version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
Note: I updated the versions in crates to use the workspace version.  We can opt-out of using the global version on a per-crate basis if needed later.