### PR TITLE
simplify the span exporter

### DIFF
--- a/crates/weaver_emit/src/spans.rs
+++ b/crates/weaver_emit/src/spans.rs
@@ -174,8 +174,6 @@ mod tests {
 
     #[derive(Debug)]
     pub struct SpanExporter {
-        // resource: Resource,
-        // is_shutdown: atomic::AtomicBool,
         spans: Arc<Mutex<Vec<export::trace::SpanData>>>,
     }
 


### PR DESCRIPTION
This simplifies the span exporter to remove the atomic lock on shutdown. This is to stop a flaky test.