### PR TITLE
Three registry dependency chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
   ([#823](https://github.com/open-telemetry/weaver/pull/823) by @lmolkova)
 - Don't serialize default values and empty arrays when resolving semantic conventions.
   ([#822](https://github.com/open-telemetry/weaver/pull/822) by @lmolkova)
+- Add support for a three registry dependency chain, a->b->c. This pattern is useful when making narrow application registries that depend on a corporate registry based on the OpenTelemetry semantic conventions.
+  ([#???](https://github.com/open-telemetry/weaver/pull/???) by @jerbly)
 
 # [0.16.1] - 2025-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
   ([#823](https://github.com/open-telemetry/weaver/pull/823) by @lmolkova)
 - Don't serialize default values and empty arrays when resolving semantic conventions.
   ([#822](https://github.com/open-telemetry/weaver/pull/822) by @lmolkova)
-- Add support for a three registry dependency chain, a->b->c. This pattern is useful when making narrow application registries that depend on a corporate registry based on the OpenTelemetry semantic conventions.
+- Add support for registry dependency chain, a->b->c. This pattern is useful when making narrow application registries that depend on a corporate registry based on the OpenTelemetry semantic conventions. Max depth is 10.
   ([#856](https://github.com/open-telemetry/weaver/pull/856) by @jerbly)
 
 # [0.16.1] - 2025-07-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Don't serialize default values and empty arrays when resolving semantic conventions.
   ([#822](https://github.com/open-telemetry/weaver/pull/822) by @lmolkova)
 - Add support for a three registry dependency chain, a->b->c. This pattern is useful when making narrow application registries that depend on a corporate registry based on the OpenTelemetry semantic conventions.
-  ([#???](https://github.com/open-telemetry/weaver/pull/???) by @jerbly)
+  ([#856](https://github.com/open-telemetry/weaver/pull/856) by @jerbly)
 
 # [0.16.1] - 2025-07-04
 

--- a/crates/weaver_resolver/data/circular-registry-test/registry_a/registry_a.yaml
+++ b/crates/weaver_resolver/data/circular-registry-test/registry_a/registry_a.yaml
@@ -1,0 +1,11 @@
+groups:
+  - id: registry_a.example
+    type: attribute_group
+    brief: Example attributes from registry A.
+    attributes:
+      - id: registry_a.name
+        type: string
+        brief: Name from registry A.
+        stability: stable
+        requirement_level: required
+        examples: "A"

--- a/crates/weaver_resolver/data/circular-registry-test/registry_a/registry_manifest.yaml
+++ b/crates/weaver_resolver/data/circular-registry-test/registry_a/registry_manifest.yaml
@@ -1,0 +1,7 @@
+name: registry_a
+description: Test registry A for circular dependency testing.
+semconv_version: 0.1.0
+schema_base_url: https://example.com/registry_a/schemas/
+dependencies:
+  - name: registry_b
+    registry_path: data/circular-registry-test/registry_b

--- a/crates/weaver_resolver/data/circular-registry-test/registry_b/registry_b.yaml
+++ b/crates/weaver_resolver/data/circular-registry-test/registry_b/registry_b.yaml
@@ -1,0 +1,11 @@
+groups:
+  - id: registry_b.example
+    type: attribute_group
+    brief: Example attributes from registry B.
+    attributes:
+      - id: registry_b.name
+        type: string
+        brief: Name from registry B.
+        stability: stable
+        requirement_level: required
+        examples: "B"

--- a/crates/weaver_resolver/data/circular-registry-test/registry_b/registry_manifest.yaml
+++ b/crates/weaver_resolver/data/circular-registry-test/registry_b/registry_manifest.yaml
@@ -1,0 +1,7 @@
+name: registry_b
+description: Test registry B for circular dependency testing.
+semconv_version: 0.1.0
+schema_base_url: https://example.com/registry_b/schemas/
+dependencies:
+  - name: registry_a
+    registry_path: data/circular-registry-test/registry_a

--- a/crates/weaver_resolver/data/multi-registry/app_registry/app_registry.yaml
+++ b/crates/weaver_resolver/data/multi-registry/app_registry/app_registry.yaml
@@ -1,0 +1,12 @@
+groups:
+  - id: app.example
+    type: attribute_group
+    brief: Example attributes for the application.
+    attributes:
+      - id: app.name
+        type: string
+        brief: Name of the application.
+        stability: stable
+        requirement_level: required
+        examples: "MyApp"
+      - ref: error.type

--- a/crates/weaver_resolver/data/multi-registry/app_registry/app_registry.yaml
+++ b/crates/weaver_resolver/data/multi-registry/app_registry/app_registry.yaml
@@ -10,3 +10,8 @@ groups:
         requirement_level: required
         examples: "MyApp"
       - ref: error.type
+      - ref: auction.name
+
+imports:
+  metrics:
+    - example.*

--- a/crates/weaver_resolver/data/multi-registry/app_registry/registry_manifest.yaml
+++ b/crates/weaver_resolver/data/multi-registry/app_registry/registry_manifest.yaml
@@ -1,0 +1,7 @@
+name: app
+description: This registry contains the semantic conventions for the App.
+semconv_version: 0.1.0
+schema_base_url: https://app.com/schemas/
+dependencies:
+  - name: acme
+    registry_path: data/multi-registry/custom_registry

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -753,12 +753,6 @@ mod tests {
                             .group("app.example")
                             .expect("app.example group should exist");
 
-                        // Should have exactly 2 attributes: app.name (local) and error.type (from otel)
-                        println!(
-                            "app.example group has {} attributes",
-                            app_group.attributes.len()
-                        );
-
                         // Collect attribute names for verification
                         let mut attr_names = HashSet::new();
                         for attr_ref in &app_group.attributes {
@@ -766,7 +760,6 @@ mod tests {
                                 .catalog
                                 .attribute(attr_ref)
                                 .expect("Failed to resolve attribute");
-                            println!("app.example attribute: {}", attr.name);
                             let _ = attr_names.insert(attr.name.clone());
                         }
 

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -29,7 +29,7 @@ pub mod attribute;
 pub mod registry;
 
 /// Maximum allowed depth for registry dependency chains.
-const MAX_DEPENDENCY_DEPTH: u32 = 3;
+const MAX_DEPENDENCY_DEPTH: u32 = 10;
 
 /// A resolver that can be used to resolve telemetry schemas.
 /// All references to semantic conventions will be resolved.
@@ -735,17 +735,21 @@ mod tests {
                         })
                         .collect();
 
-                        // Should only have the app.example group, not any imported groups
+                        // Should have the app.example group and the imported example.counter metric
                         assert_eq!(
                             all_groups.len(),
-                            1,
-                            "Expected only 1 group (app.example), but found {}: {:?}",
+                            2,
+                            "Expected 2 groups (app.example and metric.example.counter), but found {}: {:?}",
                             all_groups.len(),
                             all_groups
                         );
                         assert!(
                             all_groups.contains(&"app.example".to_owned()),
                             "Missing app.example group, found: {all_groups:?}"
+                        );
+                        assert!(
+                            all_groups.contains(&"metric.example.counter".to_owned()),
+                            "Missing metric.example.counter group, found: {all_groups:?}"
                         );
 
                         // Check that app.example group exists and has exactly the expected attributes
@@ -772,8 +776,12 @@ mod tests {
                             attr_names.contains("error.type"),
                             "Missing error.type attribute"
                         );
-                        assert_eq!(attr_names.len(), 2,
-                            "Expected exactly 2 attributes (app.name, error.type), got: {attr_names:?}");
+                        assert!(
+                            attr_names.contains("auction.name"),
+                            "Missing auction.name attribute"
+                        );
+                        assert_eq!(attr_names.len(), 3,
+                            "Expected exactly 3 attributes (app.name, error.type, auction.name), got: {attr_names:?}");
                     }
                     WResult::FatalErr(fatal) => {
                         panic!("Failed to resolve registry: {fatal}");

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -719,7 +719,6 @@ mod tests {
                             })
                             .collect();
                         
-                        println!("All groups in resolved registry: {:?}", all_groups);
                         
                         // Should only have the app.example group, not any imported groups
                         assert_eq!(all_groups.len(), 1, 

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -173,16 +173,6 @@ pub enum Error {
         error: String,
     },
 
-    /// Circular dependency detected in registry chain.
-    #[error("Circular dependency detected: registry '{registry_id}' depends on itself through the chain: {dependency_chain}")]
-    #[diagnostic(help("Remove the circular dependency from your registry manifest files."))]
-    CircularDependency {
-        /// The registry ID that creates the circular dependency.
-        registry_id: String,
-        /// The dependency chain that shows the circular path.
-        dependency_chain: String,
-    },
-
     /// A container for multiple errors.
     #[error("{:?}", format_errors(.0))]
     CompoundError(#[related] Vec<Error>),

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -672,7 +672,6 @@ mod tests {
     #[test]
     fn test_three_registry_chain_works() -> Result<(), weaver_semconv::Error> {
         // Test the three-registry chain: app -> acme -> otel
-        // This should now work with our new implementation
         let registry_path = VirtualDirectoryPath::LocalFolder {
             path: "data/multi-registry/app_registry".to_owned(),
         };

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -293,8 +293,7 @@ impl SchemaResolver {
             let chain_str = dependency_chain.join(" → ");
             return WResult::FatalErr(weaver_semconv::Error::SemConvSpecError {
                 error: format!(
-                    "Circular dependency detected: registry '{}' depends on itself through the chain: {}",
-                    registry_id, chain_str
+                    "Circular dependency detected: registry '{registry_id}' depends on itself through the chain: {chain_str}"
                 ),
             });
         }
@@ -712,8 +711,8 @@ mod tests {
                         // Should only have the app.example group, not any imported groups
                         assert_eq!(all_groups.len(), 1, 
                             "Expected only 1 group (app.example), but found {}: {:?}", all_groups.len(), all_groups);
-                        assert!(all_groups.contains(&"app.example".to_string()), 
-                            "Missing app.example group, found: {:?}", all_groups);
+                        assert!(all_groups.contains(&"app.example".to_owned()), 
+                            "Missing app.example group, found: {all_groups:?}");
                         
                         // Check that app.example group exists and has exactly the expected attributes
                         let app_group = resolved_registry.group("app.example")
@@ -735,7 +734,7 @@ mod tests {
                         assert!(attr_names.contains("app.name"), "Missing app.name attribute");
                         assert!(attr_names.contains("error.type"), "Missing error.type attribute");
                         assert_eq!(attr_names.len(), 2, 
-                            "Expected exactly 2 attributes (app.name, error.type), got: {:?}", attr_names);
+                            "Expected exactly 2 attributes (app.name, error.type), got: {attr_names:?}");
                     }
                     WResult::FatalErr(fatal) => {
                         panic!("Failed to resolve registry: {fatal}");

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -177,12 +177,17 @@ fn gc_unreferenced_objects(
         })
     };
 
+    // Filter imports to only include those from the current registry
+    let current_registry_imports: Vec<_> = all_imports.iter().filter(|import| {
+        import.provenance.registry_id.as_ref() == manifest.map(|m| m.name.as_str()).unwrap_or("")
+    }).collect();
+    
     let metrics_imports_matcher =
-        build_globset(all_imports.iter().find_map(|i| i.imports.metrics.as_ref()))?;
+        build_globset(current_registry_imports.iter().find_map(|i| i.imports.metrics.as_ref()))?;
     let events_imports_matcher =
-        build_globset(all_imports.iter().find_map(|i| i.imports.events.as_ref()))?;
+        build_globset(current_registry_imports.iter().find_map(|i| i.imports.events.as_ref()))?;
     let entities_imports_matcher =
-        build_globset(all_imports.iter().find_map(|i| i.imports.entities.as_ref()))?;
+        build_globset(current_registry_imports.iter().find_map(|i| i.imports.entities.as_ref()))?;
 
     if let Some(manifest) = manifest {
         if manifest.dependencies.as_ref().map_or(0, |d| d.len()) > 0 {
@@ -205,13 +210,15 @@ fn gc_unreferenced_objects(
                         .is_some_and(|name| entities_imports_matcher.is_match(name.as_str())),
                     _ => false,
                 };
+                
                 if ref_in_imports {
                     // This group is referenced in the `imports` section, so we keep it.
                     true
                 } else if let Some(lineage) = &group.lineage {
                     lineage.provenance().registry_id.as_ref() == current_reg_id
                 } else {
-                    true
+                    // Groups without lineage should be garbage collected.
+                    false
                 }
             });
 

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -178,16 +178,29 @@ fn gc_unreferenced_objects(
     };
 
     // Filter imports to only include those from the current registry
-    let current_registry_imports: Vec<_> = all_imports.iter().filter(|import| {
-        import.provenance.registry_id.as_ref() == manifest.map(|m| m.name.as_str()).unwrap_or("")
-    }).collect();
-    
-    let metrics_imports_matcher =
-        build_globset(current_registry_imports.iter().find_map(|i| i.imports.metrics.as_ref()))?;
-    let events_imports_matcher =
-        build_globset(current_registry_imports.iter().find_map(|i| i.imports.events.as_ref()))?;
-    let entities_imports_matcher =
-        build_globset(current_registry_imports.iter().find_map(|i| i.imports.entities.as_ref()))?;
+    let current_registry_imports: Vec<_> = all_imports
+        .iter()
+        .filter(|import| {
+            import.provenance.registry_id.as_ref()
+                == manifest.map(|m| m.name.as_str()).unwrap_or("")
+        })
+        .collect();
+
+    let metrics_imports_matcher = build_globset(
+        current_registry_imports
+            .iter()
+            .find_map(|i| i.imports.metrics.as_ref()),
+    )?;
+    let events_imports_matcher = build_globset(
+        current_registry_imports
+            .iter()
+            .find_map(|i| i.imports.events.as_ref()),
+    )?;
+    let entities_imports_matcher = build_globset(
+        current_registry_imports
+            .iter()
+            .find_map(|i| i.imports.entities.as_ref()),
+    )?;
 
     if let Some(manifest) = manifest {
         if manifest.dependencies.as_ref().map_or(0, |d| d.len()) > 0 {
@@ -210,7 +223,7 @@ fn gc_unreferenced_objects(
                         .is_some_and(|name| entities_imports_matcher.is_match(name.as_str())),
                     _ => false,
                 };
-                
+
                 if ref_in_imports {
                     // This group is referenced in the `imports` section, so we keep it.
                     true


### PR DESCRIPTION
Add support for a three registry dependency chain, a->b->c. This pattern is useful when making narrow application registries that depend on a corporate registry based on the OpenTelemetry semantic conventions. Max depth 10.