### PR TITLE
Fix README flag typo `-b` >> `-p`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ default.
 
 To check a set of policies against the registry, use the following command:
 ```
-cargo run -- registry check -b path/to/policies
+cargo run -- registry check -p path/to/policies
 ```
 
 An example of a policy file can be found here [schemas/otel_policies.rego](schemas/otel_policies.rego).


### PR DESCRIPTION
This PR:
* Fixes a flag typo in the readme.

`-b` is wrong. It should be `-p`