### PR TITLE
fix(forge): Fix the Jinja test `is deprecated`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 What's changed
 
 * For issue [#596](https://github.com/open-telemetry/weaver/issues/596) - Fix the Jinja deprecated test to accept the
-  new deprecated format. ([]() by @lquerel).
+  new deprecated format. ([#597](https://github.com/open-telemetry/weaver/pull/597) by @lquerel).
 
 ## [0.13.0] - 2025-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.1] - 2025-02-12
+
+What's changed
+
+* For issue [#596](https://github.com/open-telemetry/weaver/issues/596) - Fix the Jinja deprecated test to accept the
+  new deprecated format. ([]() by @lquerel).
+
 ## [0.13.0] - 2025-02-07
 
 What's changed


### PR DESCRIPTION
This issue fixes the problem introduced by the change to the `deprecated` field, which transitioned from a simple string to a struct. The Jinja test `is deprecated` previously expected a string, it now checks for the presence of a struct.  

Note: I didn't need to modify the JQ filter `exclude_deprecated` since it was already checking for the presence or absence of a value.
 
Closes: https://github.com/open-telemetry/weaver/issues/596