### PR TITLE
`is_experimental` returns `true` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 What's changed
 
+* For issue [#569](Add include_stability config into semconv_grouped_attributes): `is_experimental` returns `true` by default. ([#5??](https://github.com/open-telemetry/weaver/pull/5??) by @jerbly). 
 * Added an OTLP receiver to Weaver to prepare for the `weaver registry live-check` command. (see [#548](https://github.com/open-telemetry/weaver/pull/548) by @lquerel)
 * Refactored CLI registry commands to remove some duplication. Resolving the registry with policy checks is common for `generate`, `resolve` and `check`. ([#536](https://github.com/open-telemetry/weaver/pull/536) by @jerbly).
   * Added missing `after_resolution` policy checks to `generate` and `resolve` through the common code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 What's changed
 
-* For issue [#569](Add include_stability config into semconv_grouped_attributes): `is_experimental` returns `true` by default. ([#5??](https://github.com/open-telemetry/weaver/pull/5??) by @jerbly). 
+* For issue [#569](Add include_stability config into semconv_grouped_attributes): `is_experimental` returns `true` by default. ([#570](https://github.com/open-telemetry/weaver/pull/570) by @jerbly). 
 * Added an OTLP receiver to Weaver to prepare for the `weaver registry live-check` command. (see [#548](https://github.com/open-telemetry/weaver/pull/548) by @lquerel)
 * Refactored CLI registry commands to remove some duplication. Resolving the registry with policy checks is common for `generate`, `resolve` and `check`. ([#536](https://github.com/open-telemetry/weaver/pull/536) by @jerbly).
   * Added missing `after_resolution` policy checks to `generate` and `resolve` through the common code.

--- a/crates/weaver_codegen_test/semconv_registry/registry/system.yaml
+++ b/crates/weaver_codegen_test/semconv_registry/registry/system.yaml
@@ -16,6 +16,7 @@ groups:
               value: 'nice'
             - id: idle
               value: 'idle'
+              stability: stable
             - id: iowait
               value: 'iowait'
               stability: experimental

--- a/crates/weaver_forge/src/extensions/otel.rs
+++ b/crates/weaver_forge/src/extensions/otel.rs
@@ -278,7 +278,8 @@ pub(crate) fn is_stable(input: &Value) -> bool {
 }
 
 /// Checks if the input value is an object with a field named "stability" that has any value
-/// other than "stable". Otherwise, it returns false.
+/// other than "stable". Otherwise, it returns true. This implies that undefined stability
+/// is considered experimental for safety.
 #[must_use]
 pub(crate) fn is_experimental(input: &Value) -> bool {
     let result = input.get_attr("stability");
@@ -288,7 +289,7 @@ pub(crate) fn is_experimental(input: &Value) -> bool {
             return stability != "stable";
         }
     }
-    false
+    true
 }
 
 /// Checks if the input value is an object with a field named "stability" that has the value "deprecated".
@@ -753,7 +754,7 @@ mod tests {
             id: "test".to_owned(),
             r#type: "test".to_owned(),
         });
-        assert!(!is_experimental(&object));
+        assert!(is_experimental(&object));
     }
 
     #[test]


### PR DESCRIPTION
For issue #569 - Add include_stability config into semconv_grouped_attributes: `is_experimental` returns `true` by default.