### PR TITLE
Use the re-export of crossterm from ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,9 +337,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
@@ -760,7 +760,6 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix 0.38.44",
- "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -5880,7 +5879,6 @@ dependencies = [
  "assert_cmd",
  "clap",
  "clap_complete",
- "crossterm",
  "include_dir",
  "itertools 0.14.0",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,6 @@ clap = { version = "4.5.36", features = ["derive"] }
 clap_complete = "4.5.47"
 rayon = "1.10.0"
 ratatui = { version = "0.29.0", features = ["serde"] }
-crossterm = { version = "0.28.1", features = ["serde"] }
 tui-textarea = "0.7.0"
 tokio = { version = "1.44.2", features = ["rt", "net", "signal"] }
 prost = "0.13.4"

--- a/src/registry/search.rs
+++ b/src/registry/search.rs
@@ -15,12 +15,12 @@ use crate::{
     util::{load_semconv_specs, resolve_semconv_specs},
     DiagnosticArgs, ExitDirectives,
 };
-use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-    ExecutableCommand,
-};
 use ratatui::{
+    crossterm::{
+        event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+        ExecutableCommand,
+    },
     layout::{Constraint, Direction, Layout},
     prelude::{CrosstermBackend, Terminal},
     style::{Color, Modifier, Style},


### PR DESCRIPTION
This will fix #684 

Crossterm 0.29.0 is not compatible with ratatui 0.29.0. I've switched this to use the re-export of crossterm instead.