### PR TITLE
Fix #750 - Dual registry resolves incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # NEXT
 
 - Add support for metrics in Live Check. ([#728](https://github.com/open-telemetry/weaver/pull/728) by @jerbly)
+- Fix #750 - Dual registry resolves incorrectly. ([#753](https://github.com/open-telemetry/weaver/pull/753) by @lquerel)
 
 # [0.15.0] - 2025-05-01
 

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -406,6 +406,7 @@ impl SchemaResolver {
 #[cfg(test)]
 mod tests {
     use crate::SchemaResolver;
+    use std::collections::HashSet;
     use weaver_common::result::WResult;
     use weaver_common::vdir::VirtualDirectoryPath;
     use weaver_semconv::attribute::{BasicRequirementLevelSpec, RequirementLevel};
@@ -470,11 +471,13 @@ mod tests {
                         .expect("Metric not found");
                     let attributes = &metric.attributes;
                     assert_eq!(attributes.len(), 3);
+                    let mut attr_names = HashSet::new();
                     for attr_ref in attributes {
                         let attr = resolved_registry
                             .catalog
                             .attribute(attr_ref)
                             .expect("Failed to resolve attribute");
+                        _ = attr_names.insert(attr.name.clone());
                         match attr.name.as_str() {
                             "auction.name" => {}
                             "auction.id" => {}
@@ -492,6 +495,10 @@ mod tests {
                             }
                         }
                     }
+                    assert_eq!(metric.attributes.len(), 3);
+                    assert!(attr_names.contains("auction.name"));
+                    assert!(attr_names.contains("auction.id"));
+                    assert!(attr_names.contains("error.type"));
                 }
                 WResult::FatalErr(fatal) => {
                     panic!("Fatal error: {fatal}");

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -155,7 +155,8 @@ fn gc_unreferenced_objects(
         if manifest.dependencies.as_ref().map_or(0, |d| d.len()) > 0 {
             // This registry has dependencies.
             let current_reg_id = manifest.name.clone();
-            let mut attr_refs = HashSet::new();
+
+            // Remove all groups that are not defined in the current registry.
             registry.groups.retain(|group| {
                 if let Some(lineage) = &group.lineage {
                     lineage.provenance().registry_id.as_ref() == current_reg_id
@@ -165,6 +166,7 @@ fn gc_unreferenced_objects(
             });
 
             // Collect all remaining attribute references
+            let mut attr_refs = HashSet::new();
             registry.groups.iter().for_each(|group| {
                 group.attributes.iter().for_each(|attr| {
                     _ = attr_refs.insert(*attr);


### PR DESCRIPTION
This bug does not appear when:
- resolving a single registry
- resolving two registries without calling `gc_unreferenced_attribute_refs`

When two registries are involved and `gc_unreferenced_attribute_refs` is called (i.e., without the `--include-unreferenced` parameter), resolution sometimes succeeds and sometimes fails. The intermittent success occurs because `HashMap` ordering in Rust is random, and the small number of elements in the test frequently resulted in the expected outcome. Additionally, the initial test was insufficiently robust.

The source of the bug lies in the `AttributeCatalog::gc_unreferenced_attribute_refs` method, which returned the correct mapping but did not internally modify the catalog as intended... Pretty bad!

Closes #750 