### PR TITLE
Refactor: common resolve registry with policy checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ All notable changes to this project will be documented in this file.
 
 What's changed
 
-* Refactored CLI registry commands to remove some duplication. Resolving the registry with policy checks is common for `generate`, `resolve` and `check`. Added missing `after_resolution` policy checks to `generate` and `resolve` through the common code. Removed the deprecated `--registry-git-sub-dir` option. ([#536](https://github.com/open-telemetry/weaver/pull/536) by @jerbly).
+* Refactored CLI registry commands to remove some duplication. Resolving the registry with policy checks is common for `generate`, `resolve` and `check`. ([#536](https://github.com/open-telemetry/weaver/pull/536) by @jerbly).
+  * Added missing `after_resolution` policy checks to `generate` and `resolve` through the common code.
+  * Removed the deprecated `--registry-git-sub-dir` option.
+  * Fixed bug in `check` if `--skip-policies` was specified then it would not fail for any validation errors.
 
 ## [0.12.0] - 2024-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 What's changed
 
-* Refactored CLI registry commands to remove some duplication. Resolving the registry with policy checks is common for `generate`, `resolve` and `check`. Added missing `after_resolution` policy checks to `generate` and `resolve` through the common code. Removed the deprecated `--registry-git-sub-dir` option. ([#???](https://github.com/open-telemetry/weaver/pull/???) by @jerbly).
+* Refactored CLI registry commands to remove some duplication. Resolving the registry with policy checks is common for `generate`, `resolve` and `check`. Added missing `after_resolution` policy checks to `generate` and `resolve` through the common code. Removed the deprecated `--registry-git-sub-dir` option. ([#536](https://github.com/open-telemetry/weaver/pull/536) by @jerbly).
 
 ## [0.12.0] - 2024-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 What's changed
 
-* 
+* Refactored CLI registry commands to remove some duplication. Resolving the registry with policy checks is common for `generate`, `resolve` and `check`. Added missing `after_resolution` policy checks to `generate` and `resolve` through the common code. Removed the deprecated `--registry-git-sub-dir` option. ([#???](https://github.com/open-telemetry/weaver/pull/???) by @jerbly).
 
 ## [0.12.0] - 2024-12-09
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -29,11 +29,11 @@ the Rego playground.
 
 ## Creating a JSON output for your registry
 
-Many times it's useful to have raw JSON output of your registry for debugging or tooling. To generate this
+Often it's useful to have raw JSON output of your registry for debugging or tooling. To generate this
 output, simply do the following:
 
 ```bash
-weaver registry resolve -r <registry> -o resolved-registry.json
+weaver registry resolve -r <registry> -o resolved-registry.json -f json
 ```
 
 ## Adding a new Semantic Convention Field

--- a/docs/docker-guide.md
+++ b/docs/docker-guide.md
@@ -63,7 +63,7 @@ docker run --rm \
         --mount 'type=bind,source=$(PWD)/templates,target=/home/weaver/templates,readonly' \
         --mount 'type=bind,source=$(PWD)/my-doc-output,target=/home/weaver/target,readonly' \
         otel/weaver:latest \
-        registry generate \
+        registry update-markdown \
         --templates=/home/weaver/templates \
         --target=markdown \
         --dry-run \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,8 +27,6 @@ The validation process for a semantic convention registry involves several steps
 - Resolving references, extends clauses, and constraints within the specifications.
 - Checking compliance with specified Rego policies, if provided.
 
-Note: The `-d` and `--registry-git-sub-dir` options are only used when the registry is a Git URL otherwise these options are ignored.
-
 The process exits with a code of 0 if the registry validation is successful.
 
 Usage: weaver registry check [OPTIONS]
@@ -38,11 +36,6 @@ Options:
           Local path or Git URL of the semantic convention registry to check
 
           [default: https://github.com/open-telemetry/semantic-conventions.git]
-
-  -d, --registry-git-sub-dir <REGISTRY_GIT_SUB_DIR>
-          Optional path in the Git repository where the semantic convention registry is located
-
-          [default: model]
 
   -p, --policy <POLICIES>
           Optional list of policy files to check against the files of the semantic convention registry
@@ -71,8 +64,6 @@ Generates artifacts from a semantic convention registry.
 
 Rego policies present in the registry or specified using -p or --policy will be automatically validated by the policy engine before the artifact generation phase.
 
-Note: The `-d` and `--registry-git-sub-dir` options are only used when the registry is a Git URL otherwise these options are ignored.
-
 The process exits with a code of 0 if the generation is successful.
 
 Usage: weaver registry generate [OPTIONS] <TARGET> [OUTPUT]
@@ -96,11 +87,6 @@ Options:
           Local path or Git URL of the semantic convention registry
 
           [default: https://github.com/open-telemetry/semantic-conventions.git]
-
-  -d, --registry-git-sub-dir <REGISTRY_GIT_SUB_DIR>
-          Optional path in the Git repository where the semantic convention registry is located
-
-          [default: model]
 
   -p, --policy <POLICIES>
           Optional list of policy files to check against the files of the semantic convention registry
@@ -130,8 +116,6 @@ Resolves a semantic convention registry.
 
 Rego policies present in the registry or specified using -p or --policy will be automatically validated by the policy engine before the artifact generation phase.
 
-Note: The `-d` and `--registry-git-sub-dir` options are only used when the registry is a Git URL otherwise these options are ignored.
-
 The process exits with a code of 0 if the resolution is successful.
 
 Usage: weaver registry resolve [OPTIONS]
@@ -141,11 +125,6 @@ Options:
           Local path or Git URL of the semantic convention registry
 
           [default: https://github.com/open-telemetry/semantic-conventions.git]
-
-  -d, --registry-git-sub-dir <REGISTRY_GIT_SUB_DIR>
-          Optional path in the Git repository where the semantic convention registry is located
-
-          [default: model]
 
       --catalog
           Flag to indicate if the shared catalog should be included in the resolved schema
@@ -198,8 +177,6 @@ Arguments:
 Options:
   -r, --registry <REGISTRY>
           Local path or Git URL of the semantic convention registry to check [default: https://github.com/open-telemetry/semantic-conventions.git]
-  -d, --registry-git-sub-dir <REGISTRY_GIT_SUB_DIR>
-          Optional path in the Git repository where the semantic convention registry is located [default: model]
       --dry-run
           Whether or not to run updates in dry-run mode
       --attribute-registry-base-url <ATTRIBUTE_REGISTRY_BASE_URL>
@@ -209,9 +186,6 @@ Options:
   -h, --help
           Print help
 ```
-
-> Note: The `-d` and `--registry-git-sub-dir` options are only used when the
-> registry is a Git URL otherwise these options are ignored.
 
 ## registry stats
 
@@ -223,14 +197,9 @@ Usage: weaver registry stats [OPTIONS]
 Options:
   -r, --registry <REGISTRY>
           Local path or Git URL of the semantic convention registry [default: https://github.com/open-telemetry/semantic-conventions.git]
-  -d, --registry-git-sub-dir <REGISTRY_GIT_SUB_DIR>
-          Optional path in the Git repository where the semantic convention registry is located [default: model]
   -h, --help
           Print help
 ```
-
-> Note: The `-d` and `--registry-git-sub-dir` options are only used when the
-> registry is a Git URL otherwise these options are ignored.
 
 ## diagnostic init
 

--- a/src/registry/check.rs
+++ b/src/registry/check.rs
@@ -231,6 +231,3 @@ mod tests {
         }
     }
 }
-
-//TODO - Check this on the released version:
-//       cargo run -- registry check -r crates/weaver_codegen_test/semconv_registry --skip-policies --future

--- a/src/registry/check.rs
+++ b/src/registry/check.rs
@@ -111,10 +111,10 @@ pub(crate) fn command(
             })
             .capture_non_fatal_errors(&mut diag_msgs)?;
         }
+    }
 
-        if !diag_msgs.is_empty() {
-            return Err(diag_msgs);
-        }
+    if !diag_msgs.is_empty() {
+        return Err(diag_msgs);
     }
 
     Ok(ExitDirectives {

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -13,7 +13,7 @@ use weaver_forge::config::{Params, WeaverConfig};
 use weaver_forge::file_loader::{FileLoader, FileSystemFileLoader};
 use weaver_forge::{OutputDirective, TemplateEngine};
 
-use crate::registry::{CommonRegistryArgs, Error, RegistryArgs};
+use crate::registry::{Error, RegistryArgs};
 use crate::util::prepare_main_registry;
 use crate::{DiagnosticArgs, ExitDirectives};
 
@@ -69,10 +69,6 @@ pub struct RegistryGenerateArgs {
     /// Parameters to specify the diagnostic format.
     #[command(flatten)]
     pub diagnostic: DiagnosticArgs,
-
-    /// Common weaver registry parameters
-    #[command(flatten)]
-    pub common_registry_args: CommonRegistryArgs,
 }
 
 /// Utility function to parse key-value pairs from the command line.
@@ -104,14 +100,13 @@ pub(crate) fn command(
     let mut diag_msgs = DiagnosticMessages::empty();
     let params = generate_params(args)?;
 
-    let registry_path = &args.registry.registry;
+    //let registry_path = &args.registry.registry;
 
     //let registry_id = "default";
 
     let (template_registry, _) = prepare_main_registry(
         logger.clone(),
-        registry_path,
-        args.common_registry_args.follow_symlinks,
+        &args.registry,
         args.skip_policies,
         &args.policies,
         false,
@@ -220,9 +215,7 @@ mod tests {
 
     use crate::cli::{Cli, Commands};
     use crate::registry::generate::RegistryGenerateArgs;
-    use crate::registry::{
-        CommonRegistryArgs, RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand,
-    };
+    use crate::registry::{RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand};
     use crate::run_command;
 
     #[test]
@@ -247,14 +240,12 @@ mod tests {
                         registry: RegistryPath::LocalFolder {
                             path: "crates/weaver_codegen_test/semconv_registry/".to_owned(),
                         },
+                        follow_symlinks: false,
                     },
                     policies: vec![],
                     skip_policies: true,
                     future: false,
                     diagnostic: Default::default(),
-                    common_registry_args: CommonRegistryArgs {
-                        follow_symlinks: false,
-                    },
                 }),
             })),
         };
@@ -321,14 +312,12 @@ mod tests {
                         registry: RegistryPath::LocalFolder {
                             path: "crates/weaver_codegen_test/semconv_registry/".to_owned(),
                         },
+                        follow_symlinks: false,
                     },
                     policies: vec![],
                     skip_policies: false,
                     future: false,
                     diagnostic: Default::default(),
-                    common_registry_args: CommonRegistryArgs {
-                        follow_symlinks: false,
-                    },
                 }),
             })),
         };
@@ -367,14 +356,12 @@ mod tests {
                         registry: RegistryPath::LocalFolder {
                             path: "crates/weaver_codegen_test/semconv_registry/".to_owned(),
                         },
+                        follow_symlinks: false,
                     },
                     policies: vec![],
                     skip_policies: true,
                     future: false,
                     diagnostic: Default::default(),
-                    common_registry_args: CommonRegistryArgs {
-                        follow_symlinks: false,
-                    },
                 }),
             })),
         };
