### PR TITLE
Update json schema dependency and fix error messages for variants.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf04c5ec15464ace8355a7b440a33aece288993475556d461154d7a62ad9947c"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "faster-hex"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,7 +3399,7 @@ dependencies = [
  "base64 0.22.1",
  "bytecount",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.14.0",
  "fraction",
  "idna",
  "itoa",
@@ -3404,15 +3415,15 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.30.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
+checksum = "24690c68dfcdde5980d676b0f1820981841016b1f29eecb4c42ad48ab4118681"
 dependencies = [
  "ahash",
  "base64 0.22.1",
  "bytecount",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.16.1",
  "fraction",
  "idna",
  "itoa",
@@ -3420,7 +3431,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "percent-encoding",
- "referencing 0.30.0",
+ "referencing 0.32.1",
  "regex",
  "regex-syntax",
  "reqwest",
@@ -4598,9 +4609,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.30.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
+checksum = "7a3d769362109497b240e66462606bc28af68116436c8669bac17069533b908e"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -6347,7 +6358,8 @@ version = "0.17.0"
 dependencies = [
  "glob",
  "globset",
- "jsonschema 0.30.0",
+ "itertools 0.14.0",
+ "jsonschema 0.32.1",
  "miette",
  "ordered-float",
  "regex",

--- a/crates/weaver_semconv/Cargo.toml
+++ b/crates/weaver_semconv/Cargo.toml
@@ -28,8 +28,9 @@ miette.workspace = true
 schemars.workspace = true
 regex.workspace = true
 globset.workspace = true
+itertools.workspace = true
 
 glob = "0.3.2"
-jsonschema = "0.30.0"       # JSON Schema validation used to enhance error messages
+jsonschema = "0.32.1"        # JSON Schema validation used to enhance error messages
 saphyr = "0.0.4"             # YAML parser preserving span information (location in file)
 


### PR DESCRIPTION
The new version of jsonschema library now has nested error messages for AnyOf/OneOf variants.

I took a first crack at an error message.  It's not good, but it's better than what was there before.  New message example:

```
Diagnostic report:

invalid_semconv_group

  × The following YAML snippet does not match any of the allowed schemas.
  │ (Variant 1):
  │ - Value {"groups":[{"id":"test"}],"my_bad_yaml":"test","version":"1"} does not match any schema in a 'oneOf' group; it must match exactly one.
  │   (Variant 1):
  │   - Missing required property: "brief".
  │   (Variant 2):
  │   - Value "1" is not among the allowed options: ["2"].
  │ (Variant 2):
  │ - Missing required property: "brief".
  │ - Object contains unexpected properties: my_bad_yaml, version. These properties are not defined in the schema.
  help: A semantic convention file as defined [here](https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md) A semconv file
        either follows version 1 or 2.  Default is version 1.
```