### PR TITLE
[WIP] Live check implementation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,17 +12,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // - Comment the following lines.
     // - Commit the changes.
 
-    // tonic_build::configure()
-    //     // .build_client(false)
-    //     .out_dir("src/registry/otlp/grpc_stubs")
-    //     .compile_protos(
-    //         &[
-    //             "src/registry/otlp/proto/opentelemetry/proto/collector/logs/v1/logs_service.proto",
-    //             "src/registry/otlp/proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
-    //             "src/registry/otlp/proto/opentelemetry/proto/collector/trace/v1/trace_service.proto",
-    //         ],
-    //         &["src/registry/otlp/proto"],
-    //     )?;
+    tonic_build::configure()
+        .build_client(false)
+        .out_dir("src/registry/otlp/grpc_stubs")
+        .compile_protos(
+            &[
+                "src/registry/otlp/proto/opentelemetry/proto/collector/logs/v1/logs_service.proto",
+                "src/registry/otlp/proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
+                "src/registry/otlp/proto/opentelemetry/proto/collector/trace/v1/trace_service.proto",
+            ],
+            &["src/registry/otlp/proto"],
+        )?;
 
     Ok(())
 }

--- a/crates/weaver_forge/src/registry.rs
+++ b/crates/weaver_forge/src/registry.rs
@@ -28,7 +28,7 @@ pub struct ResolvedRegistry {
 }
 
 /// Resolved group specification used in the context of the template engine.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, Eq, Hash)]
 pub struct ResolvedGroup {
     /// The id that uniquely identifies the semantic convention.
     pub id: String,

--- a/crates/weaver_resolved_schema/src/lineage.rs
+++ b/crates/weaver_resolved_schema/src/lineage.rs
@@ -11,7 +11,7 @@ use weaver_semconv::attribute::{AttributeSpec, Examples, RequirementLevel};
 use weaver_semconv::stability::Stability;
 
 /// Attribute lineage (at the field level).
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub struct AttributeLineage {
     /// The group id where the attribute is coming from.
@@ -29,7 +29,7 @@ pub struct AttributeLineage {
 }
 
 /// Group lineage.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, Eq, Hash)]
 #[must_use]
 pub struct GroupLineage {
     /// The path or URL of the source file where the group is defined.

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -7,7 +7,11 @@ use crate::registry::{PolicyArgs, RegistryArgs};
 use crate::util::prepare_main_registry;
 use crate::{DiagnosticArgs, ExitDirectives};
 use clap::Args;
+use std::collections::HashSet;
+use weaver_forge::registry::ResolvedGroup;
 use std::time::Duration;
+use weaver_semconv::group::GroupType;
+use weaver_semconv::requirement_level::RequirementLevel;
 use weaver_common::diagnostic::DiagnosticMessages;
 use weaver_common::Logger;
 
@@ -64,7 +68,7 @@ pub(crate) fn command(
     )?;
 
     // @ToDo Use the following resolved registry to check the level of compliance of the incoming OTLP messages
-    let (_resolved_registry, _) =
+    let (resolved_registry, _) =
         prepare_main_registry(&args.registry, &policy, logger.clone(), &mut diag_msgs)?;
 
     logger.loading(&format!(
@@ -72,24 +76,110 @@ pub(crate) fn command(
         args.otlp_grpc_port
     ));
 
-    // @ToDo Implement the checking logic
+    let registry_data = resolved_registry.groups;
+
+    // use a hashset to keep track of what registry items are seen in the OTLP stream
+    let mut registry_set: HashSet<&ResolvedGroup> = HashSet::new();
+    for registry_item in registry_data.iter() {
+        registry_set.insert(registry_item);
+    }
+    let mut report: Vec<String> = Vec::new();
+    let registry_data_seen: HashSet<&ResolvedGroup> = HashSet::new();
+    // @ToDo Implement the checking logic d
     for otlp_request in otlp_requests {
         match otlp_request {
             OtlpRequest::Logs(_logs) => {
-                // ToDo Implement the checking logic for logs
+                for logs in _logs.resource_logs {
+                    for scope_logs in logs.scope_logs {
+                        for log_data in scope_logs.log_records {
+                            // Check if log attributes match registry definition
+                            if let Some(registry_log) = registry_data.iter().find(|m| m.r#type == GroupType::Event && m.name == Some(log_data.event_name)) {
+                                // compare the attributes stored in _registry_log.attributes to log_data.attributes
+                                registry_data_seen.insert(registry_log);
+                                // Validate log event name matches registry definition
+                                let mut attrs: HashSet<String> = log_data.attributes.iter().map(|attribute_key_value| attribute_key_value.key ).collect();
+                                for attribute in registry_log.attributes.iter() {
+                                    if (attribute.requirement_level == RequirementLevel::Basic) && !(attrs.contains(&attribute.name)) {
+                                        report.push(format!("Log event'{}' has missing required attribute '{}'", log_data.event_name, attribute.name));
+                                    }
+                                }
+                            } else {
+                                // Report missing log event in registry
+                                report.push(format!("Log event '{}' not found in registry",log_data.event_name));
+                            }
+                        }
+                    }
+                }
                 println!("Logs Request received");
             }
             OtlpRequest::Metrics(_metrics) => {
-                // ToDo Implement the checking logic for metrics
+                for metric in _metrics.resource_metrics {
+                    for scope_metric in metric.scope_metrics {
+                        for metric_data in scope_metric.metrics {
+                            if let Some(registry_metric) = registry_data.iter().find(|m| m.r#type == GroupType::Metric && m.metric_name == Some(metric_data.name)) {
+                                registry_data_seen.insert(registry_metric);
+                                if registry_metric.unit != Some(metric_data.unit) {
+                                    // Report mismatched unit
+                                    report.push(format!("Metric {} has a mismatched unit", metric_data.name));
+                                }
+                            } else {
+
+                                // Report missing metric in registry
+                                report.push(format!("Metric {} not found in registry", metric_data.name));
+                            }
+                        }
+                    }
+                }
                 println!("Metrics Request received");
             }
             OtlpRequest::Traces(_traces) => {
-                // ToDo Implement the checking logic for traces
+                for traces in _traces.resource_spans {
+                    for scope_traces in traces.scope_spans {
+                        for span_data in scope_traces.spans {
+                            // Check if span attributes match registry definition
+                            if let Some(registry_span) = registry_data.iter().find(|m| m.r#type == GroupType::Span && m.id.replace("span.", "") == Some(span_data.name)) {
+                                // compare the attributes stored in _registry_span.attributes to span_data.attributes
+                                // if they do match mark the span as seen
+                                registry_data_seen.insert(registry_span);
+                                // store all attributes in a hashset to quickly check for attribute existence
+                                let mut attrs = span_data.attributes.iter().map(|attribute_key_value| attribute_key_value.key ).collect();
+
+                                for attribute in registry_span.attributes.iter() {
+                                    if (attribute.requirement_level == RequirementLevel::Basic) && !attrs.contains(&attribute.name) {
+                                        report.push(format!("Span event '{}' has missing required attribute '{}'", span_data.name, attribute.name));
+                                    }
+                                }
+
+                            } else {
+
+                                // Report missing span in registry
+                                report.push(format!("Span {} not found in registry", span_data.name));
+                            }
+                        }
+                    }
+                }
                 println!("Trace Request received");
             }
             OtlpRequest::Stop(reason) => {
                 logger.warn(&format!("Stopping the listener, reason: {}", reason));
-                // ToDo Generate the report here
+
+                // difference between hashset registry_set - registry_data_seen = missing items in registry_data_seen
+                // difference between registry_data_seen - registry_set = missing items in registry_set
+                
+                let registry_missing = registry_set.difference(&registry_data_seen).collect();
+                let missing_items_in_registry_data_seen: HashSet<&ResolvedGroup> =
+                    registry_data_seen.d
+                
+                // loop through registry_set to print out ids that are not in registry_data_seen
+                for registry_item in registry_set.iter() {
+                    println!("Registry item {} not found in registry", registry_item.id);
+                }
+                
+                // iter through _report and print out each error
+                for report in report {
+                    println!("{}", report);
+                }
+                println!("Stopping the listener, reason: {}", reason);
                 break;
             }
             OtlpRequest::Error(error) => {
@@ -110,3 +200,4 @@ pub(crate) fn command(
         quiet_mode: false,
     })
 }
+

--- a/src/registry/otlp/grpc_stubs/opentelemetry.proto.collector.logs.v1.rs
+++ b/src/registry/otlp/grpc_stubs/opentelemetry.proto.collector.logs.v1.rs
@@ -7,7 +7,9 @@ pub struct ExportLogsServiceRequest {
     /// data from multiple origins typically batch the data before forwarding further and
     /// in that case this array will contain multiple elements.
     #[prost(message, repeated, tag = "1")]
-    pub resource_logs: ::prost::alloc::vec::Vec<super::super::super::logs::v1::ResourceLogs>,
+    pub resource_logs: ::prost::alloc::vec::Vec<
+        super::super::super::logs::v1::ResourceLogs,
+    >,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsServiceResponse {
@@ -47,122 +49,6 @@ pub struct ExportLogsPartialSuccess {
     #[prost(string, tag = "2")]
     pub error_message: ::prost::alloc::string::String,
 }
-/// Generated client implementations.
-pub mod logs_service_client {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::wildcard_imports,
-        clippy::let_unit_value
-    )]
-    use tonic::codegen::http::Uri;
-    use tonic::codegen::*;
-    /// Service that can be used to push logs between one Application instrumented with
-    /// OpenTelemetry and an collector, or between an collector and a central collector (in this
-    /// case logs are sent/received to/from multiple Applications).
-    #[derive(Debug, Clone)]
-    pub struct LogsServiceClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl LogsServiceClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> LogsServiceClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_origin(inner: T, origin: Uri) -> Self {
-            let inner = tonic::client::Grpc::with_origin(inner, origin);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> LogsServiceClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
-        {
-            LogsServiceClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with the given encoding.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.send_compressed(encoding);
-            self
-        }
-        /// Enable decompressing responses.
-        #[must_use]
-        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.accept_compressed(encoding);
-            self
-        }
-        /// Limits the maximum size of a decoded message.
-        ///
-        /// Default: `4MB`
-        #[must_use]
-        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_decoding_message_size(limit);
-            self
-        }
-        /// Limits the maximum size of an encoded message.
-        ///
-        /// Default: `usize::MAX`
-        #[must_use]
-        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_encoding_message_size(limit);
-            self
-        }
-        /// For performance reasons, it is recommended to keep this RPC
-        /// alive for the entire life of the application.
-        pub async fn export(
-            &mut self,
-            request: impl tonic::IntoRequest<super::ExportLogsServiceRequest>,
-        ) -> std::result::Result<tonic::Response<super::ExportLogsServiceResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/opentelemetry.proto.collector.logs.v1.LogsService/Export",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "opentelemetry.proto.collector.logs.v1.LogsService",
-                "Export",
-            ));
-            self.inner.unary(req, path, codec).await
-        }
-    }
-}
 /// Generated server implementations.
 pub mod logs_service_server {
     #![allow(
@@ -170,7 +56,7 @@ pub mod logs_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with LogsServiceServer.
@@ -181,7 +67,10 @@ pub mod logs_service_server {
         async fn export(
             &self,
             request: tonic::Request<super::ExportLogsServiceRequest>,
-        ) -> std::result::Result<tonic::Response<super::ExportLogsServiceResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ExportLogsServiceResponse>,
+            tonic::Status,
+        >;
     }
     /// Service that can be used to push logs between one Application instrumented with
     /// OpenTelemetry and an collector, or between an collector and a central collector (in this
@@ -207,7 +96,10 @@ pub mod logs_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -262,19 +154,23 @@ pub mod logs_service_server {
                 "/opentelemetry.proto.collector.logs.v1.LogsService/Export" => {
                     #[allow(non_camel_case_types)]
                     struct ExportSvc<T: LogsService>(pub Arc<T>);
-                    impl<T: LogsService>
-                        tonic::server::UnaryService<super::ExportLogsServiceRequest>
-                        for ExportSvc<T>
-                    {
+                    impl<
+                        T: LogsService,
+                    > tonic::server::UnaryService<super::ExportLogsServiceRequest>
+                    for ExportSvc<T> {
                         type Response = super::ExportLogsServiceResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ExportLogsServiceRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as LogsService>::export(&inner, request).await };
+                            let fut = async move {
+                                <T as LogsService>::export(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -300,19 +196,23 @@ pub mod logs_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/src/registry/otlp/grpc_stubs/opentelemetry.proto.collector.metrics.v1.rs
+++ b/src/registry/otlp/grpc_stubs/opentelemetry.proto.collector.metrics.v1.rs
@@ -7,8 +7,9 @@ pub struct ExportMetricsServiceRequest {
     /// data from multiple origins typically batch the data before forwarding further and
     /// in that case this array will contain multiple elements.
     #[prost(message, repeated, tag = "1")]
-    pub resource_metrics:
-        ::prost::alloc::vec::Vec<super::super::super::metrics::v1::ResourceMetrics>,
+    pub resource_metrics: ::prost::alloc::vec::Vec<
+        super::super::super::metrics::v1::ResourceMetrics,
+    >,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportMetricsServiceResponse {
@@ -48,122 +49,6 @@ pub struct ExportMetricsPartialSuccess {
     #[prost(string, tag = "2")]
     pub error_message: ::prost::alloc::string::String,
 }
-/// Generated client implementations.
-pub mod metrics_service_client {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::wildcard_imports,
-        clippy::let_unit_value
-    )]
-    use tonic::codegen::http::Uri;
-    use tonic::codegen::*;
-    /// Service that can be used to push metrics between one Application
-    /// instrumented with OpenTelemetry and a collector, or between a collector and a
-    /// central collector.
-    #[derive(Debug, Clone)]
-    pub struct MetricsServiceClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl MetricsServiceClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> MetricsServiceClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_origin(inner: T, origin: Uri) -> Self {
-            let inner = tonic::client::Grpc::with_origin(inner, origin);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> MetricsServiceClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
-        {
-            MetricsServiceClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with the given encoding.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.send_compressed(encoding);
-            self
-        }
-        /// Enable decompressing responses.
-        #[must_use]
-        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.accept_compressed(encoding);
-            self
-        }
-        /// Limits the maximum size of a decoded message.
-        ///
-        /// Default: `4MB`
-        #[must_use]
-        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_decoding_message_size(limit);
-            self
-        }
-        /// Limits the maximum size of an encoded message.
-        ///
-        /// Default: `usize::MAX`
-        #[must_use]
-        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_encoding_message_size(limit);
-            self
-        }
-        /// For performance reasons, it is recommended to keep this RPC
-        /// alive for the entire life of the application.
-        pub async fn export(
-            &mut self,
-            request: impl tonic::IntoRequest<super::ExportMetricsServiceRequest>,
-        ) -> std::result::Result<tonic::Response<super::ExportMetricsServiceResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "opentelemetry.proto.collector.metrics.v1.MetricsService",
-                "Export",
-            ));
-            self.inner.unary(req, path, codec).await
-        }
-    }
-}
 /// Generated server implementations.
 pub mod metrics_service_server {
     #![allow(
@@ -171,7 +56,7 @@ pub mod metrics_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with MetricsServiceServer.
@@ -182,7 +67,10 @@ pub mod metrics_service_server {
         async fn export(
             &self,
             request: tonic::Request<super::ExportMetricsServiceRequest>,
-        ) -> std::result::Result<tonic::Response<super::ExportMetricsServiceResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ExportMetricsServiceResponse>,
+            tonic::Status,
+        >;
     }
     /// Service that can be used to push metrics between one Application
     /// instrumented with OpenTelemetry and a collector, or between a collector and a
@@ -208,7 +96,10 @@ pub mod metrics_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -263,19 +154,23 @@ pub mod metrics_service_server {
                 "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export" => {
                     #[allow(non_camel_case_types)]
                     struct ExportSvc<T: MetricsService>(pub Arc<T>);
-                    impl<T: MetricsService>
-                        tonic::server::UnaryService<super::ExportMetricsServiceRequest>
-                        for ExportSvc<T>
-                    {
+                    impl<
+                        T: MetricsService,
+                    > tonic::server::UnaryService<super::ExportMetricsServiceRequest>
+                    for ExportSvc<T> {
                         type Response = super::ExportMetricsServiceResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ExportMetricsServiceRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as MetricsService>::export(&inner, request).await };
+                            let fut = async move {
+                                <T as MetricsService>::export(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -301,19 +196,23 @@ pub mod metrics_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/src/registry/otlp/grpc_stubs/opentelemetry.proto.collector.trace.v1.rs
+++ b/src/registry/otlp/grpc_stubs/opentelemetry.proto.collector.trace.v1.rs
@@ -7,7 +7,9 @@ pub struct ExportTraceServiceRequest {
     /// data from multiple origins typically batch the data before forwarding further and
     /// in that case this array will contain multiple elements.
     #[prost(message, repeated, tag = "1")]
-    pub resource_spans: ::prost::alloc::vec::Vec<super::super::super::trace::v1::ResourceSpans>,
+    pub resource_spans: ::prost::alloc::vec::Vec<
+        super::super::super::trace::v1::ResourceSpans,
+    >,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTraceServiceResponse {
@@ -47,122 +49,6 @@ pub struct ExportTracePartialSuccess {
     #[prost(string, tag = "2")]
     pub error_message: ::prost::alloc::string::String,
 }
-/// Generated client implementations.
-pub mod trace_service_client {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::wildcard_imports,
-        clippy::let_unit_value
-    )]
-    use tonic::codegen::http::Uri;
-    use tonic::codegen::*;
-    /// Service that can be used to push spans between one Application instrumented with
-    /// OpenTelemetry and a collector, or between a collector and a central collector (in this
-    /// case spans are sent/received to/from multiple Applications).
-    #[derive(Debug, Clone)]
-    pub struct TraceServiceClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl TraceServiceClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> TraceServiceClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_origin(inner: T, origin: Uri) -> Self {
-            let inner = tonic::client::Grpc::with_origin(inner, origin);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> TraceServiceClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
-        {
-            TraceServiceClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with the given encoding.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.send_compressed(encoding);
-            self
-        }
-        /// Enable decompressing responses.
-        #[must_use]
-        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.accept_compressed(encoding);
-            self
-        }
-        /// Limits the maximum size of a decoded message.
-        ///
-        /// Default: `4MB`
-        #[must_use]
-        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_decoding_message_size(limit);
-            self
-        }
-        /// Limits the maximum size of an encoded message.
-        ///
-        /// Default: `usize::MAX`
-        #[must_use]
-        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_encoding_message_size(limit);
-            self
-        }
-        /// For performance reasons, it is recommended to keep this RPC
-        /// alive for the entire life of the application.
-        pub async fn export(
-            &mut self,
-            request: impl tonic::IntoRequest<super::ExportTraceServiceRequest>,
-        ) -> std::result::Result<tonic::Response<super::ExportTraceServiceResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/opentelemetry.proto.collector.trace.v1.TraceService/Export",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "opentelemetry.proto.collector.trace.v1.TraceService",
-                "Export",
-            ));
-            self.inner.unary(req, path, codec).await
-        }
-    }
-}
 /// Generated server implementations.
 pub mod trace_service_server {
     #![allow(
@@ -170,7 +56,7 @@ pub mod trace_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with TraceServiceServer.
@@ -181,7 +67,10 @@ pub mod trace_service_server {
         async fn export(
             &self,
             request: tonic::Request<super::ExportTraceServiceRequest>,
-        ) -> std::result::Result<tonic::Response<super::ExportTraceServiceResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ExportTraceServiceResponse>,
+            tonic::Status,
+        >;
     }
     /// Service that can be used to push spans between one Application instrumented with
     /// OpenTelemetry and a collector, or between a collector and a central collector (in this
@@ -207,7 +96,10 @@ pub mod trace_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -262,19 +154,23 @@ pub mod trace_service_server {
                 "/opentelemetry.proto.collector.trace.v1.TraceService/Export" => {
                     #[allow(non_camel_case_types)]
                     struct ExportSvc<T: TraceService>(pub Arc<T>);
-                    impl<T: TraceService>
-                        tonic::server::UnaryService<super::ExportTraceServiceRequest>
-                        for ExportSvc<T>
-                    {
+                    impl<
+                        T: TraceService,
+                    > tonic::server::UnaryService<super::ExportTraceServiceRequest>
+                    for ExportSvc<T> {
                         type Response = super::ExportTraceServiceResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ExportTraceServiceRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as TraceService>::export(&inner, request).await };
+                            let fut = async move {
+                                <T as TraceService>::export(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -300,19 +196,23 @@ pub mod trace_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/src/registry/otlp/grpc_stubs/opentelemetry.proto.metrics.v1.rs
+++ b/src/registry/otlp/grpc_stubs/opentelemetry.proto.metrics.v1.rs
@@ -606,7 +606,9 @@ pub struct Exemplar {
     /// recorded alongside the original measurement. Only key/value pairs that were
     /// filtered out by the aggregator should be included
     #[prost(message, repeated, tag = "7")]
-    pub filtered_attributes: ::prost::alloc::vec::Vec<super::super::common::v1::KeyValue>,
+    pub filtered_attributes: ::prost::alloc::vec::Vec<
+        super::super::common::v1::KeyValue,
+    >,
     /// time_unix_nano is the exact time when this exemplar was recorded
     ///
     /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January

--- a/src/registry/otlp/grpc_stubs/opentelemetry.proto.trace.v1.rs
+++ b/src/registry/otlp/grpc_stubs/opentelemetry.proto.trace.v1.rs
@@ -202,7 +202,9 @@ pub mod span {
         /// Attribute keys MUST be unique (it is not allowed to have more than one
         /// attribute with the same key).
         #[prost(message, repeated, tag = "3")]
-        pub attributes: ::prost::alloc::vec::Vec<super::super::super::common::v1::KeyValue>,
+        pub attributes: ::prost::alloc::vec::Vec<
+            super::super::super::common::v1::KeyValue,
+        >,
         /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
         /// then no attributes were dropped.
         #[prost(uint32, tag = "4")]
@@ -228,7 +230,9 @@ pub mod span {
         /// Attribute keys MUST be unique (it is not allowed to have more than one
         /// attribute with the same key).
         #[prost(message, repeated, tag = "4")]
-        pub attributes: ::prost::alloc::vec::Vec<super::super::super::common::v1::KeyValue>,
+        pub attributes: ::prost::alloc::vec::Vec<
+            super::super::super::common::v1::KeyValue,
+        >,
         /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
         /// then no attributes were dropped.
         #[prost(uint32, tag = "5")]
@@ -255,7 +259,17 @@ pub mod span {
     }
     /// SpanKind is the type of span. Can be used to specify additional relationships between spans
     /// in addition to a parent/child relationship.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum SpanKind {
         /// Unspecified. Do NOT use as default.
@@ -323,7 +337,17 @@ pub struct Status {
 pub mod status {
     /// For the semantics of status codes see
     /// <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status>
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum StatusCode {
         /// The default status.


### PR DESCRIPTION
Basic starting implementation of the live-check command. 

Mapped OTLP requests data to their respective semantic convention registry files to check for any mismatches. 

Reported some mismatches with attributes, units and missing signal definitions 