### PR TITLE
WIP - fix(stats): Skip group calculations if we don't have instances

### DIFF
--- a/src/registry/stats.rs
+++ b/src/registry/stats.rs
@@ -191,16 +191,18 @@ fn display_common_group_stats(group_type: &GroupType, common_stats: &CommonGroup
             .collect::<Vec<_>>()
             .join(", ")
     );
-    println!(
-        "      - Number of group with a prefix: {} ({}%)",
-        common_stats.total_with_prefix,
-        common_stats.total_with_prefix * 100 / common_stats.count
-    );
-    println!(
-        "      - Number of group with a note: {} ({}%)",
-        common_stats.total_with_note,
-        common_stats.total_with_note * 100 / common_stats.count
-    );
+    if common_stats.count > 0 {
+        println!(
+            "      - Number of group with a prefix: {} ({}%)",
+            common_stats.total_with_prefix,
+            common_stats.total_with_prefix * 100 / common_stats.count
+        );
+        println!(
+            "      - Number of group with a note: {} ({}%)",
+            common_stats.total_with_note,
+            common_stats.total_with_note * 100 / common_stats.count
+        );
+    }
     if !common_stats.stability_breakdown.is_empty() {
         println!(
             "      - Stability breakdown ({}%):",


### PR DESCRIPTION
When playing around with https://github.com/open-telemetry/weaver/pull/627, I noticed a panic when running `stats` against the custom registry:
```
✔ `acme` semconv registry `tests/custom_registry` loaded (177 files)
Semantic Convention Registry Stats:
  - Total number of files: 177
✔ `acme` semconv registry resolved
Resolved Telemetry Schema Stats:
Registry
  - 2 groups
    - 0 Metrics
      - Total number of attributes: 0
        - [(attributes card: frequency), ...]: []

thread 'main' panicked at src/registry/stats.rs:198:13:
attempt to divide by zero
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


# Test
`cargo run registry stats -r tests/custom_registry`.

# Expected behavior
No panic