### PR TITLE
Fix division by zero and incorrect attribute counting in weaver registry stats command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6040,7 +6040,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
  "thiserror 2.0.12",
  "weaver_semconv",
  "weaver_version",

--- a/crates/weaver_resolved_schema/Cargo.toml
+++ b/crates/weaver_resolved_schema/Cargo.toml
@@ -19,7 +19,6 @@ thiserror.workspace = true
 serde.workspace = true
 ordered-float.workspace = true
 schemars.workspace = true
-serde_yaml.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/weaver_resolved_schema/src/attribute.rs
+++ b/crates/weaver_resolved_schema/src/attribute.rs
@@ -4,7 +4,6 @@
 
 //! Specification of a resolved attribute.
 
-use std::cell::{Cell, RefCell};
 use crate::tags::Tags;
 use crate::value::Value;
 use schemars::JsonSchema;
@@ -12,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::ops::Not;
-use std::rc::Rc;
 #[cfg(test)]
 use weaver_semconv::attribute::PrimitiveOrArrayTypeSpec;
 use weaver_semconv::attribute::{AttributeSpec, AttributeType, Examples, RequirementLevel};
@@ -100,7 +98,7 @@ pub struct UnresolvedAttribute {
 
 /// An internal reference to an attribute in the catalog.
 #[derive(
-    Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, JsonSchema, Hash
+    Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, JsonSchema, Hash,
 )]
 pub struct AttributeRef(pub u32);
 

--- a/crates/weaver_resolved_schema/src/attribute.rs
+++ b/crates/weaver_resolved_schema/src/attribute.rs
@@ -4,6 +4,7 @@
 
 //! Specification of a resolved attribute.
 
+use std::cell::{Cell, RefCell};
 use crate::tags::Tags;
 use crate::value::Value;
 use schemars::JsonSchema;
@@ -11,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::ops::Not;
+use std::rc::Rc;
 #[cfg(test)]
 use weaver_semconv::attribute::PrimitiveOrArrayTypeSpec;
 use weaver_semconv::attribute::{AttributeSpec, AttributeType, Examples, RequirementLevel};
@@ -98,7 +100,7 @@ pub struct UnresolvedAttribute {
 
 /// An internal reference to an attribute in the catalog.
 #[derive(
-    Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, JsonSchema,
+    Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, JsonSchema, Hash
 )]
 pub struct AttributeRef(pub u32);
 

--- a/crates/weaver_resolved_schema/src/registry.rs
+++ b/crates/weaver_resolved_schema/src/registry.rs
@@ -254,92 +254,90 @@ impl Registry {
             group_breakdown: self.groups.iter().fold(HashMap::new(), |mut acc, group| {
                 let group_type = group.r#type.clone();
 
-                _ =
-                    acc.entry(group_type)
-                        .and_modify(|stats| match stats {
-                            AttributeGroup { common_stats } => {
-                                common_stats.update_stats(group);
-                            }
-                            Metric {
-                                common_stats,
-                                metric_names,
-                                instrument_breakdown,
-                                unit_breakdown,
-                            } => {
-                                common_stats.update_stats(group);
-                                _ =
-                                    metric_names.insert(group.metric_name.clone().expect(
-                                        "metric_name is required as we are in a metric group",
-                                    ));
-                                *instrument_breakdown
-                                    .entry(group.instrument.clone().expect(
-                                        "instrument is required as we are in a metric group",
-                                    ))
-                                    .or_insert(0) += 1;
-                                *unit_breakdown
-                                    .entry(
-                                        group
-                                            .unit
-                                            .clone()
-                                            .expect("unit is required as we are in a metric group"),
-                                    )
-                                    .or_insert(0) += 1;
-                            }
-                            MetricGroup { common_stats } => {
-                                common_stats.update_stats(group);
-                            }
-                            Event { common_stats } => {
-                                common_stats.update_stats(group);
-                            }
-                            Resource { common_stats } => {
-                                common_stats.update_stats(group);
-                            }
-                            Scope { common_stats } => {
-                                common_stats.update_stats(group);
-                            }
-                            Span {
-                                common_stats,
-                                span_kind_breakdown,
-                            } => {
-                                common_stats.update_stats(group);
-                                if let Some(span_kind) = group.span_kind.clone() {
-                                    *span_kind_breakdown.entry(span_kind).or_insert(0) += 1;
-                                }
-                            }
-                        })
-                        .or_insert_with(|| match group.r#type {
-                            GroupType::AttributeGroup => AttributeGroup {
-                                common_stats: CommonGroupStats::default(),
-                            },
-                            GroupType::Metric => Metric {
-                                common_stats: CommonGroupStats::default(),
-                                metric_names: HashSet::new(),
-                                instrument_breakdown: HashMap::new(),
-                                unit_breakdown: HashMap::new(),
-                            },
-                            GroupType::MetricGroup => MetricGroup {
-                                common_stats: CommonGroupStats::default(),
-                            },
-                            GroupType::Event => Event {
-                                common_stats: CommonGroupStats::default(),
-                            },
-                            GroupType::Resource => Resource {
-                                common_stats: CommonGroupStats::default(),
-                            },
-                            GroupType::Scope => Scope {
-                                common_stats: CommonGroupStats::default(),
-                            },
-                            GroupType::Span => Span {
-                                common_stats: CommonGroupStats::default(),
-                                span_kind_breakdown: HashMap::new(),
-                            },
-                            GroupType::Undefined => {
-                                // This should never happen in a valid registry,
-                                // this variant is used for backward compatibility
-                                // which is not important for stats.
-                                panic!("Undefined group type found in registry")
-                            }
-                        });
+                // Ensure we have an initialized entry
+                let entry = acc.entry(group_type.clone()).or_insert_with(|| match group_type {
+                    GroupType::AttributeGroup => AttributeGroup {
+                        common_stats: CommonGroupStats::default(),
+                    },
+                    GroupType::Metric => Metric {
+                        common_stats: CommonGroupStats::default(),
+                        metric_names: HashSet::new(),
+                        instrument_breakdown: HashMap::new(),
+                        unit_breakdown: HashMap::new(),
+                    },
+                    GroupType::MetricGroup => MetricGroup {
+                        common_stats: CommonGroupStats::default(),
+                    },
+                    GroupType::Event => Event {
+                        common_stats: CommonGroupStats::default(),
+                    },
+                    GroupType::Resource => Resource {
+                        common_stats: CommonGroupStats::default(),
+                    },
+                    GroupType::Scope => Scope {
+                        common_stats: CommonGroupStats::default(),
+                    },
+                    GroupType::Span => Span {
+                        common_stats: CommonGroupStats::default(),
+                        span_kind_breakdown: HashMap::new(),
+                    },
+                    GroupType::Undefined => panic!("Undefined group type found in registry"),
+                });
+
+                // Update stats
+                match entry {
+                    AttributeGroup { common_stats } => {
+                        common_stats.update_stats(group);
+                    }
+                    Metric {
+                        common_stats,
+                        metric_names,
+                        instrument_breakdown,
+                        unit_breakdown,
+                    } => {
+                        common_stats.update_stats(group);
+
+                        let metric_name = group
+                            .metric_name
+                            .clone()
+                            .expect("metric_name is required as we are in a metric group");
+                        _ = metric_names.insert(metric_name);
+
+                        let instrument = group
+                            .instrument
+                            .clone()
+                            .expect("instrument is required as we are in a metric group");
+                        *instrument_breakdown.entry(instrument).or_insert(0) += 1;
+
+                        let unit = group
+                            .unit
+                            .clone()
+                            .expect("unit is required as we are in a metric group");
+                        *unit_breakdown.entry(unit).or_insert(0) += 1;
+                    }
+                    MetricGroup { common_stats } => {
+                        common_stats.update_stats(group);
+                    }
+                    Event { common_stats } => {
+                        common_stats.update_stats(group);
+                    }
+                    Resource { common_stats } => {
+                        common_stats.update_stats(group);
+                    }
+                    Scope { common_stats } => {
+                        common_stats.update_stats(group);
+                    }
+                    Span {
+                        common_stats,
+                        span_kind_breakdown,
+                    } => {
+                        common_stats.update_stats(group);
+                        if let Some(span_kind) = group.span_kind.clone() {
+                            *span_kind_breakdown.entry(span_kind).or_insert(0) += 1;
+                        }
+                    }
+                }
+
                 acc
             }),
         }

