### PR TITLE
Fixed rego typos, attrigute and deprecaded

### DIFF
--- a/crates/weaver_checker/README.md
+++ b/crates/weaver_checker/README.md
@@ -93,7 +93,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 
@@ -146,7 +146,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 
@@ -174,7 +174,7 @@ attr_registry_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute_registry",
+        "category": "attribute_registry",
         "group": group_id,
         "attr": attr_id,
     }
@@ -185,7 +185,7 @@ attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }
@@ -262,7 +262,7 @@ groups:
   {
     "type": "semconv_attribute",
     "id": "attr_stability_deprecated",
-    "category": "attrigute",
+    "category": "attribute",
     "group": "registry.network1",
     "attr": "protocol.name"
   },
@@ -276,7 +276,7 @@ groups:
   {
     "type": "semconv_attribute",
     "id": "registry_with_ref_attr",
-    "category": "attrigute_registry",
+    "category": "attribute_registry",
     "group": "registry.network1",
     "attr": "protocol.port"
   }

--- a/crates/weaver_checker/data/multi-policies/otel_policies.rego
+++ b/crates/weaver_checker/data/multi-policies/otel_policies.rego
@@ -22,7 +22,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 
@@ -50,7 +50,7 @@ attr_registry_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute_registry",
+        "category": "attribute_registry",
         "group": group_id,
         "attr": attr_id,
     }
@@ -61,7 +61,7 @@ attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }

--- a/crates/weaver_checker/data/multi-policies/otel_policies_2.rego
+++ b/crates/weaver_checker/data/multi-policies/otel_policies_2.rego
@@ -22,7 +22,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 
@@ -50,7 +50,7 @@ attr_registry_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute_registry",
+        "category": "attribute_registry",
         "group": group_id,
         "attr": attr_id,
     }
@@ -61,7 +61,7 @@ attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }

--- a/crates/weaver_checker/data/policies/invalid_policies.rego
+++ b/crates/weaver_checker/data/policies/invalid_policies.rego
@@ -22,7 +22,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 

--- a/crates/weaver_checker/data/policies/invalid_violation_object.rego
+++ b/crates/weaver_checker/data/policies/invalid_violation_object.rego
@@ -22,7 +22,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 

--- a/crates/weaver_checker/data/policies/otel_policies.rego
+++ b/crates/weaver_checker/data/policies/otel_policies.rego
@@ -22,7 +22,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 
@@ -50,7 +50,7 @@ attr_registry_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute_registry",
+        "category": "attribute_registry",
         "group": group_id,
         "attr": attr_id,
     }
@@ -61,7 +61,7 @@ attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }

--- a/crates/weaver_checker/data/registries/otel_policies.rego
+++ b/crates/weaver_checker/data/registries/otel_policies.rego
@@ -22,7 +22,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 
@@ -50,7 +50,7 @@ attr_registry_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute_registry",
+        "category": "attribute_registry",
         "group": group_id,
         "attr": attr_id,
     }
@@ -61,7 +61,7 @@ attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -484,7 +484,7 @@ mod tests {
         let expected_violations: HashMap<String, Violation> = vec![
             Violation::SemconvAttribute {
                 id: "attr_stability_deprecated".to_owned(),
-                category: "attrigute".to_owned(),
+                category: "attribute".to_owned(),
                 group: "registry.network1".to_owned(),
                 attr: "protocol.name".to_owned(),
             },
@@ -496,7 +496,7 @@ mod tests {
             },
             Violation::SemconvAttribute {
                 id: "registry_with_ref_attr".to_owned(),
-                category: "attrigute_registry".to_owned(),
+                category: "attribute_registry".to_owned(),
                 group: "registry.network1".to_owned(),
                 attr: "protocol.port".to_owned(),
             },
@@ -569,7 +569,7 @@ mod tests {
         let expected_violations: HashMap<String, Violation> = vec![
             Violation::SemconvAttribute {
                 id: "attr_stability_deprecated".to_owned(),
-                category: "attrigute".to_owned(),
+                category: "attribute".to_owned(),
                 group: "registry.network1".to_owned(),
                 attr: "protocol.name".to_owned(),
             },
@@ -581,7 +581,7 @@ mod tests {
             },
             Violation::SemconvAttribute {
                 id: "registry_with_ref_attr".to_owned(),
-                category: "attrigute_registry".to_owned(),
+                category: "attribute_registry".to_owned(),
                 group: "registry.network1".to_owned(),
                 attr: "protocol.port".to_owned(),
             },

--- a/crates/weaver_codegen_test/semconv_registry/http-post-resolution-policies.rego
+++ b/crates/weaver_codegen_test/semconv_registry/http-post-resolution-policies.rego
@@ -14,7 +14,7 @@ invalid_attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }

--- a/crates/weaver_codegen_test/semconv_registry/metrics-post-resolution-policies.rego
+++ b/crates/weaver_codegen_test/semconv_registry/metrics-post-resolution-policies.rego
@@ -14,7 +14,7 @@ invalid_attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }

--- a/crates/weaver_codegen_test/semconv_registry/otel-pre-resolution-policies.rego
+++ b/crates/weaver_codegen_test/semconv_registry/otel-pre-resolution-policies.rego
@@ -22,7 +22,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 
@@ -50,7 +50,7 @@ attr_registry_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute_registry",
+        "category": "attribute_registry",
         "group": group_id,
         "attr": attr_id,
     }
@@ -61,7 +61,7 @@ attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }

--- a/data/prev_registry/otel_policies.rego
+++ b/data/prev_registry/otel_policies.rego
@@ -22,7 +22,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 
@@ -50,7 +50,7 @@ attr_registry_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute_registry",
+        "category": "attribute_registry",
         "group": group_id,
         "attr": attr_id,
     }
@@ -61,7 +61,7 @@ attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }

--- a/data/registry/otel_policies.rego
+++ b/data/registry/otel_policies.rego
@@ -22,7 +22,7 @@ deny[attr_registry_violation("registry_with_ref_attr", group.id, attr.ref)] {
 deny[attr_violation("attr_stability_deprecated", group.id, attr.id)] {
     group := input.groups[_]
     attr := group.attributes[_]
-    attr.stability != "deprecaded"
+    attr.stability != "deprecated"
     attr.deprecated
 }
 
@@ -50,7 +50,7 @@ attr_registry_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute_registry",
+        "category": "attribute_registry",
         "group": group_id,
         "attr": attr_id,
     }
@@ -61,7 +61,7 @@ attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }

--- a/schemas/otel_policies.rego
+++ b/schemas/otel_policies.rego
@@ -62,7 +62,7 @@ attr_registry_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute_registry",
+        "category": "attribute_registry",
         "group": group_id,
         "attr": attr_id,
     }
@@ -73,7 +73,7 @@ attr_violation(violation_id, group_id, attr_id) = violation {
     violation := {
         "id": violation_id,
         "type": "semconv_attribute",
-        "category": "attrigute",
+        "category": "attribute",
         "group": group_id,
         "attr": attr_id,
     }


### PR DESCRIPTION
I noticed that in the examples and tests for rego there were two repeated typos:
* `attrigute` -> `attribute`
* `deprecaded` -> `deprecated`