### PR TITLE
Live-check stats: don't serialize 0 when reporting seen attributes and metrics

### DIFF
--- a/crates/weaver_live_check/src/lib.rs
+++ b/crates/weaver_live_check/src/lib.rs
@@ -20,6 +20,18 @@ use weaver_common::diagnostic::{DiagnosticMessage, DiagnosticMessages};
 use weaver_forge::registry::{ResolvedGroup, ResolvedRegistry};
 use weaver_semconv::group::GroupType;
 
+/// Helper function to serialize HashMap<string, usize> excluding zero values
+fn serialize_map_non_zero_values<S>(map: &HashMap<String, usize>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let filtered: HashMap<&String, &usize> = map
+        .iter()
+        .filter(|(_, &v)| v > 0)
+        .collect();
+    filtered.serialize(serializer)
+}
+
 /// Advisors for live checks
 pub mod advice;
 /// An ingester that reads samples from a JSON file.
@@ -236,10 +248,12 @@ pub struct LiveCheckStatistics {
     /// The number of entities with each advice type
     pub advice_type_counts: HashMap<String, usize>,
     /// The number of each attribute seen from the registry
+    #[serde(serialize_with = "serialize_map_non_zero_values")]
     pub seen_registry_attributes: HashMap<String, usize>,
     /// The number of each non-registry attribute seen
     pub seen_non_registry_attributes: HashMap<String, usize>,
     /// The number of each metric seen from the registry
+    #[serde(serialize_with = "serialize_map_non_zero_values")]
     pub seen_registry_metrics: HashMap<String, usize>,
     /// The number of each non-registry metric seen
     pub seen_non_registry_metrics: HashMap<String, usize>,


### PR DESCRIPTION
a tiny improvement for the report.

It currently contains ~1000 of extra lines that look like 

```json
...
    "seen_registry_attributes": {
      ...
      "vcs.ref.type": 0,
      "vcs.repository.name": 0,
      "vcs.repository.url.full": 0,
      "vcs.revision_delta.direction": 0,
      "webengine.description": 0,
      "webengine.name": 0,
      "webengine.version": 0,
      "zos.smf.id": 0,
      "zos.sysplex.name": 0
    },
    "seen_registry_metrics": {
      "aspnetcore.authentication.authenticate.duration": 0,
      "aspnetcore.authentication.challenges": 0,
      "aspnetcore.authentication.forbids": 0,
      "aspnetcore.authentication.sign_ins": 0,
      "aspnetcore.authentication.sign_outs": 0,
      "aspnetcore.authorization.attempts": 0,
      "aspnetcore.diagnostics.exceptions": 0,
      ...
    }
```

this pr customizes serialization to not print `seen_registry*` keys with 0 value.