### PR TITLE
Add javadoc <p> tag after lists

### DIFF
--- a/crates/weaver_forge/README.md
+++ b/crates/weaver_forge/README.md
@@ -767,6 +767,7 @@ The resulting comment in JavaDoc format would be:
    * adipiscing elit sed do eiusmod tempor
    * incididunt ut labore et dolore magna aliqua.
    * </ul>
+   * <p>
    * And an <strong>inline code snippet</strong>: {@code Attr.attr}.
    * <h1>Summary</h1>
    * <h2>Examples</h2>

--- a/crates/weaver_forge/expected_output/comment_format/example.java
+++ b/crates/weaver_forge/expected_output/comment_format/example.java
@@ -64,6 +64,7 @@
    *   <li>Use a domain-specific attribute
    *   <li>Set {@code error.type} to capture all errors, regardless of whether they are defined within the domain-specific set or not
    * </ul>
+   * <p>
    * And something more
    */
   static ERROR_TYPE = "";
@@ -87,6 +88,7 @@
    * adipiscing elit sed do eiusmod tempor
    * incididunt ut labore et dolore magna aliqua.
    * </ul>
+   * <p>
    * And an <strong>inline code snippet</strong>: {@code Attr.attr}.
    * <h1>Summary</h1>
    * <h2>Examples</h2>

--- a/crates/weaver_forge/src/extensions/code.rs
+++ b/crates/weaver_forge/src/extensions/code.rs
@@ -370,6 +370,7 @@ And something more..  "#;
    *   <li>Use a domain-specific attribute
    *   <li>Set {@code error.type} to capture all errors, regardless of whether they are defined within the domain-specific set or not
    * </ul>
+   * <p>
    * And something more
    */"##
         );
@@ -401,6 +402,7 @@ And something more..  "#;
    *   <li>Use a domain-specific attribute
    *   <li>Set {@code error.type} to capture all errors, regardless of whether they are defined within the domain-specific set or not
    * </ul>
+   * <p>
    * And something more
    */"##
         );
@@ -432,6 +434,7 @@ And something more..  "#;
    *   <li>Use a domain-specific attribute
    *   <li>Set {@code error.type} to capture all errors, regardless of whether they are defined within the domain-specific set or not
    * </ul>
+   * <p>
    * And something more
    */"##
         );
@@ -463,6 +466,7 @@ And something more..  "#;
 		 *   <li>Use a domain-specific attribute
 		 *   <li>Set {@code error.type} to capture all errors, regardless of whether they are defined within the domain-specific set or not
 		 * </ul>
+		 * <p>
 		 * And something more
 		 */"##
         );
@@ -523,6 +527,7 @@ And something more..  "#;
  *   are defined within the
  *   domain-specific set or not
  * </ul>
+ * <p>
  * And something more
  */"##
         );

--- a/crates/weaver_forge/src/formats/html.rs
+++ b/crates/weaver_forge/src/formats/html.rs
@@ -296,6 +296,9 @@ impl<'source> HtmlRenderer<'source> {
                 ctx.pushln(indent)?;
                 ctx.push_unbroken(&format!("</{}>", tag), indent)?;
                 ctx.add_newline = true;
+                if options.old_style_paragraph {
+                    ctx.add_old_style_paragraph = true;
+                }
             }
             Node::ListItem(item) => {
                 for child in &item.children {
@@ -564,6 +567,7 @@ it's RECOMMENDED to:
   <li>Use a domain-specific attribute
   <li>Set {@code error.type} to capture all errors, regardless of whether they are defined within the domain-specific set or not
 </ul>
+<p>
 And something more."##
         );
         Ok(())
@@ -792,6 +796,7 @@ RECOMMENDED to:
   are defined within the
   domain-specific set or not
 </ul>
+<p>
 And something more."##
         );
         Ok(())


### PR DESCRIPTION
This is the fix for the test cases added in #508.

The fix builds on top of the improvements in #509 and #510.

Here's the new semconv content that exposed this issue when updating to v1.29.0: https://github.com/open-telemetry/semantic-conventions-java/pull/118/files#r1872551505