### PR TITLE
Added span status code and message for live check

### DIFF
--- a/crates/weaver_live_check/data/policies/live_check_advice/test.rego
+++ b/crates/weaver_live_check/data/policies/live_check_advice/test.rego
@@ -22,6 +22,16 @@ deny contains make_advice(advice_type, advice_level, value, message) if {
 	message := "Name must not contain 'test'"
 }
 
+# checks span status message contains the word "test"
+deny contains make_advice(advice_type, advice_level, value, message) if {
+	input.span
+	value := input.span.status.message
+	contains(value, "test")
+	advice_type := "contains_test_in_status"
+	advice_level := "violation"
+	message := "Status message must not contain 'test'"
+}
+
 # checks span_event name contains the word "test"
 deny contains make_advice(advice_type, advice_level, value, message) if {
 	input.span_event

--- a/crates/weaver_live_check/data/span.json
+++ b/crates/weaver_live_check/data/span.json
@@ -63,7 +63,11 @@
                 }
             ],
             "kind": "client",
-            "name": "test"
+            "name": "test",
+            "status": {
+                "code": "error",
+                "message": "test status message"
+            }
         }
     }
 ]

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -550,6 +550,39 @@ mod tests {
     }
 
     #[test]
+    fn test_json_span_rego() {
+        let registry = make_registry();
+
+        // Load samples from JSON file
+        let path = "data/span.json";
+        let mut samples: Vec<Sample> =
+            serde_json::from_reader(File::open(path).expect("Unable to open file"))
+                .expect("Unable to parse JSON");
+
+        let mut live_checker = LiveChecker::new(registry, vec![]);
+        let rego_advisor = RegoAdvisor::new(
+            &live_checker,
+            &Some("data/policies/live_check_advice/".into()),
+            &Some("data/jq/test.jq".into()),
+        )
+        .expect("Failed to create Rego advisor");
+        live_checker.add_advisor(Box::new(rego_advisor));
+
+        let mut stats = LiveCheckStatistics::new(&live_checker.registry);
+        for sample in &mut samples {
+            let result = sample.run_live_check(&mut live_checker, &mut stats);
+            assert!(result.is_ok());
+        }
+        stats.finalize();
+
+        // Check the statistics
+        assert_eq!(
+            stats.advice_type_counts.get("contains_test_in_status"),
+            Some(&1)
+        );
+    }
+
+    #[test]
     fn test_bad_custom_rego() {
         let registry = ResolvedRegistry {
             registry_url: "TEST".to_owned(),

--- a/crates/weaver_live_check/src/sample_span.rs
+++ b/crates/weaver_live_check/src/sample_span.rs
@@ -10,6 +10,27 @@ use crate::{
     LiveCheckRunner, LiveCheckStatistics, SampleRef,
 };
 
+/// The status code of the span
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StatusCode {
+    /// The status is unset
+    Unset,
+    /// The status is ok
+    Ok,
+    /// The status is error
+    Error,
+}
+
+/// The status code and message of the span
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Status {
+    /// The status code
+    pub code: StatusCode,
+    /// The status message
+    pub message: String,
+}
+
 /// Represents a sample telemetry span parsed from any source
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SampleSpan {
@@ -17,6 +38,8 @@ pub struct SampleSpan {
     pub name: String,
     /// The kind of the span
     pub kind: SpanKindSpec,
+    /// Status
+    pub status: Option<Status>,
     /// The span's attributes
     #[serde(default)]
     pub attributes: Vec<SampleAttribute>,


### PR DESCRIPTION
Fixes: #713 

The OTLP status code and message for spans is now included in the samples. This allows for custom rego policies to assert on the code or message.

Added a test example to check for the word `test` in the status message.