### PR TITLE
docs(changelog): should be deprecated.note to use as of weaver 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ What's changed
     conventions must be updated to adopt this new format.
   * The changes related to the `deprecated` field (i.e., string → struct) also have a potential impact on certain
     templates that reference the `deprecated` field as containing text. These templates will need to be updated to use
-    the `brief` field, which provides a textual explanation of the reasons for the deprecation.
+    the `note` field, which provides a textual explanation of the reasons for the deprecation.
 
 
 


### PR DESCRIPTION
I was updating the semconv package for OTel JS to the new version of weaver, and I believe the mention of `deprecated.brief` in the weaver 0.13.0 change log is wrong: should be `deprecated.note`.