### PR TITLE
Moving to JAQ 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,15 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chumsky"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
-dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2344,62 +2335,43 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jaq-core"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6fda09ee08c84c81293fdf811d9ebaa87b327557b5391f290c926d728c2ddd4"
+checksum = "d03ee1b714d63f0a5820131180056b592ecd400b32879c848e53e58707f19df0"
 dependencies = [
- "aho-corasick",
- "base64 0.22.1",
- "chrono",
- "hifijson",
- "jaq-interpret",
- "libm",
- "log",
- "regex",
- "urlencoding",
+ "dyn-clone",
+ "once_cell",
+ "typed-arena",
 ]
 
 [[package]]
-name = "jaq-interpret"
-version = "1.5.0"
+name = "jaq-json"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe95ec3c24af3fd9f3dd1091593f5e49b003a66c496a8aa39d764d0a06ae17b"
+checksum = "8daf2b52304419d7bf5ec32891884c65274a3eedc0b5834b84627099901a1176"
 dependencies = [
- "ahash",
- "dyn-clone",
+ "foldhash",
  "hifijson",
  "indexmap",
- "jaq-syn",
- "once_cell",
+ "jaq-core",
+ "jaq-std",
  "serde_json",
 ]
 
 [[package]]
-name = "jaq-parse"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0346d7d3146cdda8acd929581f3d6626a332356c74d5c95aeaffaac2eb6dee82"
-dependencies = [
- "chumsky",
- "jaq-syn",
-]
-
-[[package]]
 name = "jaq-std"
-version = "1.6.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfbaa55578fd3b70433b594a370741e0c364e4afff92cc0099623fce87311bc1"
+checksum = "80e2c65cceafd4c0019f15a0dac7c0dd659b0fcf5182fc3a10d15b89d89ac6e8"
 dependencies = [
- "jaq-syn",
-]
-
-[[package]]
-name = "jaq-syn"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba44fe4428c71304604261ecbae047ee9cfb60c4f1a6bd222ebbb31726d3948"
-dependencies = [
- "serde",
+ "aho-corasick",
+ "base64 0.22.1",
+ "chrono",
+ "jaq-core",
+ "libm",
+ "log",
+ "regex-lite",
+ "urlencoding",
 ]
 
 [[package]]