@@ -471,12 +458,12 @@ mod tests {
                             registry: RegistryPath::LocalFolder {
                                 path: "data/symbolic_test/".to_owned(),
                             },
+                            follow_symlinks,
                         },
                         policies: vec![],
                         skip_policies: true,
                         future: false,
                         diagnostic: Default::default(),
-                        common_registry_args: CommonRegistryArgs { follow_symlinks },
                     }),
                 })),
             };

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -13,7 +13,7 @@ use weaver_forge::config::{Params, WeaverConfig};
 use weaver_forge::file_loader::{FileLoader, FileSystemFileLoader};
 use weaver_forge::{OutputDirective, TemplateEngine};
 
-use crate::registry::{Error, RegistryArgs};
+use crate::registry::{Error, PolicyArgs, RegistryArgs};
 use crate::util::prepare_main_registry;
 use crate::{DiagnosticArgs, ExitDirectives};
 
@@ -51,15 +51,9 @@ pub struct RegistryGenerateArgs {
     #[command(flatten)]
     registry: RegistryArgs,
 
-    /// Optional list of policy files or directories to check against the files of the semantic
-    /// convention registry. If a directory is provided all `.rego` files in the directory will be
-    /// loaded.
-    #[arg(short = 'p', long = "policy")]
-    pub policies: Vec<PathBuf>,
-
-    /// Skip the policy checks.
-    #[arg(long, default_value = "false")]
-    pub skip_policies: bool,
+    /// Policy parameters
+    #[command(flatten)]
+    policy: PolicyArgs,
 
     /// Enable the most recent validation rules for the semconv registry. It is recommended
     /// to enable this flag when checking a new registry.
@@ -104,15 +98,9 @@ pub(crate) fn command(
 
     //let registry_id = "default";
 
-    let (template_registry, _) = prepare_main_registry(
-        logger.clone(),
-        &args.registry,
-        args.skip_policies,
-        &args.policies,
-        false,
-        &mut diag_msgs,
-    )
-    .combine_diag_msgs_with(&diag_msgs)?;
+    let (template_registry, _) =
+        prepare_main_registry(logger.clone(), &args.registry, &args.policy, &mut diag_msgs)
+            .combine_diag_msgs_with(&diag_msgs)?;
     // let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
 
     // // Load the semantic convention registry into a local cache.
@@ -215,7 +203,9 @@ mod tests {
 
     use crate::cli::{Cli, Commands};
     use crate::registry::generate::RegistryGenerateArgs;
-    use crate::registry::{RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand};
+    use crate::registry::{
+        PolicyArgs, RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand,
+    };
     use crate::run_command;
 
     #[test]
@@ -242,8 +232,11 @@ mod tests {
                         },
                         follow_symlinks: false,
                     },
-                    policies: vec![],
-                    skip_policies: true,
+                    policy: PolicyArgs {
+                        policies: vec![],
+                        skip_policies: true,
+                        display_policy_coverage: false,
+                    },
                     future: false,
                     diagnostic: Default::default(),
                 }),
