### PR TITLE
Rename `resource` group type to `entity`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Add shell completion functionality. ([#682](https://github.com/open-telemetry/weaver/pull/682) by @larrys)
 - Add support for remote templates and policies. ([#700](https://github.com/open-telemetry/weaver/pull/700) by @lquerel)
 - Add [Live Check](https://github.com/open-telemetry/weaver/blob/main/crates/weaver_live_check/README.md) for Spans via OTLP/JSON and loose Attributes via JSON/Text. ([#630](https://github.com/open-telemetry/weaver/pull/630) by @jerbly)
+- 💥 BREAKING CHANGE 💥 `resource` groups are now called `entity` groups.  All JQ helper methods have been updated, but any template directly interacting with
+  `group.type` may be broken. ([#714](https://github.com/open-telemetry/weaver/pull/714) by @jsuereth)
 
 ## [0.14.0] - 2025-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - Add support for remote templates and policies. ([#700](https://github.com/open-telemetry/weaver/pull/700) by @lquerel)
 - Add [Live Check](https://github.com/open-telemetry/weaver/blob/main/crates/weaver_live_check/README.md) for Spans via OTLP/JSON and loose Attributes via JSON/Text. ([#630](https://github.com/open-telemetry/weaver/pull/630) by @jerbly)
 - 💥 BREAKING CHANGE 💥 `resource` groups are now called `entity` groups.  All JQ helper methods have been updated, but any template directly interacting with
-  `group.type` may be broken. ([#714](https://github.com/open-telemetry/weaver/pull/714) by @jsuereth)
+  `group.type` may be broken. Use `entity` instead of `resource` group type in your Jinja templates.  ([#714](https://github.com/open-telemetry/weaver/pull/714) by @jsuereth)
 
 ## [0.14.0] - 2025-04-10
 

--- a/crates/weaver_forge/templates/test/registry.md
+++ b/crates/weaver_forge/templates/test/registry.md
@@ -32,7 +32,7 @@ Url: {{ registry_url }}
 
 # Resource
 {% for group in ctx.groups -%}
-{%- if group.type == "resource" %}
+{%- if group.type == "entity" %}
 - [{{ group.id }}](resource/{{ group.id | snake_case }}.md)
   {%- endif %}
   {%- endfor %}

--- a/crates/weaver_forge/templates/whitespace_control/registry.md
+++ b/crates/weaver_forge/templates/whitespace_control/registry.md
@@ -36,7 +36,7 @@ Url:{{ registry_url }}
 ## Resource
 
 {% for group in ctx.groups %}
-{% if group.type == "resource" %}
+{% if group.type == "entity" %}
 - [{{ group.id }}](resource/{{ group.id | snake_case }}.md)
 {% endif %}
 {% endfor %}

--- a/crates/weaver_forge/templates/whitespace_control/weaver.yaml
+++ b/crates/weaver_forge/templates/whitespace_control/weaver.yaml
@@ -50,10 +50,10 @@ templates:
     filter: ".groups[] | select(.type == \"metric\")"
     application_mode: single
   - template: "**/resource.md"
-    filter: ".groups[] | select(.type == \"resource\")"
+    filter: ".groups[] | select(.type == \"entity\")"
     application_mode: each
   - template: "**/resources.md"
-    filter: ".groups[] | select(.type == \"resource\")"
+    filter: ".groups[] | select(.type == \"entity\")"
     application_mode: single
   - template: "**/scope.md"
     filter: ".groups[] | select(.type == \"scope\")"

--- a/crates/weaver_resolved_schema/src/lib.rs
+++ b/crates/weaver_resolved_schema/src/lib.rs
@@ -268,8 +268,8 @@ impl ResolvedTelemetrySchema {
             &baseline_signals,
             &mut changes,
         );
-        let latest_signals = self.groups(GroupType::Resource);
-        let baseline_signals = baseline_schema.groups(GroupType::Resource);
+        let latest_signals = self.groups(GroupType::Entity);
+        let baseline_signals = baseline_schema.groups(GroupType::Entity);
         self.diff_signals(
             SchemaItemType::Resources,
             &latest_signals,

--- a/crates/weaver_resolved_schema/src/registry.rs
+++ b/crates/weaver_resolved_schema/src/registry.rs
@@ -13,7 +13,7 @@ use crate::catalog::Catalog;
 use crate::error::{handle_errors, Error};
 use crate::lineage::GroupLineage;
 use crate::registry::GroupStats::{
-    AttributeGroup, Event, Metric, MetricGroup, Entity, Scope, Span, Undefined,
+    AttributeGroup, Entity, Event, Metric, MetricGroup, Scope, Span, Undefined,
 };
 use serde::{Deserialize, Serialize};
 use weaver_semconv::deprecated::Deprecated;

--- a/crates/weaver_resolved_schema/src/registry.rs
+++ b/crates/weaver_resolved_schema/src/registry.rs
@@ -13,7 +13,7 @@ use crate::catalog::Catalog;
 use crate::error::{handle_errors, Error};
 use crate::lineage::GroupLineage;
 use crate::registry::GroupStats::{
-    AttributeGroup, Event, Metric, MetricGroup, Resource, Scope, Span, Undefined,
+    AttributeGroup, Event, Metric, MetricGroup, Entity, Scope, Span, Undefined,
 };
 use serde::{Deserialize, Serialize};
 use weaver_semconv::deprecated::Deprecated;
@@ -186,7 +186,7 @@ pub enum GroupStats {
         common_stats: CommonGroupStats,
     },
     /// Statistics for a resource.
-    Resource {
+    Entity {
         /// Common statistics for this type of group.
         common_stats: CommonGroupStats,
     },
@@ -278,7 +278,7 @@ impl Registry {
                         GroupType::Event => Event {
                             common_stats: CommonGroupStats::default(),
                         },
-                        GroupType::Resource => Resource {
+                        GroupType::Entity => Entity {
                             common_stats: CommonGroupStats::default(),
                         },
                         GroupType::Scope => Scope {
@@ -330,7 +330,7 @@ impl Registry {
                     Event { common_stats } => {
                         common_stats.update_stats(group);
                     }
-                    Resource { common_stats } => {
+                    Entity { common_stats } => {
                         common_stats.update_stats(group);
                     }
                     Scope { common_stats } => {

--- a/crates/weaver_semconv/src/group.rs
+++ b/crates/weaver_semconv/src/group.rs
@@ -531,7 +531,7 @@ pub enum GroupType {
     /// be defined and then referenced from other metric groups using ref.
     MetricGroup,
     /// Entity semantic convention.
-    #[serde(alias="resource")]
+    #[serde(alias = "resource")]
     Entity,
     /// Scope.
     Scope,

--- a/crates/weaver_semconv/src/group.rs
+++ b/crates/weaver_semconv/src/group.rs
@@ -530,8 +530,9 @@ pub enum GroupType {
     /// The metric group semconv is a group where related metric attributes can
     /// be defined and then referenced from other metric groups using ref.
     MetricGroup,
-    /// A group of resources.
-    Resource,
+    /// Entity semantic convention.
+    #[serde(alias="resource")]
+    Entity,
     /// Scope.
     Scope,
     /// Undefined group type.
@@ -1477,7 +1478,7 @@ mod tests {
             .is_ok());
 
         group.stability = None;
-        group.r#type = GroupType::Resource;
+        group.r#type = GroupType::Entity;
         group.span_kind = None;
         let result = group.validate("<test>").into_result_failing_non_fatal();
         assert_eq!(
@@ -1676,7 +1677,7 @@ mod tests {
         group.extends = None;
 
         // Resource must have extends or attributes.
-        group.r#type = GroupType::Resource;
+        group.r#type = GroupType::Entity;
         group.span_kind = None;
         let result = group.validate("<test>").into_result_failing_non_fatal();
         assert_eq!(

--- a/crates/weaver_semconv/src/registry.rs
+++ b/crates/weaver_semconv/src/registry.rs
@@ -412,7 +412,7 @@ mod tests {
             .for_each(|(group_type, total)| match group_type {
                 GroupType::AttributeGroup => assert_eq!(*total, 1),
                 GroupType::MetricGroup => assert_eq!(*total, 0),
-                GroupType::Resource => assert_eq!(*total, 1),
+                GroupType::Entity => assert_eq!(*total, 1),
                 GroupType::Span => assert_eq!(*total, 1),
                 _ => panic!("Unexpected group type {:?}", group_type),
             });

--- a/defaults/jq/semconv.jq
+++ b/defaults/jq/semconv.jq
@@ -27,6 +27,14 @@ def stability_filter($options):
         .
     end;
 
+# Expands signal argument into a filter on groups.
+def signal_filter($signal):
+  if ($signal | index("resource")) then
+    map(select(.type == "entity"))
+  else
+    map(select(.type == $signal))
+  end;
+
 # Filters out attributes based on code generation annotations.
 # $options is an object that can contain:
 # - ignore_code_generation_annotations: a boolean to ignore code generation annotations.
@@ -101,7 +109,7 @@ def semconv_grouped_attributes: semconv_grouped_attributes({});
 # - exclude_stability: a list of stability statuses to exclude. Use `stable_only` to exclude all non-stable signals instead.
 def semconv_signal($signal; $options):
     .groups
-    | map(select(.type == $signal))
+    | signal_filter($signal)
     | stability_filter($options)
     | if ($options | has("exclude_deprecated") and $options.exclude_deprecated == true) then
         map(select(.id | endswith(".deprecated") | not))

--- a/src/registry/stats.rs
+++ b/src/registry/stats.rs
@@ -117,7 +117,7 @@ fn display_schema_stats(schema: &ResolvedTelemetrySchema) {
                     display_common_group_stats(group_type, common_stats);
                     total_number_of_attributes += common_stats.total_attribute_count;
                 }
-                GroupStats::Resource { common_stats } => {
+                GroupStats::Entity { common_stats } => {
                     display_common_group_stats(group_type, common_stats);
                     total_number_of_attributes += common_stats.total_attribute_count;
                 }


### PR DESCRIPTION
This is part of the move to Entity as a grouping of attributes on Resource. An Entity represents a named set of attributes with its own versioning defined by weaver / semantic conventions. Combined with the previous `entity_associations` work, this unlocks validating Resource in `live_check`.

Note: This is **breaking** for all templates that directly use `group.type`.
      While JQ helpers have been updated to support the chagne, direct
      group.type usage will see `entity` in the future.