### PR TITLE
improve documentation (open-telemetry/weaver#583)

### DIFF
--- a/crates/weaver_forge/README.md
+++ b/crates/weaver_forge/README.md
@@ -24,7 +24,10 @@ Weaver Forge is a component of OTEL Weaver that facilitates documentation and
 code generation from a semantic convention registry. It uses MiniJinja, a
 template engine compatible with Jinja2 syntax, which provides extensive
 customization options (refer to this [GitHub repository](https://github.com/mitsuhiko/minijinja)
-for more details). To streamline template creation for semantic conventions,
+for more details). Some good references to start developing Jinja2 templages are 
+[1](https://ttl255.com/jinja2-tutorial-part-2-loops-and-conditionals/) and 
+[2](https://jinja.palletsprojects.com/en/stable/templates).
+To streamline template creation for semantic conventions,
 additional filters, functions, tests, and naming conventions have been
 integrated with the standard Jinja logic.
 
@@ -313,7 +316,7 @@ grouped by root namespace. The `application_mode` is set to `each` so that the t
 applied to each object in the array, i.e., to each group of attributes for a given root namespace.
 
 A series of JQ filters dedicated to the manipulation of semantic conventions registries is
-available to template authors.
+available to template authors. They can be found [here](/defaults/jq/semconv.jq)
 
 **Process Registry Attributes**
 
@@ -480,7 +483,8 @@ compatibility extensions that are also enabled in Weaver.
 In addition, OTel Weaver provides a set of custom filters to facilitate the
 generation of documentation and code.
 
-The following filters are available:
+The following filters are available (the code for all available extension can be found 
+[here](./src/extensions)):
 
 - `lower_case`: Converts a string to lowercase.
 - `upper_case`: Converts a string to UPPERCASE.


### PR DESCRIPTION
### PR to improve documentation in regards to feedback provided on #583 

This is my first PR for an open telemetry project. Any feedback is welcome.  Tried to address all points listed on #583 as follows:


> - Provide better documentation for Jinja templates. Many users may not have recent experience with Jinja, so linking to good external resources would be helpful. e.g.: [1](https://ttl255.com/jinja2-tutorial-part-2-loops-and-conditionals/), [2](https://jinja.palletsprojects.com/en/stable/templates).


added references to those docs on [`crates/weaver_forge/README.md`](crates/weaver_forge/README.md)
 
> - Clarify where functions like kebab_case come from and document other built-in helper functions available in Weaver. Ideally, provide a direct link to the relevant source [file](https://github.com/open-telemetry/weaver/blob/e9e53503cb67d8cf186e7a48d4c7b1bf93d6a9f6/crates/weaver_forge/src/extensions/case.rs#L72).


Added reference to  [`crates/weaver_forge/README.md`](crates/weaver_forge/README.md)

> - The semconv schema documentation should be more concise and prominently placed in the documentation hierarchy (both in [JSON](/schemas/semconv.schema.json) and [Markdown](/schemas/semconv-syntax.md) formats).


[README.md](crates/weaver_forge/README.md) provides extensive documentation and examples with proper titles and navigation. not sure if there's a need to break it down into separate files.

The file is linked by [Markdown](https://github.com/open-telemetry/weaver/blob/main/schemas/semconv-syntax.md) formats).


> - Improve accessibility of the [Weaver YAML schema](https://github.com/open-telemetry/weaver/blob/main/docs/weaver-config.md) documentation by providing a more prominent and direct link.


[Markdown](/schemas/semconv-syntax.md)  already references the more complete documentation on line [194](/schemas/semconv-syntax.md#194) 

> - The filter parameter is confusing for first-time users. It would be useful to document:
>   - The default behavior when no filter is applied.
>   - Simple filtering examples.
>   - Explanation of the ctx variable and how it interacts with filtering.

[Markdown](/schemas/semconv-syntax.md) already provides many examples and explanation on how to use those filters. added a reference to the code where jq extensions are listed `/defaults/jq/semconv.jq`