@@ -314,8 +307,11 @@ mod tests {
                         },
                         follow_symlinks: false,
                     },
-                    policies: vec![],
-                    skip_policies: false,
+                    policy: PolicyArgs {
+                        policies: vec![],
+                        skip_policies: false,
+                        display_policy_coverage: false,
+                    },
                     future: false,
                     diagnostic: Default::default(),
                 }),
@@ -358,8 +354,11 @@ mod tests {
                         },
                         follow_symlinks: false,
                     },
-                    policies: vec![],
-                    skip_policies: true,
+                    policy: PolicyArgs {
+                        policies: vec![],
+                        skip_policies: true,
+                        display_policy_coverage: false,
+                    },
                     future: false,
                     diagnostic: Default::default(),
                 }),
@@ -460,8 +459,11 @@ mod tests {
                             },
                             follow_symlinks,
                         },
-                        policies: vec![],
-                        skip_policies: true,
+                        policy: PolicyArgs {
+                            policies: vec![],
+                            skip_policies: true,
+                            display_policy_coverage: false,
+                        },
                         future: false,
                         diagnostic: Default::default(),
                     }),

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -122,6 +122,24 @@ pub struct RegistryArgs {
     pub(crate) follow_symlinks: bool,
 }
 
+/// Set of common parameters used for policy checks.
+#[derive(Args, Debug)]
+pub struct PolicyArgs {
+    /// Optional list of policy files or directories to check against the files of the semantic
+    /// convention registry.  If a directory is provided all `.rego` files in the directory will be
+    /// loaded.
+    #[arg(short = 'p', long = "policy")]
+    pub policies: Vec<PathBuf>,
+
+    /// Skip the policy checks.
+    #[arg(long, default_value = "false")]
+    pub skip_policies: bool,
+
+    /// Display the policy coverage report (useful for debugging).
+    #[arg(long, default_value = "false")]
+    pub display_policy_coverage: bool,
+}
+
 /// Manage a semantic convention registry and return the exit code.
 pub fn semconv_registry(log: impl Logger + Sync + Clone, command: &RegistryCommand) -> CmdResult {
     match &command.command {

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -115,13 +115,6 @@ pub struct RegistryArgs {
         default_value = "https://github.com/open-telemetry/semantic-conventions.git[model]"
     )]
     pub registry: RegistryPath,
-
-    /// Optional path in the Git repository where the semantic convention
-    /// registry is located. This parameter is deprecated and should be
-    /// removed in the future. Please use the `[sub-folder]` syntax after the
-    /// URL in the `--registry` or `--baseline-registry` parameters instead.
-    #[arg(short = 'd', long, default_value = "model")]
-    pub registry_git_sub_dir: Option<String>,
 }
 
 /// Manage a semantic convention registry and return the exit code.

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -115,6 +115,11 @@ pub struct RegistryArgs {
         default_value = "https://github.com/open-telemetry/semantic-conventions.git[model]"
     )]
     pub registry: RegistryPath,
