### PR TITLE
Fix: Use requirement level for attributes in live-check

### DIFF
--- a/crates/weaver_live_check/src/advice.rs
+++ b/crates/weaver_live_check/src/advice.rs
@@ -17,7 +17,10 @@ use weaver_checker::{
 use weaver_forge::{jq, registry::ResolvedGroup};
 use weaver_resolved_schema::attribute::Attribute;
 use weaver_semconv::{
-    attribute::{AttributeType, PrimitiveOrArrayTypeSpec, TemplateTypeSpec, ValueSpec},
+    attribute::{
+        AttributeType, BasicRequirementLevelSpec, PrimitiveOrArrayTypeSpec, RequirementLevel,
+        TemplateTypeSpec, ValueSpec,
+    },
     deprecated::Deprecated,
     stability::Stability,
 };
@@ -157,23 +160,48 @@ impl Advisor for StabilityAdvisor {
 /// An advisor that checks if an attribute has the correct type
 pub struct TypeAdvisor;
 
-/// Checks if required attributes from a resolved group are present in a list of attributes
-/// Returns a list of advice for missing attributes
-fn check_required_attributes(
-    required_attributes: &[Attribute],
-    attributes: &[SampleAttribute],
+/// Checks if attributes from a resolved group are present in a list of sample attributes
+/// Returns a list of advice for the attributes based on their RequirementLevel
+fn check_attributes(
+    semconv_attributes: &[Attribute],
+    sample_attributes: &[SampleAttribute],
 ) -> Vec<Advice> {
     // Create a HashSet of attribute names for O(1) lookups
-    let attribute_set: HashSet<_> = attributes.iter().map(|attr| &attr.name).collect();
+    let attribute_set: HashSet<_> = sample_attributes.iter().map(|attr| &attr.name).collect();
 
     let mut advice_list = Vec::new();
-    for required_attribute in required_attributes {
-        if !attribute_set.contains(&required_attribute.name) {
+    for semconv_attribute in semconv_attributes {
+        if !attribute_set.contains(&semconv_attribute.name) {
+            let (advice_type, advice_level, message) = match &semconv_attribute.requirement_level {
+                RequirementLevel::Basic(BasicRequirementLevelSpec::Required) => (
+                    "required_attribute_not_present".to_owned(),
+                    AdviceLevel::Violation,
+                    "Required attribute is not present".to_owned(),
+                ),
+                RequirementLevel::Basic(BasicRequirementLevelSpec::Recommended)
+                | RequirementLevel::Recommended { .. } => (
+                    "recommended_attribute_not_present".to_owned(),
+                    AdviceLevel::Improvement,
+                    "Recommended attribute is not present".to_owned(),
+                ),
+                RequirementLevel::Basic(BasicRequirementLevelSpec::OptIn)
+                | RequirementLevel::OptIn { .. } => (
+                    "optin_attribute_not_present".to_owned(),
+                    AdviceLevel::Information,
+                    "Opt-in attribute is not present".to_owned(),
+                ),
+                RequirementLevel::ConditionallyRequired { .. } => (
+                    "conditionally_required_attribute_not_present".to_owned(),
+                    AdviceLevel::Information,
+                    "Conditionally required attribute is not present".to_owned(),
+                ),
+            };
+
             advice_list.push(Advice {
-                advice_type: "attribute_required".to_owned(),
-                value: Value::String(required_attribute.name.clone()),
-                message: "Attribute is required".to_owned(),
-                advice_level: AdviceLevel::Violation,
+                advice_type,
+                value: Value::String(semconv_attribute.name.clone()),
+                message,
+                advice_level,
             });
         }
     }
@@ -287,7 +315,7 @@ impl Advisor for TypeAdvisor {
             }
             SampleRef::NumberDataPoint(sample_number_data_point) => {
                 if let Some(semconv_metric) = registry_group {
-                    Ok(check_required_attributes(
+                    Ok(check_attributes(
                         &semconv_metric.attributes,
                         &sample_number_data_point.attributes,
                     ))
@@ -297,7 +325,7 @@ impl Advisor for TypeAdvisor {
             }
             SampleRef::HistogramDataPoint(sample_histogram_data_point) => {
                 if let Some(semconv_metric) = registry_group {
-                    Ok(check_required_attributes(
+                    Ok(check_attributes(
                         &semconv_metric.attributes,
                         &sample_histogram_data_point.attributes,
                     ))
@@ -481,5 +509,147 @@ impl Advisor for RegoAdvisor {
             registry_attribute,
             registry_group,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use weaver_resolved_schema::attribute::Attribute;
+    use weaver_semconv::attribute::{
+        AttributeType::PrimitiveOrArray, BasicRequirementLevelSpec, RequirementLevel,
+    };
+
+    fn create_test_attribute(name: &str, requirement_level: RequirementLevel) -> Attribute {
+        Attribute {
+            name: name.to_owned(),
+            requirement_level,
+            r#type: PrimitiveOrArray(PrimitiveOrArrayTypeSpec::String),
+            brief: "test attribute".to_owned(),
+            examples: None,
+            tag: None,
+            stability: None,
+            deprecated: None,
+            sampling_relevant: None,
+            note: "".to_owned(),
+            prefix: false,
+            annotations: None,
+            role: None,
+            tags: None,
+            value: None,
+        }
+    }
+
+    fn create_sample_attribute(name: &str) -> SampleAttribute {
+        SampleAttribute {
+            name: name.to_owned(),
+            value: None,
+            r#type: None,
+            live_check_result: None,
+        }
+    }
+
+    #[test]
+    fn test_check_attributes_all_requirement_levels() {
+        let semconv_attributes = vec![
+            create_test_attribute(
+                "required_attr",
+                RequirementLevel::Basic(BasicRequirementLevelSpec::Required),
+            ),
+            create_test_attribute(
+                "recommended_basic",
+                RequirementLevel::Basic(BasicRequirementLevelSpec::Recommended),
+            ),
+            create_test_attribute(
+                "recommended_text",
+                RequirementLevel::Recommended {
+                    text: "This is recommended".to_owned(),
+                },
+            ),
+            create_test_attribute(
+                "optin_basic",
+                RequirementLevel::Basic(BasicRequirementLevelSpec::OptIn),
+            ),
+            create_test_attribute(
+                "optin_text",
+                RequirementLevel::OptIn {
+                    text: "This is opt-in".to_owned(),
+                },
+            ),
+            create_test_attribute(
+                "conditional",
+                RequirementLevel::ConditionallyRequired {
+                    text: "Required when X".to_owned(),
+                },
+            ),
+        ];
+
+        // Provide no attributes
+        let sample_attributes = vec![];
+
+        let advice = check_attributes(&semconv_attributes, &sample_attributes);
+        assert_eq!(advice.len(), 6);
+
+        // Verify each advice type and level
+        let advice_map: std::collections::HashMap<_, _> = advice
+            .iter()
+            .map(|a| (a.advice_type.clone(), a.advice_level.clone()))
+            .collect();
+
+        assert_eq!(
+            advice_map.get("recommended_attribute_not_present"),
+            Some(&AdviceLevel::Improvement)
+        );
+        assert_eq!(
+            advice_map.get("optin_attribute_not_present"),
+            Some(&AdviceLevel::Information)
+        );
+        assert_eq!(
+            advice_map.get("conditionally_required_attribute_not_present"),
+            Some(&AdviceLevel::Information)
+        );
+        assert_eq!(
+            advice_map.get("required_attribute_not_present"),
+            Some(&AdviceLevel::Violation)
+        );
+
+        // Count advice levels
+        let violations = advice
+            .iter()
+            .filter(|a| a.advice_level == AdviceLevel::Violation)
+            .count();
+        let improvements = advice
+            .iter()
+            .filter(|a| a.advice_level == AdviceLevel::Improvement)
+            .count();
+        let information = advice
+            .iter()
+            .filter(|a| a.advice_level == AdviceLevel::Information)
+            .count();
+
+        assert_eq!(violations, 1);
+        assert_eq!(improvements, 2);
+        assert_eq!(information, 3);
+    }
+
+    #[test]
+    fn test_check_attributes_no_missing_attributes() {
+        let semconv_attributes = vec![
+            create_test_attribute(
+                "attr1",
+                RequirementLevel::Basic(BasicRequirementLevelSpec::Required),
+            ),
+            create_test_attribute(
+                "attr2",
+                RequirementLevel::Basic(BasicRequirementLevelSpec::Recommended),
+            ),
+        ];
+        let sample_attributes = vec![
+            create_sample_attribute("attr1"),
+            create_sample_attribute("attr2"),
+        ];
+
+        let advice = check_attributes(&semconv_attributes, &sample_attributes);
+        assert!(advice.is_empty());
     }
 }

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -785,26 +785,18 @@ mod tests {
             assert!(result.is_ok());
         }
         stats.finalize();
-        /* Assert on these:
-        total_entities_by_type: {
-            "data_point": 6,
-            "metric": 4,
-            "attribute": 3,
-        },
-        no_advice_count: 4,
-        advice_type_counts: {
-            "attribute_required": 2,
-            "missing_attribute": 2,
-            "stability": 2,
-            "missing_metric": 3,
-            "missing_namespace": 2,
-        }, */
+
         // Check the statistics
         assert_eq!(stats.total_entities_by_type.get("data_point"), Some(&6));
         assert_eq!(stats.total_entities_by_type.get("metric"), Some(&4));
         assert_eq!(stats.total_entities_by_type.get("attribute"), Some(&3));
         assert_eq!(stats.no_advice_count, 4);
-        assert_eq!(stats.advice_type_counts.get("attribute_required"), Some(&2));
+        assert_eq!(
+            stats
+                .advice_type_counts
+                .get("recommended_attribute_not_present"),
+            Some(&2)
+        );
         assert_eq!(stats.advice_type_counts.get("missing_attribute"), Some(&2));
         assert_eq!(stats.advice_type_counts.get("stability"), Some(&2));
         assert_eq!(stats.advice_type_counts.get("missing_metric"), Some(&3));


### PR DESCRIPTION
When checking the set of attributes provided in a sample metric against the model, the `requirement_level` was ignored.

This PR fixes this oversight.

If an attribute is not present in the sample this is the mapping:

| RequirementLevel | Live-check advice level |
| --- | --- |
| Required | Violation |
| Recommended | Improvement |
| Opt-In | Information |
| Conditionally Required | Information |

It would be nice to do something better with Conditionally Required but this is not possible until the condition is specified in a machine readable way.