### PR TITLE
Deprecate deprecated stability level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file.
 What's changed
 
 * Add support for annotations on attributes and groups. ([#645](https://github.com/open-telemetry/weaver/pull/645) by @lquerel).
-* 💥 BREAKING CHANGE 💥 - Upgrade to version 0.4.0 of regorus [requires all v0 policies to be modified](https://github.com/microsoft/regorus/pull/373). Policy upgrade instructions [here](https://www.openpolicyagent.org/docs/latest/v0-upgrade/#upgrading-rego) may help. ([#651](https://github.com/open-telemetry/weaver/pull/651) by @jerbly). 
+* 💥 BREAKING CHANGE 💥 - Upgrade to version 0.4.0 of regorus [requires all v0 policies to be modified](https://github.com/microsoft/regorus/pull/373). Policy upgrade instructions [here](https://www.openpolicyagent.org/docs/latest/v0-upgrade/#upgrading-rego) may help. ([#651](https://github.com/open-telemetry/weaver/pull/651) by @jerbly).
+* Stability level `Deprecated` is deprecated. Conventions should be deprecated via `deprecated` field and should keep the original stability. ([#607](https://github.com/open-telemetry/weaver/pull/607) by @lmolkova).
 
 ## [0.13.2] - 2025-02-13
 
@@ -39,11 +40,11 @@ What's changed
 
 
 
-* Improvement of comment generation: removal of `<p>` tags that precede `@` Javadoc tags. 
+* Improvement of comment generation: removal of `<p>` tags that precede `@` Javadoc tags.
   ([#574](https://github.com/open-telemetry/weaver/pull/574) by @trask).
 * For Issue [#564](https://github.com/open-telemetry/weaver/issues/564) - Require attributes and event fields to have stability: Added warnings for missing stability
   on: Attributes, Enum members in attributes, Event AnyValues, Enum members in AnyValues. ([#568](https://github.com/open-telemetry/weaver/pull/568) by @jerbly).
-* For issue [#569](Add include_stability config into semconv_grouped_attributes): `is_experimental` returns `true` by default. ([#570](https://github.com/open-telemetry/weaver/pull/570) by @jerbly). 
+* For issue [#569](Add include_stability config into semconv_grouped_attributes): `is_experimental` returns `true` by default. ([#570](https://github.com/open-telemetry/weaver/pull/570) by @jerbly).
 * Added an OTLP receiver to Weaver to prepare for the `weaver registry live-check` command. (see [#548](https://github.com/open-telemetry/weaver/pull/548) by @lquerel)
 * Add is_array filter and test for AttributeType. ([#540](https://github.com/open-telemetry/weaver/pull/540) by @arthurDiff).
 * Refactored CLI registry commands to remove some duplication. Resolving the registry with policy checks is common for
@@ -61,7 +62,7 @@ What's changed
   `semconv_signal`, `semconv_grouped_attributes`, and other `semconv_*` JQ semconv helpers. When `stable_only` is set to `true`,
   corresponding helper function returns stable conventions only. If the flag is not set or set to false, stability filtering does not apply.
   It's recommended to use `stable_only` flag instead of `exclude_stability` parameter.
-  ([#588](https://github.com/open-telemetry/weaver/pull/588) by @lmolkova)  
+  ([#588](https://github.com/open-telemetry/weaver/pull/588) by @lmolkova)
 
 ## [0.12.0] - 2024-12-09
 

--- a/crates/weaver_forge/src/extensions/otel.rs
+++ b/crates/weaver_forge/src/extensions/otel.rs
@@ -738,15 +738,6 @@ mod tests {
         });
         assert!(is_experimental(&attr));
 
-        // An attribute with stability "deprecated"
-        let attr = Value::from_object(DynAttr {
-            id: "test".to_owned(),
-            r#type: "test".to_owned(),
-            stability: "deprecated".to_owned(),
-            deprecated: None,
-        });
-        assert!(is_experimental(&attr));
-
         // An attribute with stability "stable"
         let attr = Value::from_object(DynAttr {
             id: "test".to_owned(),

--- a/crates/weaver_semconv/src/group.rs
+++ b/crates/weaver_semconv/src/group.rs
@@ -872,6 +872,7 @@ mod tests {
             requirement_level: Default::default(),
             sampling_relevant: None,
             note: "".to_owned(),
+            annotations: None,
         }];
         let result = group.validate("<test>").into_result_failing_non_fatal();
         assert_eq!(
@@ -946,6 +947,7 @@ mod tests {
             requirement_level: Default::default(),
             sampling_relevant: None,
             note: "".to_owned(),
+            annotations: None,
         }];
         let result = group.validate("<test>").into_result_failing_non_fatal();
         assert_eq!(

--- a/crates/weaver_semconv/src/group.rs
+++ b/crates/weaver_semconv/src/group.rs
@@ -274,7 +274,7 @@ impl GroupSpec {
                             attribute_id: attribute.id(),
                             error: "Missing stability field.".to_owned(),
                         });
-                    } else if stability.clone().unwrap() == Stability::Deprecated {
+                    } else if stability.clone() == Some(Stability::Deprecated) {
                         errors.push(Error::InvalidAttributeWarning {
                             path_or_url: path_or_url.to_owned(),
                             group_id: self.id.clone(),

--- a/crates/weaver_semconv/src/group.rs
+++ b/crates/weaver_semconv/src/group.rs
@@ -578,7 +578,7 @@ mod tests {
             note: "test".to_owned(),
             prefix: "".to_owned(),
             extends: None,
-            stability: Some(Stability::Deprecated),
+            stability: Some(Stability::Development),
             deprecated: Some(Deprecated::Obsoleted {
                 note: "".to_owned(),
             }),
@@ -586,7 +586,7 @@ mod tests {
                 id: "test".to_owned(),
                 r#type: AttributeType::PrimitiveOrArray(PrimitiveOrArrayTypeSpec::String),
                 brief: None,
-                stability: Some(Stability::Deprecated),
+                stability: Some(Stability::Development),
                 deprecated: Some(Deprecated::Obsoleted {
                     note: "".to_owned(),
                 }),
@@ -713,7 +713,7 @@ mod tests {
             note: "test".to_owned(),
             prefix: "".to_owned(),
             extends: None,
-            stability: Some(Stability::Deprecated),
+            stability: Some(Stability::Development),
             deprecated: Some(Deprecated::Obsoleted {
                 note: "".to_owned(),
             }),
@@ -721,7 +721,7 @@ mod tests {
                 id: "test".to_owned(),
                 r#type: AttributeType::PrimitiveOrArray(PrimitiveOrArrayTypeSpec::String),
                 brief: None,
-                stability: Some(Stability::Deprecated),
+                stability: Some(Stability::Development),
                 deprecated: Some(Deprecated::Obsoleted {
                     note: "".to_owned(),
                 }),
@@ -753,7 +753,7 @@ mod tests {
             id: "test".to_owned(),
             r#type: AttributeType::PrimitiveOrArray(PrimitiveOrArrayTypeSpec::String),
             brief: None,
-            stability: Some(Stability::Deprecated),
+            stability: Some(Stability::Development),
             deprecated: Some(Deprecated::Obsoleted {
                 note: "".to_owned(),
             }),
@@ -781,7 +781,7 @@ mod tests {
             id: "test".to_owned(),
             r#type: AttributeType::PrimitiveOrArray(PrimitiveOrArrayTypeSpec::Strings),
             brief: None,
-            stability: Some(Stability::Deprecated),
+            stability: Some(Stability::Development),
             deprecated: Some(Deprecated::Obsoleted {
                 note: "".to_owned(),
             }),
@@ -878,7 +878,7 @@ mod tests {
             note: "test".to_owned(),
             prefix: "".to_owned(),
             extends: None,
-            stability: Some(Stability::Deprecated),
+            stability: Some(Stability::Development),
             deprecated: Some(Deprecated::Obsoleted {
                 note: "".to_owned(),
             }),
@@ -889,7 +889,7 @@ mod tests {
                     allow_custom_values: Some(true),
                 },
                 brief: None,
-                stability: Some(Stability::Deprecated),
+                stability: Some(Stability::Development),
                 deprecated: Some(Deprecated::Obsoleted {
                     note: "".to_owned(),
                 }),
@@ -931,7 +931,7 @@ mod tests {
                 allow_custom_values: None,
             },
             brief: None,
-            stability: Some(Stability::Deprecated),
+            stability: Some(Stability::Development),
             deprecated: Some(Deprecated::Obsoleted {
                 note: "".to_owned(),
             }),
@@ -956,7 +956,7 @@ mod tests {
             note: "test".to_owned(),
             prefix: "".to_owned(),
             extends: None,
-            stability: Some(Stability::Deprecated),
+            stability: Some(Stability::Development),
             deprecated: Some(Deprecated::Obsoleted {
                 note: "".to_owned(),
             }),
@@ -1317,7 +1317,7 @@ mod tests {
                 id: "test".to_owned(),
                 r#type: AttributeType::PrimitiveOrArray(PrimitiveOrArrayTypeSpec::String),
                 brief: None,
-                stability: Some(Stability::Deprecated),
+                stability: Some(Stability::Development),
                 deprecated: Some(Deprecated::Obsoleted {
                     note: "".to_owned(),
                 }),
@@ -1463,7 +1463,7 @@ mod tests {
             id: "test".to_owned(),
             r#type: AttributeType::PrimitiveOrArray(PrimitiveOrArrayTypeSpec::String),
             brief: None,
-            stability: Some(Stability::Deprecated),
+            stability: Some(Stability::Development),
             deprecated: Some(Deprecated::Obsoleted {
                 note: "".to_owned(),
             }),

--- a/crates/weaver_semconv/src/stability.rs
+++ b/crates/weaver_semconv/src/stability.rs
@@ -10,6 +10,9 @@ use std::fmt::{Display, Formatter};
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Stability {
+    /// A deprecated definition.
+    #[deprecated(note = "This stability level is deprecated.")]
+    Deprecated,
     /// A stable definition.
     Stable,
     /// A definition in development. Formally known as experimental.
@@ -32,6 +35,7 @@ impl Display for Stability {
             Stability::Alpha => write!(f, "alpha"),
             Stability::Beta => write!(f, "beta"),
             Stability::ReleaseCandidate => write!(f, "release_candidate"),
+            Stability::Deprecated => write!(f, "deprecated"),
         }
     }
 }
@@ -43,6 +47,9 @@ mod tests {
 
     #[test]
     fn test_deserialize_stability() {
+        let deprecated: Stability = serde_json::from_str("\"deprecated\"").unwrap();
+        assert_eq!(deprecated, Stability::Deprecated);
+
         let stable: Stability = serde_json::from_str("\"stable\"").unwrap();
         assert_eq!(stable, Stability::Stable);
 

--- a/crates/weaver_semconv/src/stability.rs
+++ b/crates/weaver_semconv/src/stability.rs
@@ -10,8 +10,6 @@ use std::fmt::{Display, Formatter};
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Stability {
-    /// A deprecated definition.
-    Deprecated,
     /// A stable definition.
     Stable,
     /// A definition in development. Formally known as experimental.
@@ -29,7 +27,6 @@ pub enum Stability {
 impl Display for Stability {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Stability::Deprecated => write!(f, "deprecated"),
             Stability::Stable => write!(f, "stable"),
             Stability::Development => write!(f, "development"),
             Stability::Alpha => write!(f, "alpha"),
@@ -46,9 +43,6 @@ mod tests {
 
     #[test]
     fn test_deserialize_stability() {
-        let deprecated: Stability = serde_json::from_str("\"deprecated\"").unwrap();
-        assert_eq!(deprecated, Stability::Deprecated);
-
         let stable: Stability = serde_json::from_str("\"stable\"").unwrap();
         assert_eq!(stable, Stability::Stable);
 
@@ -70,7 +64,6 @@ mod tests {
 
     #[test]
     fn test_display() {
-        assert_eq!(Stability::Deprecated.to_string(), "deprecated");
         assert_eq!(Stability::Stable.to_string(), "stable");
         assert_eq!(Stability::Development.to_string(), "development");
         assert_eq!(Stability::Alpha.to_string(), "alpha");

--- a/crates/xtask/src/history.rs
+++ b/crates/xtask/src/history.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 const REPO_URL: &str = "https://github.com/open-telemetry/semantic-conventions.git";
 const ARCHIVE_URL: &str =
     "https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/";
-const START_TAG: &str = "v1.22.0";
+const START_TAG: &str = "v1.25.0";
 const TEMP_REPO_DIR: &str = "history-temp-repo";
 
 /// Get the git repository, no checkout

--- a/crates/xtask/src/history.rs
+++ b/crates/xtask/src/history.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 const REPO_URL: &str = "https://github.com/open-telemetry/semantic-conventions.git";
 const ARCHIVE_URL: &str =
     "https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/";
-const START_TAG: &str = "v1.25.0";
+const START_TAG: &str = "v1.22.0";
 const TEMP_REPO_DIR: &str = "history-temp-repo";
 
 /// Get the git repository, no checkout

--- a/schemas/semconv-syntax.md
+++ b/schemas/semconv-syntax.md
@@ -61,7 +61,6 @@ extends ::= string
 
 stability ::= "stable"
           |   "development"
-          |   "deprecated"
           |   "alpha"
           |   "beta"
           |   "release_candidate"

--- a/schemas/semconv.schema.json
+++ b/schemas/semconv.schema.json
@@ -596,7 +596,6 @@
 			"enum": [
 				"stable",
 				"development",
-				"deprecated",
 				"alpha",
 				"beta",
 				"release_candidate"


### PR DESCRIPTION
Semconv don't use `stability: deprecated` for 1+ years (since version 1.24.0) - https://github.com/open-telemetry/semantic-conventions/pull/588. This is necessary to know if deprecated attribute was stable when it was deprecated (and therefore must be generated in semconv artifact) or it was experimental and does not have to be generated.

Having it in weaver is not necessary and misleading. Let's remove it.