+
+    /// Boolean flag to specify whether to follow symlinks when loading the registry.
+    /// Default is false.
+    #[arg(short = 's', long)]
+    pub(crate) follow_symlinks: bool,
 }
 
 /// Manage a semantic convention registry and return the exit code.
@@ -149,15 +154,4 @@ pub fn semconv_registry(log: impl Logger + Sync + Clone, command: &RegistryComma
             Some(args.diagnostic.clone()),
         ),
     }
-}
-
-/// Set of Parameters used to specify the extra options for the `weaver registry` command.
-/// The CommonRegistryArgs will be shared across all `weaver registry` sub-commands. So only the general options should be
-/// included here.
-#[derive(Args, Debug)]
-pub struct CommonRegistryArgs {
-    /// Boolean flag to specify whether to follow symlinks when loading the registry.
-    /// Default is false.
-    #[arg(short = 's', long)]
-    pub(crate) follow_symlinks: bool,
 }

--- a/src/registry/resolve.rs
+++ b/src/registry/resolve.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use clap::Args;
 
-use weaver_common::diagnostic::{DiagnosticMessages, ResultExt};
+use weaver_common::diagnostic::DiagnosticMessages;
 use weaver_common::Logger;
 
 use crate::format::{apply_format, Format};
@@ -60,52 +60,9 @@ pub(crate) fn command(
     logger.loading(&format!("Resolving registry `{}`", args.registry.registry));
 
     let mut diag_msgs = DiagnosticMessages::empty();
-    //    let registry_path = &args.registry.registry;
 
     let (registry, _) =
-        prepare_main_registry(logger.clone(), &args.registry, &args.policy, &mut diag_msgs)
-            .combine_diag_msgs_with(&diag_msgs)?;
-
-    // let registry_id = "default";
-    // let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
-
-    // // Load the semantic convention registry into a local cache.
-    // let semconv_specs = load_semconv_specs(
-    //     &registry_repo,
-    //     logger.clone(),
-    //     args.common_registry_args.follow_symlinks,
-    // )
-    // .ignore(|e| matches!(e.severity(), Some(miette::Severity::Warning)))
-    // .into_result_failing_non_fatal()?;
-
-    // if !args.skip_policies {
-    //     let policy_engine = init_policy_engine(&registry_repo, &args.policies, false)?;
-    //     check_policy(&policy_engine, &semconv_specs)
-    //         .inspect(|_, violations| {
-    //             if let Some(violations) = violations {
-    //                 logger.success(&format!(
-    //                     "All `before_resolution` policies checked ({} violations found)",
-    //                     violations.len()
-    //                 ));
-    //             } else {
-    //                 logger.success("No `before_resolution` policy violation");
-    //             }
-    //         })
-    //         .capture_non_fatal_errors(&mut diag_msgs)?;
-    // }
-
-    // let mut registry = SemConvRegistry::from_semconv_specs(registry_id, semconv_specs);
-    // let schema = resolve_semconv_specs(&mut registry, logger.clone())?;
-
-    // // Serialize the resolved schema and write it
-    // // to a file or print it to stdout.
-    // let registry = ResolvedRegistry::try_from_resolved_registry(
-    //     schema
-    //         .registry(registry_id)
-    //         .expect("Failed to get the registry from the resolved schema"),
-    //     schema.catalog(),
-    // )
-    // .unwrap_or_else(|e| panic!("Failed to create the registry without catalog: {e:?}"));
+        prepare_main_registry(&args.registry, &args.policy, logger.clone(), &mut diag_msgs)?;
 
     apply_format(&args.format, &registry)
         .map_err(|e| format!("Failed to serialize the registry: {e:?}"))

--- a/src/registry/resolve.rs
+++ b/src/registry/resolve.rs
@@ -10,7 +10,7 @@ use weaver_common::diagnostic::{DiagnosticMessages, ResultExt};
 use weaver_common::Logger;
 
 use crate::format::{apply_format, Format};
-use crate::registry::{CommonRegistryArgs, RegistryArgs};
+use crate::registry::RegistryArgs;
 use crate::util::prepare_main_registry;
 use crate::{DiagnosticArgs, ExitDirectives};
 
@@ -52,10 +52,6 @@ pub struct RegistryResolveArgs {
     /// Parameters to specify the diagnostic format.
     #[command(flatten)]
     pub diagnostic: DiagnosticArgs,
-
-    // Common weaver registry parameters
-    #[command(flatten)]
-    pub common_registry_args: CommonRegistryArgs,
 }
 
 /// Resolve a semantic convention registry and write the resolved schema to a
@@ -70,12 +66,11 @@ pub(crate) fn command(
     logger.loading(&format!("Resolving registry `{}`", args.registry.registry));
 
     let mut diag_msgs = DiagnosticMessages::empty();
-    let registry_path = &args.registry.registry;
+    //    let registry_path = &args.registry.registry;
 
     let (registry, _) = prepare_main_registry(
         logger.clone(),
-        registry_path,
-        args.common_registry_args.follow_symlinks,
+        &args.registry,
         args.skip_policies,
         &args.policies,
         false,
@@ -159,9 +154,7 @@ mod tests {
     use crate::cli::{Cli, Commands};
     use crate::format::Format;
     use crate::registry::resolve::RegistryResolveArgs;
-    use crate::registry::{
-        CommonRegistryArgs, RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand,
-    };
+    use crate::registry::{RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand};
     use crate::run_command;
 
     #[test]
@@ -177,6 +170,7 @@ mod tests {
                         registry: RegistryPath::LocalFolder {
                             path: "crates/weaver_codegen_test/semconv_registry/".to_owned(),
                         },
+                        follow_symlinks: false,
                     },
                     lineage: true,
                     output: None,
@@ -184,9 +178,6 @@ mod tests {
                     policies: vec![],
                     skip_policies: true,
                     diagnostic: Default::default(),
-                    common_registry_args: CommonRegistryArgs {
-                        follow_symlinks: false,
-                    },
                 }),
             })),
         };
