### PR TITLE
Support remote templates and policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # [TBD] - TBD
 
 * Add shell completion functionality. ([#682](https://github.com/open-telemetry/weaver/pull/682) by @larrys)
+* Add support for remote templates and policies. ([#700](https://github.com/open-telemetry/weaver/pull/700) by @lquerel)
 
 ## [0.14.0] - 2025-04-10
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,40 @@ Telemetry Schemas.
 - Presentation slides from the Semantic Convention SIG meeting on October 23,
   2023 [here](https://docs.google.com/presentation/d/1nxt5VFlC1mUjZ8eecUYK4e4SxThpIVj1IRnIcodMsNI/edit?usp=sharing).
 
+## Examples of Code and Documentation Generation
+
+The following examples show how to generate code and documentation for various languages using Weaver.
+
+> Note: A more out of the box experience will be available in the future.
+
+**Java**
+From GitHub repo main branch.
+
+```bash
+weaver registry generate --templates https://github.com/open-telemetry/semantic-conventions-java.git[buildscripts/templates] java
+```
+
+**C++**
+From a specific release using the corresponding archive.
+
+```bash
+weaver registry generate --templates https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.20.0.zip[buildscripts/semantic-convention/templates] ./ --param filter=any --param output=output/ --param schema_url=https://opentelemetry.io/schemas/v1.32.0
+```
+
+**Python**
+From GitHub repo main branch.
+
+```bash
+weaver registry generate --templates https://github.com/open-telemetry/opentelemetry-python.git[scripts/semconv/templates] --param output=./ --param filter=any ./
+```
+
+**Markdown (attribute registry)**
+From a specific release using a GitHub archive release.
+
+```bash
+weaver registry generate --templates https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/v1.32.0.zip[templates] markdown
+```
+
 ## Experimental
 
 - [Component Telemetry Schema](docs/component-telemetry-schema.md) (proposal)

--- a/README.md
+++ b/README.md
@@ -180,28 +180,49 @@ The following examples show how to generate code and documentation for various l
 From GitHub repo main branch.
 
 ```bash
-weaver registry generate --templates https://github.com/open-telemetry/semantic-conventions-java.git[buildscripts/templates] java
+weaver registry generate \
+--templates https://github.com/open-telemetry/semantic-conventions-java.git[buildscripts/templates] \
+java
 ```
 
 **C++**
 From a specific release using the corresponding archive.
 
 ```bash
-weaver registry generate --templates https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.20.0.zip[buildscripts/semantic-convention/templates] ./ --param filter=any --param output=output/ --param schema_url=https://opentelemetry.io/schemas/v1.32.0
+weaver registry generate \
+--templates https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.20.0.zip[buildscripts/semantic-convention/templates] \
+./ \
+--param filter=any \
+--param output=output/ \
+--param schema_url=https://opentelemetry.io/schemas/v1.32.0
 ```
 
 **Python**
 From GitHub repo main branch.
 
 ```bash
-weaver registry generate --templates https://github.com/open-telemetry/opentelemetry-python.git[scripts/semconv/templates] --param output=./ --param filter=any ./
+weaver registry generate \
+--templates https://github.com/open-telemetry/opentelemetry-python.git[scripts/semconv/templates] \
+--param output=./ \
+--param filter=any \
+./
 ```
 
 **Markdown (attribute registry)**
 From a specific release using a GitHub archive release.
 
 ```bash
-weaver registry generate --templates https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/v1.32.0.zip[templates] markdown
+weaver registry generate \
+--templates https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/v1.32.0.zip[templates] \
+markdown
+```
+
+**Templates in local path**
+
+```bash
+weaver registry generate \
+--templates custom-templates/ \
+markdown
 ```
 
 ## Experimental

--- a/crates/weaver_common/src/lib.rs
+++ b/crates/weaver_common/src/lib.rs
@@ -60,6 +60,15 @@ pub enum Error {
         error: String,
     },
 
+    /// A virtual directory error.
+    #[error("Virtual directory `{path}` is invalid: {error}")]
+    InvalidVirtualDirectory {
+        /// The virtual directory path
+        path: String,
+        /// The error message
+        error: String,
+    },
+
     /// An invalid registry archive.
     #[error("The registry archive `{archive}` is invalid: {error}")]
     InvalidRegistryArchive {

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -16,6 +16,8 @@ use weaver_forge::{OutputDirective, TemplateEngine};
 use crate::registry::{Error, PolicyArgs, RegistryArgs};
 use crate::util::prepare_main_registry;
 use crate::{DiagnosticArgs, ExitDirectives};
+use weaver_common::vdir::VirtualDirectoryPath;
+use weaver_common::vdir::VirtualDirectory;
 
 /// Parameters for the `registry generate` sub-command
 #[derive(Debug, Args)]
@@ -31,7 +33,7 @@ pub struct RegistryGenerateArgs {
     /// Path to the directory where the templates are located.
     /// Default is the `templates` directory.
     #[arg(short = 't', long, default_value = "templates")]
-    pub templates: PathBuf,
+    pub templates: VirtualDirectoryPath,
 
     /// List of `weaver.yaml` configuration files to use. When there is a conflict, the last one
     /// will override the previous ones for the keys that are defined in both.
@@ -97,7 +99,12 @@ pub(crate) fn command(
         prepare_main_registry(&args.registry, &args.policy, logger.clone(), &mut diag_msgs)?;
 
     let params = generate_params(args)?;
-    let loader = FileSystemFileLoader::try_new(args.templates.join("registry"), &args.target)?;
+    let templates_dir = VirtualDirectory::try_new(&args.templates)
+        .map_err(|e| Error::InvalidParams {
+            params_file: PathBuf::from(args.templates.to_string()),
+            error: e.to_string(),
+        })?;
+    let loader = FileSystemFileLoader::try_new(templates_dir.path().join("registry"), &args.target)?;
     let config = if let Some(paths) = &args.config {
         WeaverConfig::try_from_config_files(paths)
     } else {
@@ -179,7 +186,9 @@ mod tests {
                 command: RegistrySubCommand::Generate(RegistryGenerateArgs {
                     target: "rust".to_owned(),
                     output: temp_output.clone(),
-                    templates: PathBuf::from("crates/weaver_codegen_test/templates/"),
+                    templates: VirtualDirectoryPath::LocalFolder {
+                        path: "crates/weaver_codegen_test/templates/".to_owned(),
+                    },
                     config: None,
                     param: None,
                     params: None,
@@ -255,7 +264,9 @@ mod tests {
                 command: RegistrySubCommand::Generate(RegistryGenerateArgs {
                     target: "rust".to_owned(),
                     output: temp_output.clone(),
-                    templates: PathBuf::from("crates/weaver_codegen_test/templates/"),
+                    templates: VirtualDirectoryPath::LocalFolder {
+                        path: "crates/weaver_codegen_test/templates/".to_owned(),
+                    },
                     config: None,
                     param: None,
                     params: None,
@@ -296,7 +307,9 @@ mod tests {
                 command: RegistrySubCommand::Generate(RegistryGenerateArgs {
                     target: "rust".to_owned(),
                     output: temp_output.clone(),
-                    templates: PathBuf::from("crates/weaver_codegen_test/templates/"),
+                    templates: VirtualDirectoryPath::LocalFolder {
+                        path: "crates/weaver_codegen_test/templates/".to_owned(),
+                    },
                     config: Some(vec![
                         PathBuf::from(
                             "crates/weaver_codegen_test/templates/registry/alt_weaver.yaml",
@@ -409,7 +422,9 @@ mod tests {
                     command: RegistrySubCommand::Generate(RegistryGenerateArgs {
                         target: "rust".to_owned(),
                         output: temp_output.clone(),
-                        templates: PathBuf::from("crates/weaver_codegen_test/templates/"),
+                        templates: VirtualDirectoryPath::LocalFolder {
+                            path: "crates/weaver_codegen_test/templates/".to_owned(),
+                        },
                         config: None,
                         param: None,
                         params: None,

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -16,8 +16,8 @@ use weaver_forge::{OutputDirective, TemplateEngine};
 use crate::registry::{Error, PolicyArgs, RegistryArgs};
 use crate::util::prepare_main_registry;
 use crate::{DiagnosticArgs, ExitDirectives};
-use weaver_common::vdir::VirtualDirectoryPath;
 use weaver_common::vdir::VirtualDirectory;
+use weaver_common::vdir::VirtualDirectoryPath;
 
 /// Parameters for the `registry generate` sub-command
 #[derive(Debug, Args)]
@@ -99,12 +99,13 @@ pub(crate) fn command(
         prepare_main_registry(&args.registry, &args.policy, logger.clone(), &mut diag_msgs)?;
 
     let params = generate_params(args)?;
-    let templates_dir = VirtualDirectory::try_new(&args.templates)
-        .map_err(|e| Error::InvalidParams {
+    let templates_dir =
+        VirtualDirectory::try_new(&args.templates).map_err(|e| Error::InvalidParams {
             params_file: PathBuf::from(args.templates.to_string()),
             error: e.to_string(),
         })?;
-    let loader = FileSystemFileLoader::try_new(templates_dir.path().join("registry"), &args.target)?;
+    let loader =
+        FileSystemFileLoader::try_new(templates_dir.path().join("registry"), &args.target)?;
     let config = if let Some(paths) = &args.config {
         WeaverConfig::try_from_config_files(paths)
     } else {

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -171,7 +171,7 @@ pub struct PolicyArgs {
     /// convention registry.  If a directory is provided all `.rego` files in the directory will be
     /// loaded.
     #[arg(short = 'p', long = "policy")]
-    pub policies: Vec<PathBuf>,
+    pub policies: Vec<VirtualDirectoryPath>,
 
     /// Skip the policy checks.
     #[arg(long, default_value = "false")]

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -7,15 +7,15 @@ use crate::registry::RegistryArgs;
 use crate::{DiagnosticArgs, ExitDirectives};
 use clap::Args;
 use weaver_common::diagnostic::{is_future_mode_enabled, DiagnosticMessages};
+use weaver_common::vdir::VirtualDirectory;
+use weaver_common::vdir::VirtualDirectoryPath;
+use weaver_common::Error;
 use weaver_common::Logger;
 use weaver_forge::config::{Params, WeaverConfig};
 use weaver_forge::file_loader::FileSystemFileLoader;
 use weaver_forge::TemplateEngine;
 use weaver_semconv::registry_repo::RegistryRepo;
 use weaver_semconv_gen::{update_markdown, SnippetGenerator};
-use weaver_common::vdir::VirtualDirectoryPath;
-use weaver_common::vdir::VirtualDirectory;
-use weaver_common::Error;
 
 /// Parameters for the `registry update-markdown` sub-command
 #[derive(Debug, Args)]
@@ -69,15 +69,14 @@ pub(crate) fn command(
 
     // Construct a generator if we were given a `--target` argument.
     let generator = {
-        let templates_dir = VirtualDirectory::try_new(&args.templates)
-            .map_err(|e| Error::InvalidVirtualDirectory {
+        let templates_dir = VirtualDirectory::try_new(&args.templates).map_err(|e| {
+            Error::InvalidVirtualDirectory {
                 path: args.templates.to_string(),
                 error: e.to_string(),
-            })?;
-        let loader = FileSystemFileLoader::try_new(
-            templates_dir.path().join("registry"),
-            &args.target,
-        )?;
+            }
+        })?;
+        let loader =
+            FileSystemFileLoader::try_new(templates_dir.path().join("registry"), &args.target)?;
         let config = WeaverConfig::try_from_loader(&loader)?;
         TemplateEngine::new(config, loader, Params::default())
     };


### PR DESCRIPTION
This PR extends the concept of a virtual directory, already used to specify a semantic convention registry, to templates and policies. It is now possible to reference templates and policies located in:
- A local directory
- A public git repository
- A remote or local archive (zip or tar.gz)

Not yet supported:
- Git tags, branches, and commit hashes
- Private repositories requiring authentication

The following examples show how to generate code and documentation for various languages using this new option.

> Note: A more out of the box experience will be available in the future.

**Java**
From GitHub repo main branch.

```bash
weaver registry generate --templates https://github.com/open-telemetry/semantic-conventions-java.git[buildscripts/templates] java
```

**C++**
From a specific release using the corresponding archive.

```bash
weaver registry generate --templates https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.20.0.zip[buildscripts/semantic-convention/templates] ./ --param filter=any --param output=output/ --param schema_url=https://opentelemetry.io/schemas/v1.32.0
```

**Python**
From GitHub repo main branch.

```bash
weaver registry generate --templates https://github.com/open-telemetry/opentelemetry-python.git[scripts/semconv/templates] --param output=./ --param filter=any ./
```

**Markdown (attribute registry)**
From a specific release using a GitHub archive release.

```bash
weaver registry generate --templates https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/v1.32.0.zip[templates] markdown
```

Closes https://github.com/open-telemetry/weaver/issues/688