@@ -3416,6 +3388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,6 +4323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4759,10 +4743,8 @@ dependencies = [
  "indexmap",
  "itertools 0.13.0",
  "jaq-core",
- "jaq-interpret",
- "jaq-parse",
+ "jaq-json",
  "jaq-std",
- "jaq-syn",
  "markdown",
  "miette",
  "minijinja",

--- a/crates/weaver_codegen_test/build.rs
+++ b/crates/weaver_codegen_test/build.rs
@@ -18,7 +18,7 @@ use weaver_common::{in_memory, Logger};
 use weaver_forge::config::{Params, WeaverConfig};
 use weaver_forge::file_loader::FileSystemFileLoader;
 use weaver_forge::registry::ResolvedRegistry;
-use weaver_forge::{OutputDirective, TemplateEngine, SEMCONV_JQ};
+use weaver_forge::{OutputDirective, TemplateEngine};
 use weaver_resolver::SchemaResolver;
 use weaver_semconv::registry::SemConvRegistry;
 
@@ -58,10 +58,7 @@ fn main() {
         .unwrap_or_else(|e| process_error(&logger, e));
     let config = WeaverConfig::try_from_path("./templates/registry/rust")
         .unwrap_or_else(|e| process_error(&logger, e));
-    let mut engine = TemplateEngine::new(config, loader, Params::default());
-    engine
-        .import_jq_package(SEMCONV_JQ)
-        .unwrap_or_else(|e| process_error(&logger, e));
+    let engine = TemplateEngine::new(config, loader, Params::default());
     let template_registry = ResolvedRegistry::try_from_resolved_registry(
         schema
             .registry(REGISTRY_ID)

--- a/crates/weaver_forge/Cargo.toml
+++ b/crates/weaver_forge/Cargo.toml
@@ -21,11 +21,9 @@ weaver_semconv = { path = "../weaver_semconv" }
 minijinja = { version = "2.5.0", features = ["loader", "custom_syntax", "debug", "json", "urlencode", "macros"] }
 minijinja-contrib = { version="2.5.0", features = ["pycompat"] }
 convert_case = "0.6.0"
-jaq-core = "1.5.1"
-jaq-std = "1.6.0"
-jaq-interpret = "1.5.0"
-jaq-parse = "1.0.3"
-jaq-syn = "1.6.0"
+jaq-core = "2.0.0"
+jaq-std = "2.0.0"
+jaq-json = { version="1.0.0", features=["serde_json"] }
 indexmap = "2.7.0"
 regex = "1.11.1"
 markdown = "=1.0.0-alpha.21"

--- a/crates/weaver_forge/src/jq.rs
+++ b/crates/weaver_forge/src/jq.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Library to hide details of jaq from the rest of weaver.
+
+use std::collections::BTreeMap;
+
+use crate::error::Error;
+use jaq_core::{
+    load::{parse::Def, Arena, File, Loader},
+    Ctx, Native, RcIter,
+};
+use jaq_json::Val;
+
+fn semconv_prelude() -> impl Iterator<Item = Def<&'static str>> {
+    jaq_core::load::parse(crate::SEMCONV_JQ, |p| p.defs())
+        .expect("BAD WEAVER BUILD - default JQ library failed to compile")
+        .into_iter()
+}
+
+fn prepare_jq_context(params: &BTreeMap<String, serde_json::Value>) -> (Vec<String>, Vec<Val>) {
+    let (jq_vars, jq_ctx): (Vec<String>, Vec<Val>) = params
+        .iter()
+        .map(|(k, v)| (format!("${k}"), Val::from(v.clone())))
+        .unzip();
+    (jq_vars, jq_ctx)
+}
+
+pub fn execute_jq(
+    // The JSON input to JQ.
+    input: &serde_json::Value,
+    // The JQ filter to compile.
+    filter_expr: &str,
+    // Note: This will be exposed with `${key}` as the variable name.
+    params: &BTreeMap<String, serde_json::Value>,
+) -> Result<serde_json::Value, Error> {
+    let loader = Loader::new(
+        // ToDo: Allow custom preludes?
+        jaq_std::defs()
+            .chain(jaq_json::defs())
+            .chain(semconv_prelude()), // [],
+    );
+    let arena = Arena::default();
+    let program = File {
+        code: filter_expr,
+        path: (), // ToDo - give this the weaver-config location.
+    };
+
+    // parse the filter
+    let modules = loader
+        .load(&arena, program)
+        .map_err(|errors| Error::FilterError {
+            filter: filter_expr.to_owned(),
+            error: format!("{errors:#?}"),
+        })?;
+
+    let (names, values) = prepare_jq_context(params);
+    let funs = jaq_std::funs().chain(jaq_json::funs());
+    #[allow(clippy::map_identity)]
+    let filter = jaq_core::Compiler::<_, Native<_>>::default()
+        .with_global_vars(names.iter().map(|s| s.as_str()))
+        // To trick compiler, we re-borrow `&'static str` with shorter lifetime.
+        // This is *NOT* a simple identity function, but a lifetime inference workaround.
+        .with_funs(funs.map(|x| x))
+        .compile(modules)
+        .map_err(|e| {
+            Error::CompoundError(
+                e.into_iter()
+                    .map(|(_, errors)| Error::FilterError {
+                        filter: filter_expr.to_owned(),
+                        error: format!("{:?}", errors),
+                    })
+                    .collect(),
+            )
+        })?;
+    let inputs = RcIter::new(core::iter::empty());
+    let ctx = Ctx::new(values, &inputs);
+
+    // Bundle Results
+    let mut errs = Vec::new();
+    let mut values = Vec::new();
+    let filter_result = filter.run((ctx, Val::from(input.clone())));
+    for r in filter_result {
+        match r {
+            Ok(v) => values.push(serde_json::Value::from(v)),
+            Err(e) => errs.push(e),
+        }
+    }
+
+    if values.len() == 1 {
+        return Ok(values.pop().expect("values.len() == 1, should not happen"));
+    }
+
+    Ok(serde_json::Value::Array(values))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    use super::execute_jq;
+
+    #[test]
+    fn run_jq() {
+        let input = json!({
+            "key1": 1,
+            "key2": 2,
+        });
+        let values = BTreeMap::new();
+        let result = execute_jq(&input, ".", &values).unwrap();
+        assert_eq!(input, result);
+    }
+
+    #[test]
+    fn run_jq_with_context() {
+        let input = json!({
+            "key1": 1,
+            "key2": 2,
+        });
+        let values = BTreeMap::from([(
+            "ctx1".to_owned(),
+            json!({
+                "key3": 3,
+            }),
+        )]);
+        let result = execute_jq(&input, "$ctx1", &values).unwrap();
+        assert_eq!(result, values["ctx1"]);
+    }
+}

--- a/crates/weaver_forge/src/jq.rs
+++ b/crates/weaver_forge/src/jq.rs
@@ -186,8 +186,7 @@ mod tests {
         let input = json!({});
         let values = BTreeMap::new();
         let error = execute_jq(&input, "(", &values)
-            .err()
-            .expect("Should have failed to lex");
+            .expect_err("Should have failed to lex");
         let msg = format!("{error}");
         assert!(
             msg.contains("expected closing parenthesis"),
@@ -200,8 +199,7 @@ mod tests {
         let input = json!({});
         let values = BTreeMap::new();
         let error = execute_jq(&input, "if false then .", &values)
-            .err()
-            .expect("Should have failed to parse");
+            .expect_err("Should have failed to parse");
         let msg = format!("{error}");
         assert!(
             msg.contains("expected else or end"),
@@ -214,8 +212,7 @@ mod tests {
         let input = json!({});
         let values = BTreeMap::new();
         let error = execute_jq(&input, ".x | de", &values)
-            .err()
-            .expect("Should have failed to parse");
+            .expect_err("Should have failed to parse");
         let msg = format!("{error}");
         assert!(
             msg.contains("undefined filter"),

--- a/crates/weaver_forge/src/jq.rs
+++ b/crates/weaver_forge/src/jq.rs
@@ -104,9 +104,9 @@ fn load_errors(errs: jaq_core::load::Errors<&str, JqFileType>) -> String {
     use jaq_core::load::Error;
     let errs = errs.into_iter().flat_map(|(_, err)| {
         let result: Vec<String> = match err {
-            Error::Io(errs) => errs.into_iter().map(|e| report_io(e)).collect(),
-            Error::Lex(errs) => errs.into_iter().map(|e| report_lex(e)).collect(),
-            Error::Parse(errs) => errs.into_iter().map(|e| report_parse(e)).collect(),
+            Error::Io(errs) => errs.into_iter().map(report_io).collect(),
+            Error::Lex(errs) => errs.into_iter().map(report_lex).collect(),
+            Error::Parse(errs) => errs.into_iter().map(report_parse).collect(),
         };
         result
     });
@@ -117,7 +117,7 @@ fn load_errors(errs: jaq_core::load::Errors<&str, JqFileType>) -> String {
 fn compile_errors(errs: jaq_core::compile::Errors<&str, JqFileType>) -> String {
     let errs = errs
         .into_iter()
-        .flat_map(|(_, errs)| errs.into_iter().map(|e| report_compile(e)));
+        .flat_map(|(_, errs)| errs.into_iter().map(report_compile));
     errors_to_string(errs)
 }
 
@@ -136,16 +136,15 @@ fn report_parse((expected, _): jaq_core::load::parse::Error<&str>) -> String {
     format!("expected {}", expected.as_str())
 }
 
-/// Turns erros coming from JAQ compile phase into raw strings.
+/// Turns errors coming from JAQ compile phase into raw strings.
 fn report_compile((found, undefined): jaq_core::compile::Error<&str>) -> String {
     use jaq_core::compile::Undefined::Filter;
     let wnoa = |exp, got| format!("wrong number of arguments (expected {exp}, found {got})");
-    let message = match (found, undefined) {
+    match (found, undefined) {
         ("reduce", Filter(arity)) => wnoa("2", arity),
         ("foreach", Filter(arity)) => wnoa("2 or 3", arity),
         (_, undefined) => format!("undefined {}", undefined.as_str()),
-    };
-    message
+    }
 }
 
 #[cfg(test)]

--- a/crates/weaver_forge/src/jq.rs
+++ b/crates/weaver_forge/src/jq.rs
@@ -185,8 +185,7 @@ mod tests {
     fn test_lex_error() {
         let input = json!({});
         let values = BTreeMap::new();
-        let error = execute_jq(&input, "(", &values)
-            .expect_err("Should have failed to lex");
+        let error = execute_jq(&input, "(", &values).expect_err("Should have failed to lex");
         let msg = format!("{error}");
         assert!(
             msg.contains("expected closing parenthesis"),
@@ -211,8 +210,8 @@ mod tests {
     fn test_compile_error() {
         let input = json!({});
         let values = BTreeMap::new();
-        let error = execute_jq(&input, ".x | de", &values)
-            .expect_err("Should have failed to parse");
+        let error =
+            execute_jq(&input, ".x | de", &values).expect_err("Should have failed to parse");
         let msg = format!("{error}");
         assert!(
             msg.contains("undefined filter"),

--- a/crates/weaver_forge/src/lib.rs
+++ b/crates/weaver_forge/src/lib.rs
@@ -739,7 +739,7 @@ mod tests {
         let loader = FileSystemFileLoader::try_new("templates".into(), target)
             .expect("Failed to create file system loader");
         let config = WeaverConfig::try_from_path(format!("templates/{}", target)).unwrap();
-        let mut engine = TemplateEngine::new(config, loader, cli_params);
+        let engine = TemplateEngine::new(config, loader, cli_params);
         let schema = SchemaResolver::resolve_semantic_convention_registry(&mut registry)
             .expect("Failed to resolve registry");
 

--- a/crates/weaver_forge/src/lib.rs
+++ b/crates/weaver_forge/src/lib.rs
@@ -10,7 +10,6 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::{fmt, fs};
 
-use jaq_interpret::Val;
 use minijinja::syntax::SyntaxConfig;
 use minijinja::value::{from_args, Enumerator, Object};
 use minijinja::{Environment, ErrorKind, State, Value};
@@ -41,6 +40,7 @@ pub mod extensions;
 pub mod file_loader;
 mod filter;
 mod formats;
+mod jq;
 pub mod registry;
 
 /// Name of the Weaver configuration file.
@@ -158,9 +158,6 @@ pub struct TemplateEngine {
 
     /// Target configuration
     target_config: WeaverConfig,
-
-    /// The jq packages that have been imported.
-    jq_packages: Vec<jaq_syn::Def>,
 }
 
 /// Global context for the template engine.
@@ -231,30 +228,7 @@ impl TemplateEngine {
         Self {
             file_loader: Arc::new(loader),
             target_config: config,
-            jq_packages: Vec::new(),
         }
-    }
-
-    /// Import a jq package into the template engine.
-    /// A jq package is a collection of jq functions that can be used in the templates.
-    pub fn import_jq_package(&mut self, package_content: &str) -> Result<(), Error> {
-        let (defs, errs) = jaq_parse::parse(package_content, jaq_parse::defs());
-
-        if !errs.is_empty() {
-            return Err(Error::CompoundError(
-                errs.into_iter()
-                    .map(|e| Error::ImportError {
-                        package: package_content.to_owned(),
-                        error: e.to_string(),
-                    })
-                    .collect(),
-            ));
-        }
-
-        if let Some(def) = defs {
-            self.jq_packages.extend(def);
-        }
-        Ok(())
     }
 
     /// Generate a template snippet from serializable context and a snippet identifier.
@@ -351,23 +325,16 @@ impl TemplateEngine {
         output_directive: &OutputDirective,
         log: impl Logger + Sync + Clone,
     ) -> Result<(), Error> {
-        let params = Self::init_params(template.params.clone())?;
-        let (jq_vars, jq_ctx) = Self::prepare_jq_context(&params)?;
-        let filter = Filter::try_new(
-            template.filter.as_str(),
-            jq_vars.clone(),
-            self.jq_packages.clone(),
-        )?;
-        // `jaq_interpret::val::Val` is not Sync, so we need to convert json_values to
-        // jaq_interpret::val::Val here.
-        let jq_ctx = jq_ctx.into_iter().map(Val::from).collect::<Vec<_>>();
-        let filtered_result = filter.apply(context.clone(), jq_ctx)?;
+        let yaml_params = Self::init_params(template.params.clone())?;
+        let params = Self::prepare_jq_context(&yaml_params)?;
+        let filter = Filter::new(template.filter.as_str());
+        let filtered_result = filter.apply(context.clone(), &params)?;
 
         match template.application_mode {
             ApplicationMode::Single => self.process_single_mode(
                 &filtered_result,
                 template.file_name.as_ref(),
-                &params,
+                &yaml_params,
                 template_file,
                 output_dir,
                 output_directive,
@@ -376,7 +343,7 @@ impl TemplateEngine {
             ApplicationMode::Each => self.process_each_mode(
                 &filtered_result,
                 template.file_name.as_ref(),
-                &params,
+                &yaml_params,
                 template_file,
                 output_dir,
                 output_directive,
@@ -459,9 +426,9 @@ impl TemplateEngine {
     /// Build a JQ context from the Weaver parameters.
     fn prepare_jq_context(
         params: &BTreeMap<String, serde_yaml::Value>,
-    ) -> Result<(Vec<String>, Vec<serde_json::Value>), Error> {
+    ) -> Result<BTreeMap<String, serde_json::Value>, Error> {
         let mut errs = Vec::new();
-        let (jq_vars, jq_ctx): (Vec<String>, Vec<serde_json::Value>) = params
+        let jq_ctx: BTreeMap<String, serde_json::Value> = params
             .iter()
             .filter_map(|(k, v)| {
                 let json_value = match serde_json::to_value(v) {
@@ -475,10 +442,9 @@ impl TemplateEngine {
                 };
                 Some((k.clone(), json_value))
             })
-            .unzip();
-
+            .collect();
         handle_errors(errs)?;
-        Ok((jq_vars, jq_ctx))
+        Ok(jq_ctx)
     }
 
     /// Initialize a map of parameters from the template parameters.
@@ -774,8 +740,6 @@ mod tests {
             .expect("Failed to create file system loader");
         let config = WeaverConfig::try_from_path(format!("templates/{}", target)).unwrap();
         let mut engine = TemplateEngine::new(config, loader, cli_params);
-        engine.import_jq_package(super::SEMCONV_JQ).unwrap();
-
         let schema = SchemaResolver::resolve_semantic_convention_registry(&mut registry)
             .expect("Failed to resolve registry");
 
@@ -937,7 +901,6 @@ mod tests {
         let config =
             WeaverConfig::try_from_loader(&loader).expect("Failed to load `templates/weaver.yaml`");
         let mut engine = TemplateEngine::new(config, loader, Params::default());
-        engine.import_jq_package(super::SEMCONV_JQ).unwrap();
 
         // Add a template configuration for converter.md on top
         // of the default template configuration. This is useful

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -14,7 +14,7 @@ use weaver_common::Logger;
 use weaver_forge::config::{Params, WeaverConfig};
 use weaver_forge::file_loader::{FileLoader, FileSystemFileLoader};
 use weaver_forge::registry::ResolvedRegistry;
-use weaver_forge::{OutputDirective, TemplateEngine, SEMCONV_JQ};
+use weaver_forge::{OutputDirective, TemplateEngine};
 use weaver_semconv::registry::SemConvRegistry;
 
 use crate::registry::{CommonRegistryArgs, Error, RegistryArgs};
@@ -150,8 +150,7 @@ pub(crate) fn command(
     } else {
         WeaverConfig::try_from_path(loader.root())
     }?;
-    let mut engine = TemplateEngine::new(config, loader, params);
-    engine.import_jq_package(SEMCONV_JQ)?;
+    let engine = TemplateEngine::new(config, loader, params);
 
     let template_registry = ResolvedRegistry::try_from_resolved_registry(
         schema

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -11,7 +11,7 @@ use weaver_common::diagnostic::{is_future_mode_enabled, DiagnosticMessages};
 use weaver_common::Logger;
 use weaver_forge::config::{Params, WeaverConfig};
 use weaver_forge::file_loader::FileSystemFileLoader;
-use weaver_forge::{TemplateEngine, SEMCONV_JQ};
+use weaver_forge::TemplateEngine;
 use weaver_semconv_gen::{update_markdown, SnippetGenerator};
 
 /// Parameters for the `registry update-markdown` sub-command
@@ -75,9 +75,7 @@ pub(crate) fn command(
             &args.target,
         )?;
         let config = WeaverConfig::try_from_loader(&loader)?;
-        let mut engine = TemplateEngine::new(config, loader, Params::default());
-        engine.import_jq_package(SEMCONV_JQ)?;
-        engine
+        TemplateEngine::new(config, loader, Params::default())
     };
 
     let mut registry_path = args.registry.registry.clone();


### PR DESCRIPTION
- Update Filter to only remember strings, as we can't safely precompile with new lifetime shenanigans.
- Create new jq file to hide all details of calling JQ
- Update filter/engine to start passing serde-JSON structures by default, instead of JAQ internals.
- Create error-message generation.
- Update tests.