@@ -206,6 +197,7 @@ mod tests {
                         registry: RegistryPath::LocalFolder {
                             path: "crates/weaver_codegen_test/semconv_registry/".to_owned(),
                         },
+                        follow_symlinks: false,
                     },
                     lineage: true,
                     output: None,
@@ -213,9 +205,6 @@ mod tests {
                     policies: vec![],
                     skip_policies: false,
                     diagnostic: Default::default(),
-                    common_registry_args: CommonRegistryArgs {
-                        follow_symlinks: false,
-                    },
                 }),
             })),
         };

--- a/src/registry/search.rs
+++ b/src/registry/search.rs
@@ -12,7 +12,7 @@ use weaver_resolved_schema::{attribute::Attribute, ResolvedTelemetrySchema};
 use weaver_semconv::registry::SemConvRegistry;
 
 use crate::{
-    registry::{CommonRegistryArgs, RegistryArgs},
+    registry::RegistryArgs,
     util::{load_semconv_specs, resolve_semconv_specs},
     DiagnosticArgs, ExitDirectives,
 };
@@ -51,10 +51,6 @@ pub struct RegistrySearchArgs {
     /// An (optional) search string to use.  If specified, will return matching values on the command line.
     /// Otherwise, runs an interactive terminal UI.
     pub search_string: Option<String>,
-
-    /// Common weaver registry parameters
-    #[command(flatten)]
-    pub common_registry_args: CommonRegistryArgs,
 }
 
 #[derive(thiserror::Error, Debug, serde::Serialize, Diagnostic)]
