### PR TITLE
Add debug logs about config and templates loading

### DIFF
--- a/crates/weaver_forge/src/config.rs
+++ b/crates/weaver_forge/src/config.rs
@@ -485,6 +485,7 @@ impl WeaverConfig {
     pub fn try_from_loader(
         loader: &(impl FileLoader + Send + Sync + 'static),
     ) -> Result<Self, Error> {
+        log::debug!("Searching for Weaver configuration from {} at {:?}", WEAVER_YAML, loader.root().display());
         match loader.load_file(WEAVER_YAML)? {
             Some(config) => Self::resolve_from(&[config]),
             None => Ok(WeaverConfig::default()),
@@ -499,6 +500,7 @@ impl WeaverConfig {
     /// configuration content can't be deserialized into a `WeaverConfig` struct.
     fn resolve_from(configs: &[FileContent]) -> Result<WeaverConfig, Error> {
         if configs.is_empty() {
+            log::debug!("No configuration file found. Using default config.");
             return Ok(WeaverConfig::default());
         }
 
@@ -507,14 +509,16 @@ impl WeaverConfig {
 
         // Each configuration is loaded and merged into the current configuration.
         for conf in configs {
-            let conf: WeaverConfig =
+            let weaver_config: WeaverConfig =
                 serde_yaml::from_str(&conf.content).map_err(|e| InvalidConfigFile {
                     config_file: conf.path.clone(),
                     error: e.to_string(),
                 })?;
-            config.override_with(conf);
+            log::debug!("Loaded Weaver configuration from {}", conf.path.display());
+            config.override_with(weaver_config);
         }
 
+        log::trace!("Using the following Weaver configuration: {:#?}", config);
         Ok(config)
     }
 

--- a/crates/weaver_forge/src/config.rs
+++ b/crates/weaver_forge/src/config.rs
@@ -485,7 +485,11 @@ impl WeaverConfig {
     pub fn try_from_loader(
         loader: &(impl FileLoader + Send + Sync + 'static),
     ) -> Result<Self, Error> {
-        log::debug!("Searching for Weaver configuration from {} at {:?}", WEAVER_YAML, loader.root().display());
+        log::debug!(
+            "Searching for Weaver configuration from {} at {:?}",
+            WEAVER_YAML,
+            loader.root().display()
+        );
         match loader.load_file(WEAVER_YAML)? {
             Some(config) => Self::resolve_from(&[config]),
             None => Ok(WeaverConfig::default()),

--- a/crates/weaver_forge/src/file_loader.rs
+++ b/crates/weaver_forge/src/file_loader.rs
@@ -66,11 +66,14 @@ impl EmbeddedFileLoader {
         local_dir: PathBuf,
         target: &str,
     ) -> Result<Self, Error> {
-        let target_embedded_dir = embedded_dir.get_dir(target).ok_or_else(|| TargetNotSupported {
-            root_path: embedded_dir.path().to_string_lossy().to_string(),
-            target: target.to_owned(),
-            error: "Target not found".to_owned(),
-        })?;
+        let target_embedded_dir =
+            embedded_dir
+                .get_dir(target)
+                .ok_or_else(|| TargetNotSupported {
+                    root_path: embedded_dir.path().to_string_lossy().to_string(),
+                    target: target.to_owned(),
+                    error: "Target not found".to_owned(),
+                })?;
 
         let target_local_dir = local_dir.join(target);
         let fs_loader = if target_local_dir.exists() {
@@ -80,9 +83,15 @@ impl EmbeddedFileLoader {
         };
 
         if fs_loader.is_some() {
-            log::debug!("Using local templates from `{}`", target_local_dir.display());
+            log::debug!(
+                "Using local templates from `{}`",
+                target_local_dir.display()
+            );
         } else {
-            log::debug!("No local templates found at `{}`. Using embedded templates.", target_embedded_dir.path().display());
+            log::debug!(
+                "No local templates found at `{}`. Using embedded templates.",
+                target_embedded_dir.path().display()
+            );
         }
 
         Ok(Self {


### PR DESCRIPTION
A trivial PR adding a few debug logs to help understand where weaver config comes from. 

E.g. when running live-check with `--format json --templates ./templates`

```
Using local templates from `./templates/json`
Searching for Weaver configuration from weaver.yaml at "/Users/lmolkova/repo/weaver-live-demo/templates/json"
Loaded Weaver configuration from /Users/lmolkova/repo/weaver-live-demo/templates/json/weaver.yaml
```

no format/no templates

```log
No local templates found at `ansi`. Using embedded templates.
Searching for Weaver configuration from weaver.yaml at "ansi"
Loaded Weaver configuration from ansi/weaver.yaml
```

Could be better but helps to learn there are embedded configs and templates and shows which config is loaded. 