--- a/src/registry/stats.rs
+++ b/src/registry/stats.rs
@@ -136,6 +136,9 @@ fn display_schema_stats(schema: &ResolvedTelemetrySchema) {
                         println!("        - {:#?}: {}", span_kind, count);
                     }
                 }
+                GroupStats::Undefined { common_stats } => {
+                    display_common_group_stats(group_type, common_stats);
+                }
             }
         }
     }
@@ -191,16 +194,18 @@ fn display_common_group_stats(group_type: &GroupType, common_stats: &CommonGroup
             .collect::<Vec<_>>()
             .join(", ")
     );
-    println!(
-        "      - Number of group with a prefix: {} ({}%)",
-        common_stats.total_with_prefix,
-        common_stats.total_with_prefix * 100 / common_stats.count
-    );
-    println!(
-        "      - Number of group with a note: {} ({}%)",
-        common_stats.total_with_note,
-        common_stats.total_with_note * 100 / common_stats.count
-    );
+    if common_stats.count > 0 {
+        println!(
+            "      - Number of group with a prefix: {} ({}%)",
+            common_stats.total_with_prefix,
+            common_stats.total_with_prefix * 100 / common_stats.count
+        );
+        println!(
+            "      - Number of group with a note: {} ({}%)",
+            common_stats.total_with_note,
+            common_stats.total_with_note * 100 / common_stats.count
+        );
+    }
     if !common_stats.stability_breakdown.is_empty() {
         println!(
             "      - Stability breakdown ({}%):",

--- a/tests/registry_stats.rs
+++ b/tests/registry_stats.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Test the registry stats command.
+
+use assert_cmd::Command;
+
+/// This test checks the CLI interface for the registry stats command.
+/// This test doesn't count for the coverage report as it runs a separate process.
+#[test]
+fn test_cli_interface() {
+    let mut cmd = Command::cargo_bin("weaver").unwrap();
+    let output = cmd
+        .arg("registry")
+        .arg("stats")
+        .arg("-r")
+        .arg("tests/custom_registry")
+        .timeout(std::time::Duration::from_secs(60))
+        .output()
+        .expect("failed to execute process");
+
+    assert!(output.status.success());
+}


### PR DESCRIPTION
@xiu reported a bug in the execution of the command `weaver registry stats` when applied to the custom registry located in `tests/custom_registry`. This registry contained only one `attribute_group` and a single `metric`, and the counting logic was off by one, resulting in a division by zero error.

Additionally, testing the stats command revealed another issue. When the `--include-unreferenced` flag is inactive, groups not referenced in the top-level registry are removed. However, the catalog of unique attributes wasn’t purged accordingly. This resulted in inflated statistics. This PR also addresses this issue by ensuring the attributes catalog now only includes attributes referenced by groups returned after the resolution phase. It’s important to note that this attribute catalog purging issue had no problematic effect on commands such as resolve, template, ...

Finally, another previously unnoticed problem, introduced with the concept of an `undefined` group type, was fixed in the `weaver registry stats` command. A corresponding test has also been added.