@@ -389,7 +385,7 @@ pub(crate) fn command(
     let semconv_specs = load_semconv_specs(
         &registry_repo,
         logger.clone(),
-        args.common_registry_args.follow_symlinks,
+        args.registry.follow_symlinks,
     )
     .ignore(|e| matches!(e.severity(), Some(miette::Severity::Warning)))
     .into_result_failing_non_fatal()?;

--- a/src/registry/search.rs
+++ b/src/registry/search.rs
@@ -12,7 +12,6 @@ use weaver_resolved_schema::{attribute::Attribute, ResolvedTelemetrySchema};
 use weaver_semconv::registry::SemConvRegistry;
 
 use crate::{
-    registry,
     registry::{CommonRegistryArgs, RegistryArgs},
     util::{load_semconv_specs, resolve_semconv_specs},
     DiagnosticArgs, ExitDirectives,
@@ -382,14 +381,9 @@ pub(crate) fn command(
     logger.loading(&format!("Resolving registry `{}`", args.registry.registry));
 
     let registry_id = "default";
-    let mut registry_path = args.registry.registry.clone();
-    // Support for --registry-git-sub-dir (should be removed in the future)
-    if let registry::RegistryPath::GitRepo { sub_folder, .. } = &mut registry_path {
-        if sub_folder.is_none() {
-            sub_folder.clone_from(&args.registry.registry_git_sub_dir);
-        }
-    }
-    let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
+    let registry_path = &args.registry.registry;
+
+    let registry_repo = RegistryRepo::try_new("main", registry_path)?;
 
     // Load the semantic convention registry into a local cache.
     let semconv_specs = load_semconv_specs(

--- a/src/registry/stats.rs
+++ b/src/registry/stats.rs
@@ -2,7 +2,7 @@
 
 //! Compute stats on a semantic convention registry.
 
-use crate::registry::{CommonRegistryArgs, RegistryArgs};
+use crate::registry::RegistryArgs;
 use crate::util::{load_semconv_specs, resolve_semconv_specs};
 use crate::{DiagnosticArgs, ExitDirectives};
 use clap::Args;
@@ -25,10 +25,6 @@ pub struct RegistryStatsArgs {
     /// Parameters to specify the diagnostic format.
     #[command(flatten)]
     pub diagnostic: DiagnosticArgs,
-
-    /// Common weaver registry parameters
-    #[command(flatten)]
-    pub common_registry_args: CommonRegistryArgs,
 }
 
 /// Compute stats on a semantic convention registry.
@@ -50,7 +46,7 @@ pub(crate) fn command(
     let semconv_specs = load_semconv_specs(
         &registry_repo,
         logger.clone(),
-        args.common_registry_args.follow_symlinks,
+        args.registry.follow_symlinks,
     )
     .ignore(|e| matches!(e.severity(), Some(miette::Severity::Warning)))
     .into_result_failing_non_fatal()?;

--- a/src/registry/stats.rs
+++ b/src/registry/stats.rs
@@ -4,7 +4,7 @@
 
 use crate::registry::{CommonRegistryArgs, RegistryArgs};
 use crate::util::{load_semconv_specs, resolve_semconv_specs};
-use crate::{registry, DiagnosticArgs, ExitDirectives};
+use crate::{DiagnosticArgs, ExitDirectives};
 use clap::Args;
 use miette::Diagnostic;
 use weaver_cache::RegistryRepo;
@@ -42,14 +42,9 @@ pub(crate) fn command(
     ));
 
     let registry_id = "default";
-    let mut registry_path = args.registry.registry.clone();
-    // Support for --registry-git-sub-dir (should be removed in the future)
-    if let registry::RegistryPath::GitRepo { sub_folder, .. } = &mut registry_path {
-        if sub_folder.is_none() {
-            sub_folder.clone_from(&args.registry.registry_git_sub_dir);
-        }
-    }
-    let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
+    let registry_path = &args.registry.registry;
+
+    let registry_repo = RegistryRepo::try_new("main", registry_path)?;
 
     // Load the semantic convention registry into a local cache.
     let semconv_specs = load_semconv_specs(

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -4,7 +4,7 @@
 //! update the specified sections.
 
 use crate::registry::{CommonRegistryArgs, RegistryArgs};
-use crate::{registry, DiagnosticArgs, ExitDirectives};
+use crate::{DiagnosticArgs, ExitDirectives};
 use clap::Args;
 use weaver_cache::RegistryRepo;
 use weaver_common::diagnostic::{is_future_mode_enabled, DiagnosticMessages};
@@ -78,14 +78,9 @@ pub(crate) fn command(
         TemplateEngine::new(config, loader, Params::default())
     };
 
-    let mut registry_path = args.registry.registry.clone();
-    // Support for --registry-git-sub-dir (should be removed in the future)
-    if let registry::RegistryPath::GitRepo { sub_folder, .. } = &mut registry_path {
-        if sub_folder.is_none() {
-            sub_folder.clone_from(&args.registry.registry_git_sub_dir);
-        }
-    }
-    let registry_repo = RegistryRepo::try_new("main", &registry_path)?;
+    let registry_path = &args.registry.registry;
+
+    let registry_repo = RegistryRepo::try_new("main", registry_path)?;
     let generator = SnippetGenerator::try_from_registry_repo(
         &registry_repo,
         generator,
@@ -163,7 +158,6 @@ mod tests {
                         registry: RegistryPath::LocalFolder {
                             path: "data/update_markdown/registry".to_owned(),
                         },
-                        registry_git_sub_dir: None,
                     },
                     dry_run: true,
                     attribute_registry_base_url: Some("/docs/attributes-registry".to_owned()),

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -3,7 +3,7 @@
 //! Update markdown files that contain markers indicating the templates used to
 //! update the specified sections.
 
-use crate::registry::{CommonRegistryArgs, RegistryArgs};
+use crate::registry::RegistryArgs;
 use crate::{DiagnosticArgs, ExitDirectives};
 use clap::Args;
 use weaver_cache::RegistryRepo;
@@ -49,10 +49,6 @@ pub struct RegistryUpdateMarkdownArgs {
     /// Parameters to specify the diagnostic format.
     #[command(flatten)]
     pub diagnostic: DiagnosticArgs,
-
-    /// Common weaver registry parameters
-    #[command(flatten)]
-    pub common_registry_args: CommonRegistryArgs,
 }
 
 /// Update markdown files.
@@ -85,7 +81,7 @@ pub(crate) fn command(
         &registry_repo,
         generator,
         &mut diag_msgs,
-        args.common_registry_args.follow_symlinks,
+        args.registry.follow_symlinks,
     )?;
 
     if is_future_mode_enabled() && !diag_msgs.is_empty() {
@@ -139,9 +135,7 @@ mod tests {
 
     use crate::cli::{Cli, Commands};
     use crate::registry::update_markdown::RegistryUpdateMarkdownArgs;
-    use crate::registry::{
-        CommonRegistryArgs, RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand,
-    };
+    use crate::registry::{RegistryArgs, RegistryCommand, RegistryPath, RegistrySubCommand};
     use crate::run_command;
 
     #[test]
@@ -158,15 +152,13 @@ mod tests {
                         registry: RegistryPath::LocalFolder {
                             path: "data/update_markdown/registry".to_owned(),
                         },
+                        follow_symlinks: false,
                     },
                     dry_run: true,
                     attribute_registry_base_url: Some("/docs/attributes-registry".to_owned()),
                     templates: "data/update_markdown/templates".to_owned(),
                     diagnostic: Default::default(),
                     target: "markdown".to_owned(),
-                    common_registry_args: CommonRegistryArgs {
-                        follow_symlinks: false,
-                    },
                 }),
             })),
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -205,10 +205,25 @@ pub(crate) fn resolve_semconv_specs(
     Ok(resolved_schema)
 }
 
+/// Resolves the main registry and optionally checks policies.
+/// This is a common starting point for some `registry` commands.
+/// e.g., `check`, `generate`, `resolve`
+///
+/// # Arguments
+///
+/// * `registry_args` - The common CLI args for the main registry.
+/// * `policy_args` - The common CLI args for policies.
+/// * `logger` - The logger for logging messages.
+/// * `diag_msgs` - The DiagnosticMessages to append to.
+///
+/// # Returns
+///
+/// A `Result` containing the `ResolvedRegistry` and `PolicyEngine` on success, or
+/// `DiagnosticMessages` on failure.
 pub(crate) fn prepare_main_registry(
-    logger: impl Logger + Sync + Clone,
     registry_args: &RegistryArgs,
     policy_args: &PolicyArgs,
+    logger: impl Logger + Sync + Clone,
     diag_msgs: &mut DiagnosticMessages,
 ) -> Result<(ResolvedRegistry, Option<Engine>), DiagnosticMessages> {
     let registry_path = &registry_args.registry;
@@ -285,10 +300,6 @@ pub(crate) fn prepare_main_registry(
         })
         .capture_non_fatal_errors(diag_msgs)?;
     }
-
-    // if !diag_msgs.is_empty() {
-    //     return Err(diag_msgs);
-    // }
 
     Ok((main_resolved_registry, policy_engine))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,7 +18,7 @@ use weaver_resolver::SchemaResolver;
 use weaver_semconv::registry::SemConvRegistry;
 use weaver_semconv::semconv::SemConvSpec;
 
-use crate::registry::RegistryArgs;
+use crate::registry::{PolicyArgs, RegistryArgs};
 
 /// Loads the semantic convention specifications from a registry path.
 ///
@@ -208,9 +208,7 @@ pub(crate) fn resolve_semconv_specs(
 pub(crate) fn prepare_main_registry(
     logger: impl Logger + Sync + Clone,
     registry_args: &RegistryArgs,
-    skip_policies: bool,
-    policies: &[PathBuf],
-    display_policy_coverage: bool,
+    policy_args: &PolicyArgs,
     diag_msgs: &mut DiagnosticMessages,
 ) -> Result<(ResolvedRegistry, Option<Engine>), DiagnosticMessages> {
     let registry_path = &registry_args.registry;
@@ -226,11 +224,11 @@ pub(crate) fn prepare_main_registry(
     .capture_non_fatal_errors(diag_msgs)?;
 
     // Optionally init policy engine
-    let mut policy_engine = if !skip_policies {
+    let mut policy_engine = if !policy_args.skip_policies {
         Some(init_policy_engine(
             &main_registry_repo,
-            policies,
-            display_policy_coverage,
+            &policy_args.policies,
+            policy_args.display_policy_coverage,
         )?)
     } else {
         None

--- a/tests/registry_generate.rs
+++ b/tests/registry_generate.rs
@@ -44,6 +44,6 @@ fn test_cli_interface() {
     // We should be able to parse the JSON output from stdout.
     let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8");
     let json_value: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("Invalid JSON");
-    // We expect 13 policy violations.
-    assert_eq!(json_value.len(), 13);
+    // We expect 37 policy violations.
+    assert_eq!(json_value.len(), 37);
 }


### PR DESCRIPTION
- Refactored CLI registry commands to remove some duplication. Resolving the registry with policy checks is common for `generate`, `resolve` and `check`.
- Added missing `after_resolution` policy checks to `generate` and `resolve` through the common code.
- Removed duplication in CLI args to maintain consistency.
- Removed the deprecated `--registry-git-sub-dir` option.
- Fixed bug in `check` if `--skip-policies` was specified then it would not fail for any validation errors. e.g. this fails `registry check -r "https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/v1.27.0.zip[model]" --future` but this would pass `registry check -r "https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/v1.27.0.zip[model]" --future --skip-policies`