### PR TITLE
build: add cross-compile support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,8 @@
 [alias]
 xtask = "run --package xtask --bin xtask --"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.x86_64-unknown-linux-gnu]
+linker = "x86_64-linux-gnu-gcc"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
 [alias]
 xtask = "run --package xtask --bin xtask --"
 
-[target.aarch64-unknown-linux-gnu]
+[target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-gnu-gcc"
 
-[target.x86_64-unknown-linux-gnu]
+[target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-gnu-gcc"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 # Rust related build artifacts.
 /target
-.cargo/
 wix/
 scripts/
 examples/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN addgroup weaver \
   --disabled-password \
   weaver
 WORKDIR /home/weaver
-COPY --from=weaver-build /build/weaver /weaver/weaver
+COPY --from=weaver-build --chown=weaver:weaver /build/weaver /weaver/weaver
 USER weaver
 RUN mkdir /home/weaver/target
 ENTRYPOINT ["/weaver/weaver"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,25 @@
-
 # The build image
-FROM rust:1.83.0-alpine3.20 AS weaver-build
-RUN apk add musl-dev
+FROM --platform=$BUILDPLATFORM docker.io/rust:1.83.0 AS weaver-build
 WORKDIR /build
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 # list out directories to avoid pulling local cargo `target/`
 COPY Cargo.toml /build/Cargo.toml
 COPY Cargo.lock /build/Cargo.lock
+COPY .cargo /build/.cargo
 COPY crates /build/crates
 COPY data /build/data
 COPY src /build/src
 COPY tests /build/tests
 COPY defaults /build/defaults
+COPY cross-arch-build.sh /build/cross-arch-build.sh
 
 # Build weaver
-RUN cargo build --release
+RUN ./cross-arch-build.sh
 
 # The runtime image
-FROM alpine:3.20.3
+FROM docker.io/alpine:3.20.3
 LABEL maintainer="The OpenTelemetry Authors"
 RUN addgroup weaver \
   && adduser \
@@ -25,7 +27,7 @@ RUN addgroup weaver \
   --disabled-password \
   weaver
 WORKDIR /home/weaver
-COPY --from=weaver-build /build/target/release/weaver /weaver/weaver
+COPY --from=weaver-build /build/weaver /weaver/weaver
 USER weaver
 RUN mkdir /home/weaver/target
 ENTRYPOINT ["/weaver/weaver"]

--- a/cross-arch-build.sh
+++ b/cross-arch-build.sh
@@ -1,0 +1,20 @@
+set -exu
+
+if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then
+  RUST_TARGET=x86_64-unknown-linux-gnu
+  if [ "${TARGETPLATFORM}" != "${BUILDPLATFORM}" ]; then
+    apt-get update && apt-get install -y gcc-x86-64-linux-gnu
+  fi
+elif [ "${TARGETPLATFORM}" = "linux/arm64" ]; then
+  RUST_TARGET=aarch64-unknown-linux-gnu
+  if [ "${TARGETPLATFORM}" != "${BUILDPLATFORM}" ]; then
+    apt-get update && apt-get install -y gcc-aarch64-linux-gnu
+  fi
+else
+  echo "Unsupported target platform: ${TARGETPLATFORM}"
+  exit 1
+fi
+
+rustup target add "${RUST_TARGET}"
+cargo build --release --target="${RUST_TARGET}"
+cp "target/${RUST_TARGET}/release/weaver" .

--- a/cross-arch-build.sh
+++ b/cross-arch-build.sh
@@ -1,12 +1,12 @@
 set -exu
 
 if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then
-  RUST_TARGET=x86_64-unknown-linux-gnu
+  RUST_TARGET=x86_64-unknown-linux-musl
   if [ "${TARGETPLATFORM}" != "${BUILDPLATFORM}" ]; then
     apt-get update && apt-get install -y gcc-x86-64-linux-gnu
   fi
 elif [ "${TARGETPLATFORM}" = "linux/arm64" ]; then
-  RUST_TARGET=aarch64-unknown-linux-gnu
+  RUST_TARGET=aarch64-unknown-linux-musl
   if [ "${TARGETPLATFORM}" != "${BUILDPLATFORM}" ]; then
     apt-get update && apt-get install -y gcc-aarch64-linux-gnu
   fi


### PR DESCRIPTION
The build currently relies on QEMU emulation for arm64 builds (#346). [This is slow](https://blog.bernot.io/qemu).

This change uses Rust's ability to cross-compile for different platforms instead of relying on emulation, resulting in much faster builds.

Expected improvement is from [≈1h25m](https://github.com/open-telemetry/weaver/actions/runs/12184896455/job/33989858643) to <10m. Local cross-platform builds took about 3-7 minutes for me.