### PR TITLE
Log that the manifest was found or not

### DIFF
--- a/crates/weaver_semconv/src/registry_repo.rs
+++ b/crates/weaver_semconv/src/registry_repo.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use crate::manifest::RegistryManifest;
 use crate::Error;
 use weaver_common::vdir::{VirtualDirectory, VirtualDirectoryPath};
+use weaver_common::{log_info, log_warn};
 
 /// The name of the registry manifest file.
 pub const REGISTRY_MANIFEST: &str = "registry_manifest.yaml";
@@ -79,8 +80,16 @@ impl RegistryRepo {
     pub fn manifest_path(&self) -> Option<PathBuf> {
         let manifest_path = self.registry.path().join(REGISTRY_MANIFEST);
         if manifest_path.exists() {
+            log_info(format!(
+                "Found registry manifest: {}",
+                manifest_path.display()
+            ));
             Some(manifest_path)
         } else {
+            log_warn(format!(
+                "No registry manifest found: {}",
+                manifest_path.display()
+            ));
             None
         }
     }

--- a/crates/weaver_semconv/src/registry_repo.rs
+++ b/crates/weaver_semconv/src/registry_repo.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 
 use crate::manifest::RegistryManifest;
 use crate::Error;
+use weaver_common::log_info;
 use weaver_common::vdir::{VirtualDirectory, VirtualDirectoryPath};
-use weaver_common::{log_info, log_warn};
 
 /// The name of the registry manifest file.
 pub const REGISTRY_MANIFEST: &str = "registry_manifest.yaml";
@@ -86,7 +86,7 @@ impl RegistryRepo {
             ));
             Some(manifest_path)
         } else {
-            log_warn(format!(
+            log_info(format!(
                 "No registry manifest found: {}",
                 manifest_path.display()
             ));


### PR DESCRIPTION
Fixes: #691 

Example output:
```
Checking registry `crates/weaver_resolver/data/multi-registry/custom_registry`
ℹ Found registry manifest: crates/weaver_resolver/data/multi-registry/custom_registry/registry_manifest.yaml
ℹ No registry manifest found: data/multi-registry/otel_registry/registry_manifest.yaml
```