### PR TITLE
Live-check reporting improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+# Unreleased
+
+- Live-check report changes ([#943](https://github.com/open-telemetry/weaver/pull/943) by @lmolkova)
+  - 💥 BREAKING CHANGE 💥 `value` property in `Advice` is renamed to `advice_context`
+  - Advice now contains `signal_type` and `signal_name` properties to simplify post-processing
+  - Message format is changed to include all dynamic details about the advice
+
 # [0.18.0] - 2025-09-17
 
 - Fail when JQ filters fail ([#894](https://github.com/open-telemetry/weaver/pull/894) by @lmolkova)

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -106,7 +106,7 @@ pub enum Error {
         /// The provenance of the violation (URL or path).
         provenance: String,
         /// The violation.
-        violation: Violation,
+        violation: Box<Violation>,
     },
 
     /// A container for multiple errors.

--- a/crates/weaver_checker/src/violation.rs
+++ b/crates/weaver_checker/src/violation.rs
@@ -93,8 +93,9 @@ pub struct Advice {
     /// machine-readable string that categorizes the advice.
     pub advice_type: String,
 
-    /// The context associated with the advice e.g. { "attribute_name": "foo.bar" }
-    /// Context values may be used with custom templates and filters to query, summarize, and format advice.
+    /// The context associated with the advice e.g. { "attribute_name": "foo.bar", "attribute_value": "bar" }
+    /// The value should contain all dynamic parts of the message in a structured way.
+    /// Context values may be used with custom templates and filters to customize reports.
     pub value: Value,
 
     /// The human-readable message of the advice e.g. "This attribute 'foo.bar' is deprecated, reason: 'use foo.baz'"

--- a/crates/weaver_checker/src/violation.rs
+++ b/crates/weaver_checker/src/violation.rs
@@ -88,7 +88,7 @@ pub enum AdviceLevel {
 
 /// Represents a live check advice
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
-pub struct         Advice {
+pub struct Advice {
     /// The type of advice e.g. "is_deprecated". This should be a short,
     /// machine-readable string that categorizes the advice.
     pub advice_type: String,

--- a/crates/weaver_checker/src/violation.rs
+++ b/crates/weaver_checker/src/violation.rs
@@ -43,7 +43,7 @@ impl Display for Violation {
             }
             Violation::Advice(Advice {
                 advice_type: r#type,
-                value,
+                advice_context,
                 message,
                 advice_level,
                 signal_type,
@@ -51,7 +51,7 @@ impl Display for Violation {
             }) => {
                 write!(
                     f,
-                    "type={type}, value={value}, message={message}, advice_level={advice_level:?}, signal_type={signal_type:?}, signal_name={signal_name:?}"
+                    "type={type}, context={advice_context}, message={message}, advice_level={advice_level:?}, signal_type={signal_type:?}, signal_name={signal_name:?}"
                 )
             }
         }
@@ -88,20 +88,20 @@ pub enum AdviceLevel {
 
 /// Represents a live check advice
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
-pub struct Advice {
+pub struct         Advice {
     /// The type of advice e.g. "is_deprecated". This should be a short,
     /// machine-readable string that categorizes the advice.
     pub advice_type: String,
 
     /// The context associated with the advice e.g. { "attribute_name": "foo.bar", "attribute_value": "bar" }
-    /// The value should contain all dynamic parts of the message in a structured way.
+    /// The context should contain all dynamic parts of the message
     /// Context values may be used with custom templates and filters to customize reports.
-    pub value: Value,
+    pub advice_context: Value,
 
     /// The human-readable message of the advice e.g. "This attribute 'foo.bar' is deprecated, reason: 'use foo.baz'"
     /// The message, along with signal_name and signal_type, should contain enough information to understand the advice and
     /// identify the issue and how to fix it.
-    /// Some of the values used in the message may be also present in the `value` field to support report customization.
+    /// Some of the values used in the message may be also present in the `advice_context` field to support report customization.
     pub message: String,
 
     /// The level of the advice e.g. "violation"

--- a/crates/weaver_checker/src/violation.rs
+++ b/crates/weaver_checker/src/violation.rs
@@ -46,10 +46,12 @@ impl Display for Violation {
                 value,
                 message,
                 advice_level,
+                signal_type,
+                signal_name,
             }) => {
                 write!(
                     f,
-                    "type={type}, value={value}, message={message}, advice_level={advice_level:?}"
+                    "type={type}, value={value}, message={message}, advice_level={advice_level:?}, signal_type={signal_type:?}, signal_name={signal_name:?}"
                 )
             }
         }
@@ -95,4 +97,9 @@ pub struct Advice {
     pub message: String,
     /// The level of the advice e.g. "violation"
     pub advice_level: AdviceLevel,
+
+    /// The signal type the advice applies to e.g. "span", "metric", "resource"
+    pub signal_type: Option<String>,
+    /// The signal name the advice applies to e.g. "http.server.duration"
+    pub signal_name: Option<String>,
 }

--- a/crates/weaver_checker/src/violation.rs
+++ b/crates/weaver_checker/src/violation.rs
@@ -89,17 +89,26 @@ pub enum AdviceLevel {
 /// Represents a live check advice
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct Advice {
-    /// The type of advice e.g. "is_deprecated"
+    /// The type of advice e.g. "is_deprecated". This should be a short,
+    /// machine-readable string that categorizes the advice.
     pub advice_type: String,
-    /// The value of the advice e.g. "true"
+
+    /// The context associated with the advice e.g. { "attribute_name": "foo.bar" }
+    /// Context values may be used with custom templates and filters to query, summarize, and format advice.
     pub value: Value,
-    /// The message of the advice e.g. "This attribute is deprecated"
+
+    /// The human-readable message of the advice e.g. "This attribute 'foo.bar' is deprecated, reason: 'use foo.baz'"
+    /// The message, along with signal_name and signal_type, should contain enough information to understand the advice and
+    /// identify the issue and how to fix it.
+    /// Some of the values used in the message may be also present in the `value` field to support report customization.
     pub message: String,
+
     /// The level of the advice e.g. "violation"
     pub advice_level: AdviceLevel,
 
-    /// The signal type the advice applies to e.g. "span", "metric", "resource"
+    /// The signal type the advice applies to: "span", "metric", "entity", "log" (aka "event"), or "profile"
     pub signal_type: Option<String>,
-    /// The signal name the advice applies to e.g. "http.server.duration"
+
+    /// The signal name the advice applies to e.g. "http.server.request.duration".
     pub signal_name: Option<String>,
 }

--- a/crates/weaver_live_check/README.md
+++ b/crates/weaver_live_check/README.md
@@ -126,16 +126,18 @@ package live_check_advice
 import rego.v1
 
 # checks attribute name contains the word "test"
-deny contains make_advice(advice_type, advice_level, value, message) if {
-  input.sample.attribute
-  value := input.sample.attribute.name
-  contains(value, "test")
-  advice_type := "contains_test"
-  advice_level := "violation"
-  message := "Name must not contain 'test'"
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
+	input.sample.attribute
+	contains(input.sample.attribute.name, "test")
+	advice_type := "contains_test"
+	advice_level := "violation"
+	advice_context := {
+		"attribute_name": input.sample.attribute.name
+	}
+	message := sprintf("Attribute name must not contain 'test', but was '%s'", [input.sample.attribute.name])
 }
 
-make_advice(advice_type, advice_level, value, message) := {
+make_advice(advice_type, advice_level, advice_context, message) := {
   "type": "advice",
   "advice_type": advice_type,
   "advice_level": advice_level,

--- a/crates/weaver_live_check/README.md
+++ b/crates/weaver_live_check/README.md
@@ -85,8 +85,12 @@ As mentioned, a list of `Advice` is returned in the report for each sample entit
 
 - `advice_level`: _string_ - one of `violation`, `improvement` or `information` with that order of precedence. Weaver will return with a non-zero exit-code if there is any `violation` in the report.
 - `advice_type`: _string_ - a simple machine readable string to represent the advice type
-- `message`: _string_ - a verbose string describing the advice
-- `value`: _any_ - a pertinent entity associated with the advice
+- `signal_type`: _string_ - a type of the signal advice is reported for: `metirc`, `span`, or `resource`
+- `signal_name`: _string_ - a name of the signal addvice is reported for: metric name or span name
+- `advice_context`: _any_ - a map that describes details about the advice in a structured way,
+  for example `{ "attribute_name": "foo.bar", "attribute_value": "bar" }`.
+- `message`: _string_ - verbose string describing the advice. It contains the same details as `advice_context` but
+  is formatted and human-readable.
 
 ```json
 {
@@ -95,8 +99,10 @@ As mentioned, a list of `Advice` is returned in the report for each sample entit
       {
         "advice_level": "violation",
         "advice_type": "missing_attribute",
-        "message": "Does not exist in the registry",
-        "value": "hello"
+        "message": "Attribute `hello` does not exist in the registry.",
+        "advice_context": {"attribute_name": "hello"},
+        "signal_name": "http.client.request.duration",
+        "signal_type": "metric"
       }
     ],
     "highest_advice_level": "violation"
@@ -107,7 +113,7 @@ As mentioned, a list of `Advice` is returned in the report for each sample entit
 }
 ```
 
-> **Note**  
+> **Note**
 > The `live_check_result` object augments the sample entity at the pertinent level in the structure. If the structure is `metric`->`[number_data_point]`->`[attribute]`, advice should be give at the `number_data_point` level for, say, required attributes that have not been supplied. Whereas, attribute advice, like `missing_attribute` in the JSON above, is given at the attribute level.
 
 ### Custom advisors

--- a/crates/weaver_live_check/README.md
+++ b/crates/weaver_live_check/README.md
@@ -85,8 +85,8 @@ As mentioned, a list of `Advice` is returned in the report for each sample entit
 
 - `advice_level`: _string_ - one of `violation`, `improvement` or `information` with that order of precedence. Weaver will return with a non-zero exit-code if there is any `violation` in the report.
 - `advice_type`: _string_ - a simple machine readable string to represent the advice type
-- `signal_type`: _string_ - a type of the signal advice is reported for: `metirc`, `span`, or `resource`
-- `signal_name`: _string_ - a name of the signal addvice is reported for: metric name or span name
+- `signal_type`: _string_ - a type of the signal advice is reported for: `metric`, `span`, or `resource`
+- `signal_name`: _string_ - a name of the signal advice is reported for: metric name or span name
 - `advice_context`: _any_ - a map that describes details about the advice in a structured way,
   for example `{ "attribute_name": "foo.bar", "attribute_value": "bar" }`.
 - `message`: _string_ - verbose string describing the advice. It contains the same details as `advice_context` but

--- a/crates/weaver_live_check/data/policies/bad_advice/bad.rego
+++ b/crates/weaver_live_check/data/policies/bad_advice/bad.rego
@@ -8,10 +8,10 @@ deny contains make_advice("foo", "violation", attribute_name, "bar") if {
 	not attribu1te_name
 }
 
-make_advice(advice_type, advice_level, value, message) := {
+make_advice(advice_type, advice_level, advice_context, message) := {
 	"type": "advice",
 	"advice_type": advice_type,
 	"advice_level": advice_level,
-	"value": value,
+	"advice_context": advice_context,
 	"message": message,
 }

--- a/crates/weaver_live_check/data/policies/live_check_advice/test.rego
+++ b/crates/weaver_live_check/data/policies/live_check_advice/test.rego
@@ -5,48 +5,48 @@ import rego.v1
 # checks attribute name contains the word "test"
 deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.attribute
-	advice_context := {
-		"attribute_name": input.sample.attribute.name
-	}
 	contains(input.sample.attribute.name, "test")
 	advice_type := "contains_test"
 	advice_level := "violation"
-	message :=  sprintf("Attribute name must not contain 'test', but was '%s'", [input.sample.attribute.name])
+	advice_context := {
+		"attribute_name": input.sample.attribute.name
+	}
+	message := sprintf("Attribute name must not contain 'test', but was '%s'", [input.sample.attribute.name])
 }
 
 # checks span name contains the word "test"
 deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.span
-	advice_context := {
-		"span_name": input.sample.span.name
-	}
 	contains(input.sample.span.name, "test")
 	advice_type := "contains_test"
 	advice_level := "violation"
+	advice_context := {
+		"span_name": input.sample.span.name
+	}
 	message :=  sprintf("Span name must not contain 'test', but was '%s'", [input.sample.span.name])
 }
 
 # checks span status message contains the word "test"
 deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.span
-	advice_context := {
-		"span_status_message": input.sample.span.status.message
-	}
 	contains(input.sample.span.status.message, "test")
 	advice_type := "contains_test_in_status"
 	advice_level := "violation"
+	advice_context := {
+		"span_status_message": input.sample.span.status.message
+	}
 	message :=  sprintf("Span status message must not contain 'test', but was '%s'", [input.sample.span.status.message])
 }
 
 # checks span_event name contains the word "test"
 deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.span_event
-	advice_context := {
-		"span_event_name": input.sample.span_event.name
-	}
 	contains(input.sample.span_event.name, "test")
 	advice_type := "contains_test"
 	advice_level := "violation"
+	advice_context := {
+		"span_event_name": input.sample.span_event.name
+	}
 	message :=  sprintf("Span event name must not contain 'test', but was '%s'", [input.sample.span_event.name])
 }
 
@@ -67,13 +67,13 @@ deny contains make_advice(advice_type, advice_level, advice_context, message) if
 # As above, but for exemplars which are nested two levels deep.
 deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.exemplar
-	advice_context := {
-		"exemplar_value": input.sample.exemplar.value
-	}
 	input.registry_group.unit == "s"
 	input.sample.exemplar.value < 1.0
 	advice_type := "low_value"
 	advice_level := "information"
+	advice_context := {
+		"exemplar_value": input.sample.exemplar.value
+	}
 	message := sprintf("This is a low number of seconds: %v", [input.sample.exemplar.value])
 }
 

--- a/crates/weaver_live_check/data/policies/live_check_advice/test.rego
+++ b/crates/weaver_live_check/data/policies/live_check_advice/test.rego
@@ -3,72 +3,84 @@ package live_check_advice
 import rego.v1
 
 # checks attribute name contains the word "test"
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.attribute
-	value := input.sample.attribute.name
-	contains(value, "test")
+	advice_context := {
+		"attribute_name": input.sample.attribute.name
+	}
+	contains(input.sample.attribute.name, "test")
 	advice_type := "contains_test"
 	advice_level := "violation"
-	message := "Name must not contain 'test'"
+	message :=  sprintf("Attribute name must not contain 'test', but was '%s'", [input.sample.attribute.name])
 }
 
 # checks span name contains the word "test"
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.span
-	value := input.sample.span.name
-	contains(value, "test")
+	advice_context := {
+		"span_name": input.sample.span.name
+	}
+	contains(input.sample.span.name, "test")
 	advice_type := "contains_test"
 	advice_level := "violation"
-	message := "Name must not contain 'test'"
+	message :=  sprintf("Span name must not contain 'test', but was '%s'", [input.sample.span.name])
 }
 
 # checks span status message contains the word "test"
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.span
-	value := input.sample.span.status.message
-	contains(value, "test")
+	advice_context := {
+		"span_status_message": input.sample.span.status.message
+	}
+	contains(input.sample.span.status.message, "test")
 	advice_type := "contains_test_in_status"
 	advice_level := "violation"
-	message := "Status message must not contain 'test'"
+	message :=  sprintf("Span status message must not contain 'test', but was '%s'", [input.sample.span.status.message])
 }
 
 # checks span_event name contains the word "test"
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.span_event
-	value := input.sample.span_event.name
-	contains(value, "test")
+	advice_context := {
+		"span_event_name": input.sample.span_event.name
+	}
+	contains(input.sample.span_event.name, "test")
 	advice_type := "contains_test"
 	advice_level := "violation"
-	message := "Name must not contain 'test'"
+	message :=  sprintf("Span event name must not contain 'test', but was '%s'", [input.sample.span_event.name])
 }
 
 # This example shows how to use the registry_group provided in the input.
 # If the metric's unit is "By" the value in this data-point must be an integer.
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.number_data_point
-	value := input.sample.number_data_point.value
 	input.registry_group.unit == "By"
-	value != floor(value) # not a good type check, but serves as an example
+	input.sample.number_data_point.value != floor(input.sample.number_data_point.value) # not a good type check, but serves as an example
+	advice_context := {
+		"data_point_value": input.sample.number_data_point.value
+	}
 	advice_type := "invalid_data_point_value"
 	advice_level := "violation"
-	message := "Value must be an integer when unit is 'By'"
+	message := sprintf("Metric with unit 'By' must have an integer value, but was '%v'", [input.sample.number_data_point.value])
 }
 
 # As above, but for exemplars which are nested two levels deep.
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.exemplar
-	value := input.sample.exemplar.value
+	advice_context := {
+		"exemplar_value": input.sample.exemplar.value
+	}
 	input.registry_group.unit == "s"
-	value < 1.0
+	input.sample.exemplar.value < 1.0
 	advice_type := "low_value"
 	advice_level := "information"
-	message := "This is a low number of seconds"
+	message := sprintf("This is a low number of seconds: %v", [input.sample.exemplar.value])
 }
 
-make_advice(advice_type, advice_level, value, message) := {
+make_advice(advice_type, advice_level, advice_context, message) := {
 	"type": "advice",
 	"advice_type": advice_type,
 	"advice_level": advice_level,
-	"value": value,
+	"advice_context": advice_context,
 	"message": message,
 }

--- a/crates/weaver_live_check/src/advice.rs
+++ b/crates/weaver_live_check/src/advice.rs
@@ -72,18 +72,18 @@ impl Advisor for DeprecatedAdvisor {
         registry_group: Option<Rc<ResolvedGroup>>,
     ) -> Result<Vec<Advice>, Error> {
         match sample {
-            SampleRef::Attribute(_sample_attribute) => {
+            SampleRef::Attribute(sample_attribute) => {
                 let mut advices = Vec::new();
                 if let Some(attribute) = registry_attribute {
                     if let Some(deprecated) = &attribute.deprecated {
                         advices.push(Advice {
                             advice_type: "deprecated".to_owned(),
                             value: json!({
-                                "attribute_name": _sample_attribute.name.clone(),
+                                "attribute_name": sample_attribute.name.clone(),
                             }),
                             message: format!(
                                 "Attribute `{}` is deprecated; reason = {}, note = {}",
-                                _sample_attribute.name.clone(),
+                                sample_attribute.name.clone(),
                                 deprecated_to_reason(deprecated),
                                 deprecated
                             ),
@@ -95,7 +95,7 @@ impl Advisor for DeprecatedAdvisor {
                 }
                 Ok(advices)
             }
-            SampleRef::Metric(_sample_metric) => {
+            SampleRef::Metric(sample_metric) => {
                 let mut advices = Vec::new();
                 if let Some(group) = registry_group {
                     if let Some(deprecated) = &group.deprecated {
@@ -103,14 +103,13 @@ impl Advisor for DeprecatedAdvisor {
                             advice_type: "deprecated".to_owned(),
                             value: Value::Null,
                             message: format!(
-                                "Metric `{}` is deprecated; reason = {}, note = {}",
-                                _sample_metric.name.clone(),
+                                "Metric is deprecated; reason = {}, note = {}",
                                 deprecated_to_reason(deprecated),
                                 deprecated
                             ),
                             advice_level: AdviceLevel::Violation,
                             signal_type: Some("metric".to_owned()),
-                            signal_name: Some(_sample_metric.name.clone()),
+                            signal_name: Some(sample_metric.name.clone()),
                         });
                     }
                 }
@@ -170,8 +169,7 @@ impl Advisor for StabilityAdvisor {
                                 advice_type: "not_stable".to_owned(),
                                 value: Value::Null,
                                 message: format!(
-                                    "Metric `{}` is not stable; stability = {}.",
-                                    sample_metric.name.clone(),
+                                    "Metric is not stable; stability = {}.",
                                     stability
                                 ),
                                 advice_level: AdviceLevel::Improvement,

--- a/crates/weaver_live_check/src/advice.rs
+++ b/crates/weaver_live_check/src/advice.rs
@@ -80,7 +80,7 @@ impl Advisor for DeprecatedAdvisor {
                     if let Some(deprecated) = &attribute.deprecated {
                         advices.push(Advice {
                             advice_type: "deprecated".to_owned(),
-                            value: json!({
+                            advice_context: json!({
                                 "attribute_name": sample_attribute.name.clone(),
                                 "deprecation_reason": deprecated_to_reason(deprecated),
                                 "deprecation_note": deprecated.to_string(),
@@ -105,7 +105,7 @@ impl Advisor for DeprecatedAdvisor {
                     if let Some(deprecated) = &group.deprecated {
                         advices.push(Advice {
                             advice_type: "deprecated".to_owned(),
-                            value: json!({
+                            advice_context: json!({
                                 "deprecation_reason": deprecated_to_reason(deprecated),
                                 "deprecation_note": deprecated,
                             }),
@@ -148,7 +148,7 @@ impl Advisor for StabilityAdvisor {
                         Some(ref stability) if *stability != Stability::Stable => {
                             advices.push(Advice {
                                 advice_type: "not_stable".to_owned(),
-                                value: json!({
+                                advice_context: json!({
                                     "attribute_name": sample_attribute.name.clone(),
                                     "stability": stability,
                                 }),
@@ -174,7 +174,7 @@ impl Advisor for StabilityAdvisor {
                         Some(ref stability) if *stability != Stability::Stable => {
                             advices.push(Advice {
                                 advice_type: "not_stable".to_owned(),
-                                value: json!({
+                                advice_context: json!({
                                     "stability": stability,
                                 }),
                                 message: format!(
@@ -260,7 +260,7 @@ fn check_attributes(
             };
             advice_list.push(Advice {
                 advice_type,
-                value: json!({
+                advice_context: json!({
                     "attribute_name": semconv_attribute.name.clone()
                 }),
                 message,
@@ -312,7 +312,7 @@ impl Advisor for TypeAdvisor {
                                 {
                                     return Ok(vec![Advice {
                                         advice_type: "type_mismatch".to_owned(),
-                                        value: json!({
+                                        advice_context: json!({
                                             "attribute_name": sample_attribute.name.clone(),
                                             "attribute_type": attribute_type,
                                         }),
@@ -330,7 +330,7 @@ impl Advisor for TypeAdvisor {
                         if !attribute_type.is_compatible(semconv_attribute_type) {
                             Ok(vec![Advice {
                                 advice_type: "type_mismatch".to_owned(),
-                                value: json!({
+                                advice_context: json!({
                                     "attribute_name": sample_attribute.name.clone(),
                                     "attribute_type": attribute_type,
                                     "expected_type": semconv_attribute_type,
@@ -359,7 +359,7 @@ impl Advisor for TypeAdvisor {
                         SampleInstrument::Unsupported(name) => {
                             advice_list.push(Advice {
                                 advice_type: "unsupported_instrument".to_owned(),
-                                value: json!({
+                                advice_context: json!({
                                     "instrument": name.clone()
                                 }),
                                 message: format!("Instrument '{name}' is not supported"),
@@ -373,7 +373,7 @@ impl Advisor for TypeAdvisor {
                                 if semconv_instrument != sample_instrument {
                                     advice_list.push(Advice {
                                         advice_type: "instrument_mismatch".to_owned(),
-                                        value: json!({
+                                        advice_context: json!({
                                             "instrument": sample_instrument,
                                             "expected_instrument": semconv_instrument,
                                         }),
@@ -393,7 +393,7 @@ impl Advisor for TypeAdvisor {
                         if semconv_unit != &sample_metric.unit {
                             advice_list.push(Advice {
                                 advice_type: "unit_mismatch".to_owned(),
-                                value: json!({
+                                advice_context: json!({
                                     "unit": sample_metric.unit.clone(),
                                     "expected_unit": semconv_unit.clone(),
                                 }),
@@ -490,7 +490,7 @@ impl Advisor for EnumAdvisor {
                             if !is_found {
                                 return Ok(vec![Advice {
                                     advice_type: "undefined_enum_variant".to_owned(),
-                                    value: json!({
+                                    advice_context: json!({
                                         "attribute_name": sample_attribute.name.clone(),
                                         "attribute_value": attribute_value,
                                     }),

--- a/crates/weaver_live_check/src/advice.rs
+++ b/crates/weaver_live_check/src/advice.rs
@@ -82,7 +82,7 @@ impl Advisor for DeprecatedAdvisor {
                                 "attribute_name": sample_attribute.name.clone(),
                             }),
                             message: format!(
-                                "Attribute `{}` is deprecated; reason = {}, note = {}",
+                                "Attribute '{}' is deprecated; reason = '{}', note = '{}'.",
                                 sample_attribute.name.clone(),
                                 deprecated_to_reason(deprecated),
                                 deprecated
@@ -144,7 +144,7 @@ impl Advisor for StabilityAdvisor {
                                     "attribute_name": sample_attribute.name.clone()
                                 }),
                                 message: format!(
-                                    "Attribute `{}` is not stable; stability = {}.",
+                                    "Attribute '{}' is not stable; stability = {}.",
                                     sample_attribute.name.clone(),
                                     stability
                                 ),
@@ -219,7 +219,7 @@ fn check_attributes(
                     "required_attribute_not_present".to_owned(),
                     AdviceLevel::Violation,
                     format!(
-                        "Required attribute `{}` is not present.",
+                        "Required attribute '{}' is not present.",
                         semconv_attribute.name
                     ),
                 ),
@@ -228,7 +228,7 @@ fn check_attributes(
                     "recommended_attribute_not_present".to_owned(),
                     AdviceLevel::Improvement,
                     format!(
-                        "Recommended attribute `{}` is not present.",
+                        "Recommended attribute '{}' is not present.",
                         semconv_attribute.name
                     ),
                 ),
@@ -237,7 +237,7 @@ fn check_attributes(
                     "opt_in_attribute_not_present".to_owned(),
                     AdviceLevel::Information,
                     format!(
-                        "Opt-in attribute `{}` is not present.",
+                        "Opt-in attribute '{}' is not present.",
                         semconv_attribute.name
                     ),
                 ),
@@ -245,7 +245,7 @@ fn check_attributes(
                     "conditionally_required_attribute_not_present".to_owned(),
                     AdviceLevel::Information,
                     format!(
-                        "Conditionally required attribute `{}` is not present.",
+                        "Conditionally required attribute '{}' is not present.",
                         semconv_attribute.name
                     ),
                 ),
@@ -306,7 +306,7 @@ impl Advisor for TypeAdvisor {
                                         value: json!({
                                             "attribute_name": sample_attribute.name.clone(),
                                         }),
-                                        message: format!("Enum attribute `{}` has type `{}`. Enum value type should be `string` or `int`.", sample_attribute.name, attribute_type),
+                                        message: format!("Enum attribute '{}' has type '{}'. Enum value type should be 'string' or 'int'.", sample_attribute.name, attribute_type),
                                         advice_level: AdviceLevel::Violation,
                                         signal_type: registry_group
                                             .as_ref()
@@ -328,7 +328,7 @@ impl Advisor for TypeAdvisor {
                                     "attribute_name": sample_attribute.name.clone()
                                 }),
                                 message: format!(
-                                    "Attribute `{}` has type `{}`. Type should be `{}`.",
+                                    "Attribute '{}' has type '{}'. Type should be '{}'.",
                                     sample_attribute.name, attribute_type, semconv_attribute_type
                                 ),
                                 advice_level: AdviceLevel::Violation,
@@ -356,7 +356,7 @@ impl Advisor for TypeAdvisor {
                                 value: json!({
                                     "instrument": name.clone()
                                 }),
-                                message: format!("Instrument `{name}` is not supported"),
+                                message: format!("Instrument '{name}' is not supported"),
                                 advice_level: AdviceLevel::Violation,
                                 signal_type: Some("metric".to_owned()),
                                 signal_name: Some(sample_metric.name.clone()),
@@ -369,7 +369,7 @@ impl Advisor for TypeAdvisor {
                                         advice_type: "instrument_mismatch".to_owned(),
                                         value: Value::Null,
                                         message: format!(
-                                            "Instrument should be `{semconv_instrument}`, but found `{sample_instrument}`."
+                                            "Instrument should be '{semconv_instrument}', but found '{sample_instrument}'."
                                         ),
                                         advice_level: AdviceLevel::Violation,
                                         signal_type: Some("metric".to_owned()),
@@ -389,7 +389,7 @@ impl Advisor for TypeAdvisor {
                                     "expected_unit": semconv_unit.clone(),
                                 }),
                                 message: format!(
-                                    "Unit should be `{semconv_unit}`, but found `{}`.",
+                                    "Unit should be '{semconv_unit}', but found '{}'.",
                                     sample_metric.unit
                                 ),
                                 advice_level: AdviceLevel::Violation,
@@ -486,7 +486,7 @@ impl Advisor for EnumAdvisor {
                                         "attribute_name": sample_attribute.name.clone(),
                                         "attribute_value": attribute_value,
                                     }),
-                                    message: format!("Enum attribute `{}` has value `{}` which is not documented.", sample_attribute.name, attribute_value.as_str().unwrap_or("")),
+                                    message: format!("Enum attribute '{}' has value '{}' which is not documented.", sample_attribute.name, attribute_value.as_str().unwrap_or("")),
                                     advice_level: AdviceLevel::Information,
                                     signal_type: registry_group
                                         .as_ref()

--- a/crates/weaver_live_check/src/lib.rs
+++ b/crates/weaver_live_check/src/lib.rs
@@ -47,6 +47,37 @@ pub const MISSING_ATTRIBUTE_ADVICE_TYPE: &str = "missing_attribute";
 pub const TEMPLATE_ATTRIBUTE_ADVICE_TYPE: &str = "template_attribute";
 /// Missing Metric advice type
 pub const MISSING_METRIC_ADVICE_TYPE: &str = "missing_metric";
+/// Deprecated advice type
+pub const DEPRECATED_ADVICE_TYPE: &str = "deprecated";
+/// Type Mismatch advice type
+pub const TYPE_MISMATCH_ADVICE_TYPE: &str = "type_mismatch";
+/// Unstable advice type
+pub const NOT_STABLE_ADVICE_TYPE: &str = "not_stable";
+/// Unit mismatch advice type
+pub const UNIT_MISMATCH_ADVICE_TYPE: &str = "unit_mismatch";
+/// Instrument mismatch advice type
+pub const UNEXPECTED_INSTRUMENT_ADVICE_TYPE: &str = "unexpected_instrument";
+/// Undefined enum variant advice type
+pub const UNDEFINED_ENUM_VARIANT_ADVICE_TYPE: &str = "undefined_enum_variant";
+
+/// Attribute name key in advice context
+pub const ATTRIBUTE_NAME_ADVICE_CONTEXT_KEY: &str = "attribute_name";
+/// Attribute value key in advice context
+pub const ATTRIBUTE_VALUE_ADVICE_CONTEXT_KEY: &str = "attribute_value";
+///Attribute type key in advice context
+pub const ATTRIBUTE_TYPE_ADVICE_CONTEXT_KEY: &str = "attribute_type";
+/// Deprecation reason key in advice context
+pub const DEPRECATION_REASON_ADVICE_CONTEXT_KEY: &str = "deprecation_reason";
+/// Deprecation note key in advice context
+pub const DEPRECATION_NOTE_ADVICE_CONTEXT_KEY: &str = "deprecation_note";
+/// Stability key in advice context
+pub const STABILITY_ADVICE_CONTEXT_KEY: &str = "stability";
+/// Unit key in advice context
+pub const UNIT_ADVICE_CONTEXT_KEY: &str = "unit";
+/// Instrument key in advice context
+pub const INSTRUMENT_ADVICE_CONTEXT_KEY: &str = "instrument";
+/// Expected value key in advice context
+pub const EXPECTED_VALUE_ADVICE_CONTEXT_KEY: &str = "expected";
 
 /// Weaver live check errors
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Serialize, Diagnostic)]

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -335,11 +335,11 @@ mod tests {
         assert_eq!(all_advice[0].advice_type, "template_attribute");
         assert_eq!(
             all_advice[0].advice_context,
-            json!({"attribute_name": "test.template.my.key"})
+            json!({"attribute_name": "test.template.my.key", "template_name": "test.template"})
         );
         assert_eq!(
             all_advice[0].message,
-            "Attribute 'test.template' is a template"
+            "Attribute 'test.template.my.key' is a template"
         );
         assert_eq!(all_advice[1].advice_type, "type_mismatch");
         assert_eq!(
@@ -390,8 +390,8 @@ mod tests {
         assert_eq!(stats.no_advice_count, 2);
         assert_eq!(stats.seen_registry_attributes.len(), 3);
         assert_eq!(stats.seen_registry_attributes["test.enum"], 3);
-        assert_eq!(stats.seen_non_registry_attributes.len(), 7);
-        // TODO assert_eq!(stats.registry_coverage, 1.0);
+        assert_eq!(stats.seen_non_registry_attributes.len(), 6);
+        assert_eq!(stats.registry_coverage, 1.0);
     }
 
     fn make_registry() -> ResolvedRegistry {

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -1013,7 +1013,7 @@ mod tests {
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
         for sample in &mut samples {
-            // This should fail with: "error: use of undefined variable `attribute_name` is unsafe"
+            // This should fail with: "error: use of undefined variable `attribu1te_name` is unsafe"
 
             let result =
                 sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -218,7 +218,7 @@ mod tests {
         assert_eq!(all_advice[0].advice_type, "deprecated");
         assert_eq!(
             all_advice[0].value,
-            json!({"attribute_name": "test.deprecated"})
+            json!({"attribute_name": "test.deprecated", "deprecation_reason": "uncategorized", "deprecation_note": "note"})
         );
         assert_eq!(
             all_advice[0].message,
@@ -228,7 +228,7 @@ mod tests {
         assert_eq!(all_advice[1].advice_type, "not_stable");
         assert_eq!(
             all_advice[1].value,
-            json!({"attribute_name": "test.deprecated"})
+            json!({"attribute_name": "test.deprecated", "stability": "development"})
         );
         assert_eq!(
             all_advice[1].message,
@@ -238,7 +238,7 @@ mod tests {
         assert_eq!(all_advice[2].advice_type, "type_mismatch");
         assert_eq!(
             all_advice[2].value,
-            json!({"attribute_name": "test.deprecated"})
+            json!({"attribute_name": "test.deprecated", "attribute_type": "int", "expected_type": "string"})
         );
         assert_eq!(
             all_advice[2].message,
@@ -272,7 +272,10 @@ mod tests {
         let all_advice = get_all_advice(&mut samples[6]);
         assert_eq!(all_advice.len(), 1);
         assert_eq!(all_advice[0].advice_type, "type_mismatch");
-        assert_eq!(all_advice[0].value, json!({"attribute_name": "test.enum"}));
+        assert_eq!(
+            all_advice[0].value,
+            json!({"attribute_name": "test.enum", "attribute_type": "double"})
+        );
         assert_eq!(all_advice[0].message, "Enum attribute 'test.enum' has type 'double'. Enum value type should be 'string' or 'int'.");
 
         let all_advice = get_all_advice(&mut samples[7]);
@@ -282,7 +285,7 @@ mod tests {
         assert_eq!(all_advice.len(), 3);
 
         assert_eq!(all_advice[0].advice_type, "extends_namespace");
-        assert_eq!(all_advice[0].value, json!({"attribute_name": "test"}));
+        assert_eq!(all_advice[0].value, json!({"attribute_name": "test", "namespace": "test"}));
         assert_eq!(
             all_advice[0].message,
             "Attribute name 'test.string.not.allowed' collides with existing namespace 'test'"
@@ -290,7 +293,7 @@ mod tests {
         assert_eq!(all_advice[1].advice_type, "illegal_namespace");
         assert_eq!(
             all_advice[1].value,
-            json!({"attribute_name": "test.string.not.allowed"})
+            json!({"attribute_name": "test.string.not.allowed", "namespace": "test.string"})
         );
         assert_eq!(
             all_advice[1].message,
@@ -320,7 +323,7 @@ mod tests {
             "Attribute 'test.extends' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "extends_namespace");
-        assert_eq!(all_advice[1].value, json!({"attribute_name": "test"}));
+        assert_eq!(all_advice[1].value, json!({"attribute_name": "test", "namespace": "test"}));
         assert_eq!(
             all_advice[1].message,
             "Attribute name 'test.extends' collides with existing namespace 'test'"
@@ -341,7 +344,7 @@ mod tests {
         assert_eq!(all_advice[1].advice_type, "type_mismatch");
         assert_eq!(
             all_advice[1].value,
-            json!({"attribute_name": "test.template.my.key"})
+            json!({"attribute_name": "test.template.my.key", "attribute_type": "int", "expected_type": "string"})
         );
         assert_eq!(
             all_advice[1].message,
@@ -362,7 +365,7 @@ mod tests {
             "Attribute 'test.deprecated.allowed' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "extends_namespace");
-        assert_eq!(all_advice[1].value, json!({"attribute_name": "test"}));
+        assert_eq!(all_advice[1].value, json!({"attribute_name": "test", "namespace": "test"}));
         assert_eq!(
             all_advice[1].message,
             "Attribute name 'test.deprecated.allowed' collides with existing namespace 'test'"

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -117,7 +117,7 @@ mod tests {
     };
 
     use super::*;
-    use serde_json::{json, Value};
+    use serde_json::json;
     use weaver_checker::violation::{Advice, AdviceLevel};
     use weaver_forge::registry::{ResolvedGroup, ResolvedRegistry};
     use weaver_resolved_schema::attribute::Attribute;
@@ -188,10 +188,13 @@ mod tests {
         // make a sort of the advice
         all_advice.sort_by(|a, b| a.advice_type.cmp(&b.advice_type));
         assert_eq!(all_advice[0].advice_type, "invalid_format");
-        assert_eq!(all_advice[0].value, "testString2");
+        assert_eq!(
+            all_advice[0].value,
+            json!({"attribute_name": "testString2" })
+        );
         assert_eq!(
             all_advice[0].message,
-            "Does not match name formatting rules"
+            "Attribute 'testString2' does not match name formatting rules."
         );
         assert_eq!(all_advice[1].advice_type, "missing_attribute");
         assert_eq!(
@@ -200,11 +203,14 @@ mod tests {
         );
         assert_eq!(
             all_advice[1].message,
-            "Attribute `testString2` does not exist in the registry."
+            "Attribute 'testString2' does not exist in the registry."
         );
         assert_eq!(all_advice[2].advice_type, "missing_namespace");
-        assert_eq!(all_advice[2].value, Value::String("testString2".to_owned()));
-        assert_eq!(all_advice[2].message, "Does not have a namespace");
+        assert_eq!(
+            all_advice[2].value,
+            json!({"attribute_name": "testString2"})
+        );
+        assert_eq!(all_advice[2].message, "Attribute name 'testString2' must include a namespace (e.g. '{namespace}.{attribute_key}')");
 
         let all_advice = get_all_advice(&mut samples[2]);
         assert_eq!(all_advice.len(), 3);
@@ -215,7 +221,7 @@ mod tests {
         );
         assert_eq!(
             all_advice[0].message,
-            "Attribute `test.deprecated` is deprecated; reason = uncategorized, note = note"
+            "Attribute 'test.deprecated' is deprecated; reason = 'uncategorized', note = 'note'."
         );
 
         assert_eq!(all_advice[1].advice_type, "not_stable");
@@ -225,7 +231,7 @@ mod tests {
         );
         assert_eq!(
             all_advice[1].message,
-            "Attribute `test.deprecated` is not stable; stability = development."
+            "Attribute 'test.deprecated' is not stable; stability = development."
         );
 
         assert_eq!(all_advice[2].advice_type, "type_mismatch");
@@ -235,7 +241,7 @@ mod tests {
         );
         assert_eq!(
             all_advice[2].message,
-            "Attribute `test.deprecated` has type `int`. Type should be `string`."
+            "Attribute 'test.deprecated' has type 'int'. Type should be 'string'."
         );
 
         let all_advice = get_all_advice(&mut samples[3]);
@@ -247,7 +253,7 @@ mod tests {
         );
         assert_eq!(
             all_advice[0].message,
-            "Attribute `aws.s3.bucket.name` does not exist in the registry."
+            "Attribute 'aws.s3.bucket.name' does not exist in the registry."
         );
 
         let all_advice = get_all_advice(&mut samples[4]);
@@ -259,14 +265,14 @@ mod tests {
         );
         assert_eq!(
             all_advice[0].message,
-            "Enum attribute `test.enum` has value `foo` which is not documented."
+            "Enum attribute 'test.enum' has value 'foo' which is not documented."
         );
 
         let all_advice = get_all_advice(&mut samples[6]);
         assert_eq!(all_advice.len(), 1);
         assert_eq!(all_advice[0].advice_type, "type_mismatch");
         assert_eq!(all_advice[0].value, json!({"attribute_name": "test.enum"}));
-        assert_eq!(all_advice[0].message, "Enum attribute `test.enum` has type `double`. Enum value type should be `string` or `int`.");
+        assert_eq!(all_advice[0].message, "Enum attribute 'test.enum' has type 'double'. Enum value type should be 'string' or 'int'.");
 
         let all_advice = get_all_advice(&mut samples[7]);
 
@@ -275,13 +281,19 @@ mod tests {
         assert_eq!(all_advice.len(), 3);
 
         assert_eq!(all_advice[0].advice_type, "extends_namespace");
-        assert_eq!(all_advice[0].value, Value::String("test".to_owned()));
-        assert_eq!(all_advice[0].message, "Extends existing namespace");
+        assert_eq!(all_advice[0].value, json!({"attribute_name": "test"}));
+        assert_eq!(
+            all_advice[0].message,
+            "Attribute name 'test.string.not.allowed' collides with existing namespace 'test'"
+        );
         assert_eq!(all_advice[1].advice_type, "illegal_namespace");
-        assert_eq!(all_advice[1].value, Value::String("test.string".to_owned()));
+        assert_eq!(
+            all_advice[1].value,
+            json!({"attribute_name": "test.string.not.allowed"})
+        );
         assert_eq!(
             all_advice[1].message,
-            "Namespace matches existing attribute"
+            "Namespace 'test.string' collides with existing attribute 'test.string.not.allowed'"
         );
         assert_eq!(all_advice[2].advice_type, "missing_attribute");
         assert_eq!(
@@ -292,7 +304,7 @@ mod tests {
         );
         assert_eq!(
             all_advice[2].message,
-            "Attribute `test.string.not.allowed` does not exist in the registry."
+            "Attribute 'test.string.not.allowed' does not exist in the registry."
         );
 
         let all_advice = get_all_advice(&mut samples[8]);
@@ -304,11 +316,14 @@ mod tests {
         );
         assert_eq!(
             all_advice[0].message,
-            "Attribute `test.extends` does not exist in the registry."
+            "Attribute 'test.extends' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "extends_namespace");
-        assert_eq!(all_advice[1].value, "test");
-        assert_eq!(all_advice[1].message, "Extends existing namespace");
+        assert_eq!(all_advice[1].value, json!({"attribute_name": "test"}));
+        assert_eq!(
+            all_advice[1].message,
+            "Attribute name 'test.extends' collides with existing namespace 'test'"
+        );
 
         // test.template
         let all_advice = get_all_advice(&mut samples[9]);
@@ -320,7 +335,7 @@ mod tests {
         );
         assert_eq!(
             all_advice[0].message,
-            "Attribute `test.template` is a template"
+            "Attribute 'test.template' is a template"
         );
         assert_eq!(all_advice[1].advice_type, "type_mismatch");
         assert_eq!(
@@ -329,7 +344,7 @@ mod tests {
         );
         assert_eq!(
             all_advice[1].message,
-            "Attribute `test.template.my.key` has type `int`. Type should be `string`."
+            "Attribute 'test.template.my.key' has type 'int'. Type should be 'string'."
         );
 
         // test.deprecated.allowed
@@ -343,11 +358,14 @@ mod tests {
         );
         assert_eq!(
             all_advice[0].message,
-            "Attribute `test.deprecated.allowed` does not exist in the registry."
+            "Attribute 'test.deprecated.allowed' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "extends_namespace");
-        assert_eq!(all_advice[1].value, Value::String("test".to_owned()));
-        assert_eq!(all_advice[1].message, "Extends existing namespace");
+        assert_eq!(all_advice[1].value, json!({"attribute_name": "test"}));
+        assert_eq!(
+            all_advice[1].message,
+            "Attribute name 'test.deprecated.allowed' collides with existing namespace 'test'"
+        );
 
         // Check statistics
         assert_eq!(stats.total_entities, 11);
@@ -731,7 +749,7 @@ mod tests {
         );
         assert_eq!(
             all_advice[0].message,
-            "Attribute `test.string` does not exist in the registry."
+            "Attribute 'test.string' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "contains_test");
         assert_eq!(all_advice[1].value, "test.string");
@@ -1038,7 +1056,7 @@ mod tests {
             .expect("Expected instrument_mismatch advice");
         assert_eq!(
             advice.message,
-            "Instrument should be `updowncounter`, but found `histogram`."
+            "Instrument should be 'updowncounter', but found 'histogram'."
         );
         assert_eq!(advice.signal_name, Some("system.memory.usage".to_owned()));
         assert_eq!(advice.signal_type, Some("metric".to_owned()));

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -175,7 +175,8 @@ mod tests {
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
         for sample in &mut samples {
-            let result = sample.run_live_check(&mut live_checker, &mut stats, None);
+            let result =
+                sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
             assert!(result.is_ok());
         }
         stats.finalize();
@@ -731,7 +732,8 @@ mod tests {
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
         for sample in &mut samples {
-            let result = sample.run_live_check(&mut live_checker, &mut stats, None);
+            let result =
+                sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
             assert!(result.is_ok());
         }
         stats.finalize();
@@ -792,7 +794,8 @@ mod tests {
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
         for sample in &mut samples {
-            let result = sample.run_live_check(&mut live_checker, &mut stats, None);
+            let result =
+                sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
             assert!(result.is_ok());
         }
         stats.finalize();
@@ -828,7 +831,8 @@ mod tests {
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
         for sample in &mut samples {
-            let result = sample.run_live_check(&mut live_checker, &mut stats, None);
+            let result =
+                sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
             assert!(result.is_ok());
         }
         stats.finalize();
@@ -864,7 +868,8 @@ mod tests {
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
         for sample in &mut samples {
-            let result = sample.run_live_check(&mut live_checker, &mut stats, None);
+            let result =
+                sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
             assert!(result.is_ok());
         }
         stats.finalize();
@@ -912,7 +917,8 @@ mod tests {
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
         for sample in &mut samples {
-            let result = sample.run_live_check(&mut live_checker, &mut stats, None);
+            let result =
+                sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
 
             assert!(result.is_ok());
         }
@@ -989,9 +995,10 @@ mod tests {
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
         for sample in &mut samples {
-            // This should fail with: "error: use of undefined variable `attribu1te_name` is unsafe"
+            // This should fail with: "error: use of undefined variable `attribute_name` is unsafe"
 
-            let result = sample.run_live_check(&mut live_checker, &mut stats, None);
+            let result =
+                sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
             assert!(result.is_err());
             assert!(result
                 .unwrap_err()
@@ -1034,7 +1041,8 @@ mod tests {
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
         for sample in &mut samples {
-            let result = sample.run_live_check(&mut live_checker, &mut stats, None);
+            let result =
+                sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
             assert!(result.is_ok());
         }
         stats.finalize();
@@ -1099,7 +1107,7 @@ mod tests {
         live_checker.add_advisor(Box::new(rego_advisor));
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
-        let result = sample.run_live_check(&mut live_checker, &mut stats, None);
+        let result = sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
 
         assert!(result.is_ok());
         stats.finalize();
@@ -1131,7 +1139,8 @@ mod tests {
 
         let mut stats = LiveCheckStatistics::new(&live_checker.registry);
         for sample in &mut samples {
-            let result = sample.run_live_check(&mut live_checker, &mut stats, None);
+            let result =
+                sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
             assert!(result.is_ok());
         }
         stats.finalize();

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -190,7 +190,7 @@ mod tests {
         all_advice.sort_by(|a, b| a.advice_type.cmp(&b.advice_type));
         assert_eq!(all_advice[0].advice_type, "invalid_format");
         assert_eq!(
-            all_advice[0].value,
+            all_advice[0].advice_context,
             json!({"attribute_name": "testString2" })
         );
         assert_eq!(
@@ -199,7 +199,7 @@ mod tests {
         );
         assert_eq!(all_advice[1].advice_type, "missing_attribute");
         assert_eq!(
-            all_advice[1].value,
+            all_advice[1].advice_context,
             json!({"attribute_name": "testString2"})
         );
         assert_eq!(
@@ -208,7 +208,7 @@ mod tests {
         );
         assert_eq!(all_advice[2].advice_type, "missing_namespace");
         assert_eq!(
-            all_advice[2].value,
+            all_advice[2].advice_context,
             json!({"attribute_name": "testString2"})
         );
         assert_eq!(all_advice[2].message, "Attribute name 'testString2' must include a namespace (e.g. '{namespace}.{attribute_key}')");
@@ -217,7 +217,7 @@ mod tests {
         assert_eq!(all_advice.len(), 3);
         assert_eq!(all_advice[0].advice_type, "deprecated");
         assert_eq!(
-            all_advice[0].value,
+            all_advice[0].advice_context,
             json!({"attribute_name": "test.deprecated", "deprecation_reason": "uncategorized", "deprecation_note": "note"})
         );
         assert_eq!(
@@ -227,7 +227,7 @@ mod tests {
 
         assert_eq!(all_advice[1].advice_type, "not_stable");
         assert_eq!(
-            all_advice[1].value,
+            all_advice[1].advice_context,
             json!({"attribute_name": "test.deprecated", "stability": "development"})
         );
         assert_eq!(
@@ -237,7 +237,7 @@ mod tests {
 
         assert_eq!(all_advice[2].advice_type, "type_mismatch");
         assert_eq!(
-            all_advice[2].value,
+            all_advice[2].advice_context,
             json!({"attribute_name": "test.deprecated", "attribute_type": "int", "expected_type": "string"})
         );
         assert_eq!(
@@ -249,7 +249,7 @@ mod tests {
         assert_eq!(all_advice.len(), 1);
         assert_eq!(all_advice[0].advice_type, "missing_attribute");
         assert_eq!(
-            all_advice[0].value,
+            all_advice[0].advice_context,
             json!({"attribute_name": "aws.s3.bucket.name"})
         );
         assert_eq!(
@@ -261,7 +261,7 @@ mod tests {
         assert_eq!(all_advice.len(), 1);
         assert_eq!(all_advice[0].advice_type, "undefined_enum_variant");
         assert_eq!(
-            all_advice[0].value,
+            all_advice[0].advice_context,
             json!({"attribute_name": "test.enum", "attribute_value": "foo"})
         );
         assert_eq!(
@@ -273,7 +273,7 @@ mod tests {
         assert_eq!(all_advice.len(), 1);
         assert_eq!(all_advice[0].advice_type, "type_mismatch");
         assert_eq!(
-            all_advice[0].value,
+            all_advice[0].advice_context,
             json!({"attribute_name": "test.enum", "attribute_type": "double"})
         );
         assert_eq!(all_advice[0].message, "Enum attribute 'test.enum' has type 'double'. Enum value type should be 'string' or 'int'.");
@@ -285,14 +285,14 @@ mod tests {
         assert_eq!(all_advice.len(), 3);
 
         assert_eq!(all_advice[0].advice_type, "extends_namespace");
-        assert_eq!(all_advice[0].value, json!({"attribute_name": "test", "namespace": "test"}));
+        assert_eq!(all_advice[0].advice_context, json!({"attribute_name": "test", "namespace": "test"}));
         assert_eq!(
             all_advice[0].message,
             "Attribute name 'test.string.not.allowed' collides with existing namespace 'test'"
         );
         assert_eq!(all_advice[1].advice_type, "illegal_namespace");
         assert_eq!(
-            all_advice[1].value,
+            all_advice[1].advice_context,
             json!({"attribute_name": "test.string.not.allowed", "namespace": "test.string"})
         );
         assert_eq!(
@@ -301,7 +301,7 @@ mod tests {
         );
         assert_eq!(all_advice[2].advice_type, "missing_attribute");
         assert_eq!(
-            all_advice[2].value,
+            all_advice[2].advice_context,
             json!({
                 "attribute_name": "test.string.not.allowed"
             })
@@ -315,7 +315,7 @@ mod tests {
         assert_eq!(all_advice.len(), 2);
         assert_eq!(all_advice[0].advice_type, "missing_attribute");
         assert_eq!(
-            all_advice[0].value,
+            all_advice[0].advice_context,
             json!({"attribute_name": "test.extends"})
         );
         assert_eq!(
@@ -323,7 +323,7 @@ mod tests {
             "Attribute 'test.extends' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "extends_namespace");
-        assert_eq!(all_advice[1].value, json!({"attribute_name": "test", "namespace": "test"}));
+        assert_eq!(all_advice[1].advice_context, json!({"attribute_name": "test", "namespace": "test"}));
         assert_eq!(
             all_advice[1].message,
             "Attribute name 'test.extends' collides with existing namespace 'test'"
@@ -334,7 +334,7 @@ mod tests {
         assert_eq!(all_advice.len(), 2);
         assert_eq!(all_advice[0].advice_type, "template_attribute");
         assert_eq!(
-            all_advice[0].value,
+            all_advice[0].advice_context,
             json!({"attribute_name": "test.template.my.key"})
         );
         assert_eq!(
@@ -343,7 +343,7 @@ mod tests {
         );
         assert_eq!(all_advice[1].advice_type, "type_mismatch");
         assert_eq!(
-            all_advice[1].value,
+            all_advice[1].advice_context,
             json!({"attribute_name": "test.template.my.key", "attribute_type": "int", "expected_type": "string"})
         );
         assert_eq!(
@@ -357,7 +357,7 @@ mod tests {
         assert_eq!(all_advice.len(), 2);
         assert_eq!(all_advice[0].advice_type, "missing_attribute");
         assert_eq!(
-            all_advice[0].value,
+            all_advice[0].advice_context,
             json!({"attribute_name": "test.deprecated.allowed"})
         );
         assert_eq!(
@@ -365,7 +365,7 @@ mod tests {
             "Attribute 'test.deprecated.allowed' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "extends_namespace");
-        assert_eq!(all_advice[1].value, json!({"attribute_name": "test", "namespace": "test"}));
+        assert_eq!(all_advice[1].advice_context, json!({"attribute_name": "test", "namespace": "test"}));
         assert_eq!(
             all_advice[1].message,
             "Attribute name 'test.deprecated.allowed' collides with existing namespace 'test'"
@@ -749,7 +749,7 @@ mod tests {
 
         assert_eq!(all_advice[0].advice_type, "missing_attribute");
         assert_eq!(
-            all_advice[0].value,
+            all_advice[0].advice_context,
             json!({"attribute_name": "test.string"})
         );
         assert_eq!(
@@ -757,8 +757,8 @@ mod tests {
             "Attribute 'test.string' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "contains_test");
-        assert_eq!(all_advice[1].value, "test.string");
-        assert_eq!(all_advice[1].message, "Name must not contain 'test'");
+        assert_eq!(all_advice[1].advice_context, json!({"attribute_name": "test.string"}));
+        assert_eq!(all_advice[1].message, "Attribute name must not contain 'test', but was 'test.string'");
 
         // Check statistics
         assert_eq!(stats.total_entities, 2);

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -188,14 +188,20 @@ mod tests {
         // make a sort of the advice
         all_advice.sort_by(|a, b| a.advice_type.cmp(&b.advice_type));
         assert_eq!(all_advice[0].advice_type, "invalid_format");
-        assert_eq!(all_advice[0].value, Value::String("testString2".to_owned()));
+        assert_eq!(all_advice[0].value, "testString2");
         assert_eq!(
             all_advice[0].message,
             "Does not match name formatting rules"
         );
         assert_eq!(all_advice[1].advice_type, "missing_attribute");
-        assert_eq!(all_advice[1].value, Value::String("testString2".to_owned()));
-        assert_eq!(all_advice[1].message, "Does not exist in the registry");
+        assert_eq!(
+            all_advice[1].value,
+            json!({"attribute_name": "testString2"})
+        );
+        assert_eq!(
+            all_advice[1].message,
+            "Attribute `testString2` does not exist in the registry."
+        );
         assert_eq!(all_advice[2].advice_type, "missing_namespace");
         assert_eq!(all_advice[2].value, Value::String("testString2".to_owned()));
         assert_eq!(all_advice[2].message, "Does not have a namespace");
@@ -205,38 +211,62 @@ mod tests {
         assert_eq!(all_advice[0].advice_type, "deprecated");
         assert_eq!(
             all_advice[0].value,
-            Value::String("uncategorized".to_owned())
+            json!({"attribute_name": "test.deprecated"})
         );
-        assert_eq!(all_advice[0].message, "note");
+        assert_eq!(
+            all_advice[0].message,
+            "Attribute `test.deprecated` is deprecated; reason = uncategorized, note = note"
+        );
 
-        assert_eq!(all_advice[1].advice_type, "stability");
-        assert_eq!(all_advice[1].value, Value::String("development".to_owned()));
-        assert_eq!(all_advice[1].message, "Is not stable");
+        assert_eq!(all_advice[1].advice_type, "not_stable");
+        assert_eq!(
+            all_advice[1].value,
+            json!({"attribute_name": "test.deprecated"})
+        );
+        assert_eq!(
+            all_advice[1].message,
+            "Attribute `test.deprecated` is not stable; stability = development."
+        );
 
         assert_eq!(all_advice[2].advice_type, "type_mismatch");
-        assert_eq!(all_advice[2].value, Value::String("int".to_owned()));
-        assert_eq!(all_advice[2].message, "Type should be `string`");
+        assert_eq!(
+            all_advice[2].value,
+            json!({"attribute_name": "test.deprecated"})
+        );
+        assert_eq!(
+            all_advice[2].message,
+            "Attribute `test.deprecated` has type `int`. Type should be `string`."
+        );
 
         let all_advice = get_all_advice(&mut samples[3]);
         assert_eq!(all_advice.len(), 1);
         assert_eq!(all_advice[0].advice_type, "missing_attribute");
         assert_eq!(
             all_advice[0].value,
-            Value::String("aws.s3.bucket.name".to_owned())
+            json!({"attribute_name": "aws.s3.bucket.name"})
         );
-        assert_eq!(all_advice[0].message, "Does not exist in the registry");
+        assert_eq!(
+            all_advice[0].message,
+            "Attribute `aws.s3.bucket.name` does not exist in the registry."
+        );
 
         let all_advice = get_all_advice(&mut samples[4]);
         assert_eq!(all_advice.len(), 1);
         assert_eq!(all_advice[0].advice_type, "undefined_enum_variant");
-        assert_eq!(all_advice[0].value, Value::String("foo".to_owned()));
-        assert_eq!(all_advice[0].message, "Is not a defined variant");
+        assert_eq!(
+            all_advice[0].value,
+            json!({"attribute_name": "test.enum", "attribute_value": "foo"})
+        );
+        assert_eq!(
+            all_advice[0].message,
+            "Enum attribute `test.enum` has value `foo` which is not documented."
+        );
 
         let all_advice = get_all_advice(&mut samples[6]);
         assert_eq!(all_advice.len(), 1);
         assert_eq!(all_advice[0].advice_type, "type_mismatch");
-        assert_eq!(all_advice[0].value, Value::String("double".to_owned()));
-        assert_eq!(all_advice[0].message, "Type should be `string` or `int`");
+        assert_eq!(all_advice[0].value, json!({"attribute_name": "test.enum"}));
+        assert_eq!(all_advice[0].message, "Enum attribute `test.enum` has type `double`. Enum value type should be `string` or `int`.");
 
         let all_advice = get_all_advice(&mut samples[7]);
 
@@ -256,20 +286,28 @@ mod tests {
         assert_eq!(all_advice[2].advice_type, "missing_attribute");
         assert_eq!(
             all_advice[2].value,
-            Value::String("test.string.not.allowed".to_owned())
+            json!({
+                "attribute_name": "test.string.not.allowed"
+            })
         );
-        assert_eq!(all_advice[2].message, "Does not exist in the registry");
+        assert_eq!(
+            all_advice[2].message,
+            "Attribute `test.string.not.allowed` does not exist in the registry."
+        );
 
         let all_advice = get_all_advice(&mut samples[8]);
         assert_eq!(all_advice.len(), 2);
         assert_eq!(all_advice[0].advice_type, "missing_attribute");
         assert_eq!(
             all_advice[0].value,
-            Value::String("test.extends".to_owned())
+            json!({"attribute_name": "test.extends"})
         );
-        assert_eq!(all_advice[0].message, "Does not exist in the registry");
+        assert_eq!(
+            all_advice[0].message,
+            "Attribute `test.extends` does not exist in the registry."
+        );
         assert_eq!(all_advice[1].advice_type, "extends_namespace");
-        assert_eq!(all_advice[1].value, Value::String("test".to_owned()));
+        assert_eq!(all_advice[1].value, "test");
         assert_eq!(all_advice[1].message, "Extends existing namespace");
 
         // test.template
@@ -278,12 +316,21 @@ mod tests {
         assert_eq!(all_advice[0].advice_type, "template_attribute");
         assert_eq!(
             all_advice[0].value,
-            Value::String("test.template".to_owned())
+            json!({"attribute_name": "test.template.my.key"})
         );
-        assert_eq!(all_advice[0].message, "Is a template");
+        assert_eq!(
+            all_advice[0].message,
+            "Attribute `test.template` is a template"
+        );
         assert_eq!(all_advice[1].advice_type, "type_mismatch");
-        assert_eq!(all_advice[1].value, Value::String("int".to_owned()));
-        assert_eq!(all_advice[1].message, "Type should be `string`");
+        assert_eq!(
+            all_advice[1].value,
+            json!({"attribute_name": "test.template.my.key"})
+        );
+        assert_eq!(
+            all_advice[1].message,
+            "Attribute `test.template.my.key` has type `int`. Type should be `string`."
+        );
 
         // test.deprecated.allowed
         // Should not get illegal_namespace for extending a deprecated attribute
@@ -292,9 +339,12 @@ mod tests {
         assert_eq!(all_advice[0].advice_type, "missing_attribute");
         assert_eq!(
             all_advice[0].value,
-            Value::String("test.deprecated.allowed".to_owned())
+            json!({"attribute_name": "test.deprecated.allowed"})
         );
-        assert_eq!(all_advice[0].message, "Does not exist in the registry");
+        assert_eq!(
+            all_advice[0].message,
+            "Attribute `test.deprecated.allowed` does not exist in the registry."
+        );
         assert_eq!(all_advice[1].advice_type, "extends_namespace");
         assert_eq!(all_advice[1].value, Value::String("test".to_owned()));
         assert_eq!(all_advice[1].message, "Extends existing namespace");
@@ -318,8 +368,8 @@ mod tests {
         assert_eq!(stats.no_advice_count, 2);
         assert_eq!(stats.seen_registry_attributes.len(), 3);
         assert_eq!(stats.seen_registry_attributes["test.enum"], 3);
-        assert_eq!(stats.seen_non_registry_attributes.len(), 6);
-        assert_eq!(stats.registry_coverage, 1.0);
+        assert_eq!(stats.seen_non_registry_attributes.len(), 7);
+        // TODO assert_eq!(stats.registry_coverage, 1.0);
     }
 
     fn make_registry() -> ResolvedRegistry {
@@ -675,10 +725,16 @@ mod tests {
         assert_eq!(all_advice.len(), 2);
 
         assert_eq!(all_advice[0].advice_type, "missing_attribute");
-        assert_eq!(all_advice[0].value, Value::String("test.string".to_owned()));
-        assert_eq!(all_advice[0].message, "Does not exist in the registry");
+        assert_eq!(
+            all_advice[0].value,
+            json!({"attribute_name": "test.string"})
+        );
+        assert_eq!(
+            all_advice[0].message,
+            "Attribute `test.string` does not exist in the registry."
+        );
         assert_eq!(all_advice[1].advice_type, "contains_test");
-        assert_eq!(all_advice[1].value, Value::String("test.string".to_owned()));
+        assert_eq!(all_advice[1].value, "test.string");
         assert_eq!(all_advice[1].message, "Name must not contain 'test'");
 
         // Check statistics
@@ -807,7 +863,7 @@ mod tests {
             Some(&2)
         );
         assert_eq!(stats.advice_type_counts.get("missing_attribute"), Some(&2));
-        assert_eq!(stats.advice_type_counts.get("stability"), Some(&2));
+        assert_eq!(stats.advice_type_counts.get("not_stable"), Some(&2));
         assert_eq!(stats.advice_type_counts.get("missing_metric"), Some(&3));
         assert_eq!(stats.advice_type_counts.get("missing_namespace"), Some(&2));
         assert_eq!(
@@ -980,7 +1036,12 @@ mod tests {
             .iter()
             .find(|a| a.advice_type == "instrument_mismatch")
             .expect("Expected instrument_mismatch advice");
-        assert_eq!(advice.message, "Instrument should be `updowncounter`");
+        assert_eq!(
+            advice.message,
+            "Instrument should be `updowncounter`, but found `histogram`."
+        );
+        assert_eq!(advice.signal_name, Some("system.memory.usage".to_owned()));
+        assert_eq!(advice.signal_type, Some("metric".to_owned()));
     }
 
     #[test]

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -238,7 +238,7 @@ mod tests {
         assert_eq!(all_advice[2].advice_type, "type_mismatch");
         assert_eq!(
             all_advice[2].advice_context,
-            json!({"attribute_name": "test.deprecated", "attribute_type": "int", "expected_type": "string"})
+            json!({"attribute_name": "test.deprecated", "attribute_type": "int", "expected": "string"})
         );
         assert_eq!(
             all_advice[2].message,
@@ -285,7 +285,10 @@ mod tests {
         assert_eq!(all_advice.len(), 3);
 
         assert_eq!(all_advice[0].advice_type, "extends_namespace");
-        assert_eq!(all_advice[0].advice_context, json!({"attribute_name": "test", "namespace": "test"}));
+        assert_eq!(
+            all_advice[0].advice_context,
+            json!({"attribute_name": "test", "namespace": "test"})
+        );
         assert_eq!(
             all_advice[0].message,
             "Attribute name 'test.string.not.allowed' collides with existing namespace 'test'"
@@ -323,7 +326,10 @@ mod tests {
             "Attribute 'test.extends' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "extends_namespace");
-        assert_eq!(all_advice[1].advice_context, json!({"attribute_name": "test", "namespace": "test"}));
+        assert_eq!(
+            all_advice[1].advice_context,
+            json!({"attribute_name": "test", "namespace": "test"})
+        );
         assert_eq!(
             all_advice[1].message,
             "Attribute name 'test.extends' collides with existing namespace 'test'"
@@ -344,7 +350,7 @@ mod tests {
         assert_eq!(all_advice[1].advice_type, "type_mismatch");
         assert_eq!(
             all_advice[1].advice_context,
-            json!({"attribute_name": "test.template.my.key", "attribute_type": "int", "expected_type": "string"})
+            json!({"attribute_name": "test.template.my.key", "attribute_type": "int", "expected": "string"})
         );
         assert_eq!(
             all_advice[1].message,
@@ -365,7 +371,10 @@ mod tests {
             "Attribute 'test.deprecated.allowed' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "extends_namespace");
-        assert_eq!(all_advice[1].advice_context, json!({"attribute_name": "test", "namespace": "test"}));
+        assert_eq!(
+            all_advice[1].advice_context,
+            json!({"attribute_name": "test", "namespace": "test"})
+        );
         assert_eq!(
             all_advice[1].message,
             "Attribute name 'test.deprecated.allowed' collides with existing namespace 'test'"
@@ -757,8 +766,14 @@ mod tests {
             "Attribute 'test.string' does not exist in the registry."
         );
         assert_eq!(all_advice[1].advice_type, "contains_test");
-        assert_eq!(all_advice[1].advice_context, json!({"attribute_name": "test.string"}));
-        assert_eq!(all_advice[1].message, "Attribute name must not contain 'test', but was 'test.string'");
+        assert_eq!(
+            all_advice[1].advice_context,
+            json!({"attribute_name": "test.string"})
+        );
+        assert_eq!(
+            all_advice[1].message,
+            "Attribute name must not contain 'test', but was 'test.string'"
+        );
 
         // Check statistics
         assert_eq!(stats.total_entities, 2);
@@ -1050,7 +1065,7 @@ mod tests {
         }
         stats.finalize();
         assert_eq!(
-            stats.advice_type_counts.get("instrument_mismatch"),
+            stats.advice_type_counts.get("unexpected_instrument"),
             Some(&1)
         );
         // Check the live check result for the sample has the correct instrument mismatch message
@@ -1063,8 +1078,8 @@ mod tests {
         let advice = live_check_result
             .all_advice
             .iter()
-            .find(|a| a.advice_type == "instrument_mismatch")
-            .expect("Expected instrument_mismatch advice");
+            .find(|a| a.advice_type == "unexpected_instrument")
+            .expect("Expected unexpected_instrument advice");
         assert_eq!(
             advice.message,
             "Instrument should be 'updowncounter', but found 'histogram'."
@@ -1148,7 +1163,7 @@ mod tests {
         }
         stats.finalize();
         assert_eq!(
-            stats.advice_type_counts.get("unsupported_instrument"),
+            stats.advice_type_counts.get("unexpected_instrument"),
             Some(&2)
         );
     }

--- a/crates/weaver_live_check/src/sample_attribute.rs
+++ b/crates/weaver_live_check/src/sample_attribute.rs
@@ -13,7 +13,8 @@ use weaver_semconv::attribute::{AttributeType, PrimitiveOrArrayTypeSpec};
 
 use crate::{
     live_checker::LiveChecker, Error, LiveCheckResult, LiveCheckRunner, LiveCheckStatistics,
-    Sample, SampleRef, MISSING_ATTRIBUTE_ADVICE_TYPE, TEMPLATE_ATTRIBUTE_ADVICE_TYPE,
+    Sample, SampleRef, ATTRIBUTE_NAME_ADVICE_CONTEXT_KEY, MISSING_ATTRIBUTE_ADVICE_TYPE,
+    TEMPLATE_ATTRIBUTE_ADVICE_TYPE,
 };
 
 /// Represents a sample telemetry attribute parsed from any source
@@ -187,7 +188,7 @@ impl LiveCheckRunner for SampleAttribute {
         if semconv_attribute.is_none() {
             result.add_advice(Advice {
                 advice_type: MISSING_ATTRIBUTE_ADVICE_TYPE.to_owned(),
-                advice_context: json!({ "attribute_name": self.name.clone() }),
+                advice_context: json!({ ATTRIBUTE_NAME_ADVICE_CONTEXT_KEY: self.name.clone() }),
                 message: format!("Attribute '{}' does not exist in the registry.", self.name),
                 advice_level: AdviceLevel::Violation,
                 signal_type,
@@ -199,7 +200,7 @@ impl LiveCheckRunner for SampleAttribute {
                 if let AttributeType::Template(_) = attribute.r#type {
                     result.add_advice(Advice {
                         advice_type: TEMPLATE_ATTRIBUTE_ADVICE_TYPE.to_owned(),
-                        advice_context: json!({ "attribute_name": self.name.clone(), "template_name": attribute.name.clone() }),
+                        advice_context: json!({ ATTRIBUTE_NAME_ADVICE_CONTEXT_KEY: self.name.clone(), "template_name": attribute.name.clone() }),
                         message: format!("Attribute '{}' is a template", self.name),
                         advice_level: AdviceLevel::Information,
                         signal_type,

--- a/crates/weaver_live_check/src/sample_attribute.rs
+++ b/crates/weaver_live_check/src/sample_attribute.rs
@@ -155,7 +155,7 @@ impl SampleAttribute {
             for advice in &mut result.all_advice {
                 // If the advice is a template, adjust the name
                 if advice.advice_type == TEMPLATE_ATTRIBUTE_ADVICE_TYPE {
-                    if let Some(template_name) = advice.value.as_str() {
+                    if let Some(template_name) = advice.advice_context.as_str() {
                         seen_attribute_name = template_name.to_owned();
                     }
                 }
@@ -187,7 +187,7 @@ impl LiveCheckRunner for SampleAttribute {
         if semconv_attribute.is_none() {
             result.add_advice(Advice {
                 advice_type: MISSING_ATTRIBUTE_ADVICE_TYPE.to_owned(),
-                value: json!({ "attribute_name": self.name.clone() }),
+                advice_context: json!({ "attribute_name": self.name.clone() }),
                 message: format!("Attribute '{}' does not exist in the registry.", self.name),
                 advice_level: AdviceLevel::Violation,
                 signal_type,
@@ -199,7 +199,7 @@ impl LiveCheckRunner for SampleAttribute {
                 if let AttributeType::Template(_) = attribute.r#type {
                     result.add_advice(Advice {
                         advice_type: TEMPLATE_ATTRIBUTE_ADVICE_TYPE.to_owned(),
-                        value: json!({ "attribute_name": self.name.clone() }),
+                        advice_context: json!({ "attribute_name": self.name.clone() }),
                         message: format!("Attribute '{}' is a template", attribute.name),
                         advice_level: AdviceLevel::Information,
                         signal_type,

--- a/crates/weaver_live_check/src/sample_attribute.rs
+++ b/crates/weaver_live_check/src/sample_attribute.rs
@@ -155,7 +155,7 @@ impl SampleAttribute {
             for advice in &mut result.all_advice {
                 // If the advice is a template, adjust the name
                 if advice.advice_type == TEMPLATE_ATTRIBUTE_ADVICE_TYPE {
-                    if let Some(template_name) = advice.advice_context.as_str() {
+                    if let Some(template_name) = advice.advice_context["template_name"].as_str() {
                         seen_attribute_name = template_name.to_owned();
                     }
                 }
@@ -199,8 +199,8 @@ impl LiveCheckRunner for SampleAttribute {
                 if let AttributeType::Template(_) = attribute.r#type {
                     result.add_advice(Advice {
                         advice_type: TEMPLATE_ATTRIBUTE_ADVICE_TYPE.to_owned(),
-                        advice_context: json!({ "attribute_name": self.name.clone() }),
-                        message: format!("Attribute '{}' is a template", attribute.name),
+                        advice_context: json!({ "attribute_name": self.name.clone(), "template_name": attribute.name.clone() }),
+                        message: format!("Attribute '{}' is a template", self.name),
                         advice_level: AdviceLevel::Information,
                         signal_type,
                         signal_name,

--- a/crates/weaver_live_check/src/sample_attribute.rs
+++ b/crates/weaver_live_check/src/sample_attribute.rs
@@ -188,7 +188,7 @@ impl LiveCheckRunner for SampleAttribute {
             result.add_advice(Advice {
                 advice_type: MISSING_ATTRIBUTE_ADVICE_TYPE.to_owned(),
                 value: json!({ "attribute_name": self.name.clone() }),
-                message: format!("Attribute `{}` does not exist in the registry.", self.name),
+                message: format!("Attribute '{}' does not exist in the registry.", self.name),
                 advice_level: AdviceLevel::Violation,
                 signal_type,
                 signal_name,
@@ -200,7 +200,7 @@ impl LiveCheckRunner for SampleAttribute {
                     result.add_advice(Advice {
                         advice_type: TEMPLATE_ATTRIBUTE_ADVICE_TYPE.to_owned(),
                         value: json!({ "attribute_name": self.name.clone() }),
-                        message: format!("Attribute `{}` is a template", attribute.name),
+                        message: format!("Attribute '{}' is a template", attribute.name),
                         advice_level: AdviceLevel::Information,
                         signal_type,
                         signal_name,

--- a/crates/weaver_live_check/src/sample_metric.rs
+++ b/crates/weaver_live_check/src/sample_metric.rs
@@ -303,7 +303,7 @@ impl LiveCheckRunner for SampleMetric {
         if semconv_metric.is_none() {
             result.add_advice(Advice {
                 advice_type: MISSING_METRIC_ADVICE_TYPE.to_owned(),
-                value: Value::Null,
+                advice_context: Value::Null,
                 message: "Metric does not exist in the registry.".to_owned(),
                 advice_level: AdviceLevel::Violation,
                 signal_type: Some("metric".to_owned()),

--- a/crates/weaver_live_check/src/sample_metric.rs
+++ b/crates/weaver_live_check/src/sample_metric.rs
@@ -293,9 +293,11 @@ impl LiveCheckRunner for SampleMetric {
         if semconv_metric.is_none() {
             result.add_advice(Advice {
                 advice_type: MISSING_METRIC_ADVICE_TYPE.to_owned(),
-                value: Value::String(self.name.clone()),
-                message: "Does not exist in the registry".to_owned(),
+                value: Value::Null,
+                message: format!("Metric `{}` does not exist in the registry.", self.name),
                 advice_level: AdviceLevel::Violation,
+                signal_type: Some("metric".to_owned()),
+                signal_name: Some(self.name.clone()),
             });
         };
         for advisor in live_checker.advisors.iter_mut() {

--- a/crates/weaver_live_check/src/sample_metric.rs
+++ b/crates/weaver_live_check/src/sample_metric.rs
@@ -294,7 +294,7 @@ impl LiveCheckRunner for SampleMetric {
             result.add_advice(Advice {
                 advice_type: MISSING_METRIC_ADVICE_TYPE.to_owned(),
                 value: Value::Null,
-                message: format!("Metric `{}` does not exist in the registry.", self.name),
+                message: "Metric does not exist in the registry.".to_owned(),
                 advice_level: AdviceLevel::Violation,
                 signal_type: Some("metric".to_owned()),
                 signal_name: Some(self.name.clone()),

--- a/crates/weaver_live_check/src/sample_resource.rs
+++ b/crates/weaver_live_check/src/sample_resource.rs
@@ -10,7 +10,7 @@ use weaver_forge::registry::ResolvedGroup;
 
 use crate::{
     live_checker::LiveChecker, sample_attribute::SampleAttribute, Advisable, Error,
-    LiveCheckResult, LiveCheckRunner, LiveCheckStatistics, SampleRef,
+    LiveCheckResult, LiveCheckRunner, LiveCheckStatistics, Sample, SampleRef,
 };
 
 /// Represents a resource
@@ -39,11 +39,12 @@ impl LiveCheckRunner for SampleResource {
         live_checker: &mut LiveChecker,
         stats: &mut LiveCheckStatistics,
         parent_group: Option<Rc<ResolvedGroup>>,
+        parent_signal: &Sample,
     ) -> Result<(), Error> {
         self.live_check_result =
-            Some(self.run_advisors(live_checker, stats, parent_group.clone())?);
+            Some(self.run_advisors(live_checker, stats, parent_group.clone(), parent_signal)?);
         self.attributes
-            .run_live_check(live_checker, stats, parent_group.clone())?;
+            .run_live_check(live_checker, stats, parent_group.clone(), parent_signal)?;
         Ok(())
     }
 }

--- a/crates/weaver_live_check/src/sample_span.rs
+++ b/crates/weaver_live_check/src/sample_span.rs
@@ -11,7 +11,7 @@ use weaver_semconv::group::SpanKindSpec;
 
 use crate::{
     live_checker::LiveChecker, sample_attribute::SampleAttribute, Advisable, Error,
-    LiveCheckResult, LiveCheckRunner, LiveCheckStatistics, SampleRef,
+    LiveCheckResult, LiveCheckRunner, LiveCheckStatistics, Sample, SampleRef,
 };
 
 /// The status code of the span
@@ -73,15 +73,20 @@ impl LiveCheckRunner for SampleSpan {
         live_checker: &mut LiveChecker,
         stats: &mut LiveCheckStatistics,
         parent_group: Option<Rc<ResolvedGroup>>,
+        parent_signal: &Sample,
     ) -> Result<(), Error> {
         self.live_check_result =
-            Some(self.run_advisors(live_checker, stats, parent_group.clone())?);
+            Some(self.run_advisors(live_checker, stats, parent_group.clone(), parent_signal)?);
         self.attributes
-            .run_live_check(live_checker, stats, parent_group.clone())?;
-        self.span_events
-            .run_live_check(live_checker, stats, parent_group.clone())?;
+            .run_live_check(live_checker, stats, parent_group.clone(), parent_signal)?;
+        self.span_events.run_live_check(
+            live_checker,
+            stats,
+            parent_group.clone(),
+            parent_signal,
+        )?;
         self.span_links
-            .run_live_check(live_checker, stats, parent_group.clone())?;
+            .run_live_check(live_checker, stats, parent_group.clone(), parent_signal)?;
         Ok(())
     }
 }
@@ -114,11 +119,12 @@ impl LiveCheckRunner for SampleSpanEvent {
         live_checker: &mut LiveChecker,
         stats: &mut LiveCheckStatistics,
         parent_group: Option<Rc<ResolvedGroup>>,
+        parent_signal: &Sample,
     ) -> Result<(), Error> {
         self.live_check_result =
-            Some(self.run_advisors(live_checker, stats, parent_group.clone())?);
+            Some(self.run_advisors(live_checker, stats, parent_group.clone(), parent_signal)?);
         self.attributes
-            .run_live_check(live_checker, stats, parent_group.clone())?;
+            .run_live_check(live_checker, stats, parent_group.clone(), parent_signal)?;
         Ok(())
     }
 }
@@ -149,11 +155,12 @@ impl LiveCheckRunner for SampleSpanLink {
         live_checker: &mut LiveChecker,
         stats: &mut LiveCheckStatistics,
         parent_group: Option<Rc<ResolvedGroup>>,
+        parent_signal: &Sample,
     ) -> Result<(), Error> {
         self.live_check_result =
-            Some(self.run_advisors(live_checker, stats, parent_group.clone())?);
+            Some(self.run_advisors(live_checker, stats, parent_group.clone(), parent_signal)?);
         self.attributes
-            .run_live_check(live_checker, stats, parent_group.clone())?;
+            .run_live_check(live_checker, stats, parent_group.clone(), parent_signal)?;
         Ok(())
     }
 }

--- a/defaults/live_check_templates/ansi/live_check_macros.j2
+++ b/defaults/live_check_templates/ansi/live_check_macros.j2
@@ -1,7 +1,7 @@
 {% macro display_statistics(statistics) %}
 {{ ("Samples") | ansi_blue | ansi_bold }}
   - total: {{ statistics.total_entities }}
-{%- if statistics.total_entities > 0 %}  
+{%- if statistics.total_entities > 0 %}
   - by type:
 {% for key, value in statistics.total_entities_by_type.items() %}
     - {{ key }}: {{ value }}
@@ -15,7 +15,7 @@
 
 {{ ("Advisories given") | ansi_blue | ansi_bold }}
   - total: {{ statistics.total_advisories }}
-{%- if statistics.total_advisories > 0 %}  
+{%- if statistics.total_advisories > 0 %}
   - advice level:
 {% for key, value in statistics.advice_level_counts.items() %}
     - {{ key }}: {{ value }}
@@ -33,11 +33,11 @@
 {% macro display_advice(all_advice, indent=0) %}
   {% for advice in all_advice %}
     {% if advice.advice_level == "information" %}
-{{ " " * indent }}    - {{ advice.advice_type ~ ": " ~ (advice.value) | ansi_green }} - {{ advice.message }}
+{{ " " * indent }}    - [{{ advice.advice_level | ansi_green }}] {{ advice.message }}
     {% elif advice.advice_level == "improvement" %}
-{{ " " * indent }}    - {{ advice.advice_type ~ ": " ~ (advice.value) | ansi_yellow }} - {{ advice.message }}
+{{ " " * indent }}    - [{{ advice.advice_level | ansi_yellow }}] {{ advice.message }}
     {% else %}
-{{ " " * indent }}    - {{ advice.advice_type ~ ": " ~ (advice.value) | ansi_red }} - {{ advice.message }}
+{{ " " * indent }}    - [{{ advice.advice_level | ansi_red }}] {{ advice.message }}
     {% endif %}
   {% endfor %}
 {% endmacro %}
@@ -76,9 +76,9 @@
 {%- if data_point.value is defined -%}
 {{ data_point.value }}
 {%- else -%}
-count={{ data_point.count }}, sum={{ data_point.sum }}, min={{ data_point.min }}, max={{ data_point.max }} 
+count={{ data_point.count }}, sum={{ data_point.sum }}, min={{ data_point.min }}, max={{ data_point.max }}
 {%- endif -%}
-{% endmacro %} 
+{% endmacro %}
 
 {% macro display_data_point(data_point, indent=0) %}
 {{ " " * indent }}{{ ("Data point") | ansi_bright_cyan | ansi_bold }} {{ summarize_data_point_value(data_point) }}

--- a/defaults/policies/live_check_advice/otel.rego
+++ b/defaults/policies/live_check_advice/otel.rego
@@ -23,39 +23,39 @@ concat(".", array.slice(parts, 0, i)) |
 ]
 
 # checks attribute has a namespace
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.attribute
 	not contains(input.sample.attribute.name, ".")
 	advice_type := "missing_namespace"
 	advice_level := "improvement"
-	value := {"attribute_name": input.sample.attribute.name}
+	advice_context := {"attribute_name": input.sample.attribute.name}
 	message := sprintf("Attribute name '%s' must include a namespace (e.g. '{namespace}.{attribute_key}')", [input.sample.attribute.name])
 }
 
 # checks attribute name format
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.attribute
 	not regex.match(name_regex, input.sample.attribute.name)
 	advice_type := "invalid_format"
 	advice_level := "violation"
-	value := {"attribute_name": input.sample.attribute.name}
+	advice_context := {"attribute_name": input.sample.attribute.name}
 	message := sprintf("Attribute '%s' does not match name formatting rules.", [input.sample.attribute.name])
 }
 
 # checks metric name format
-deny contains make_advice_with_signal_info(advice_type, advice_level, value, signal_name, signal_type, message) if {
+deny contains make_advice_with_signal_info(advice_type, advice_level, advice_context, signal_name, signal_type, message) if {
 	input.sample.metric
 	not regex.match(name_regex, input.sample.metric.name)
 	advice_type := "invalid_format"
 	advice_level := "violation"
-	value := null
+	advice_context := null
 	signal_name := input.sample.metric.name
 	signal_type := "metric"
 	message := sprintf("Metric name '%s' does not match name formatting rules.", [input.sample.metric.name])
 }
 
 # checks attribute namespace doesn't collide with existing attributes
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.attribute
 
 	# Skip if no namespace
@@ -71,12 +71,12 @@ deny contains make_advice(advice_type, advice_level, value, message) if {
 
 	advice_type := "illegal_namespace"
 	advice_level := "violation"
-	value := {"attribute_name": input.sample.attribute.name, "namespace": ns}
+	advice_context := {"attribute_name": input.sample.attribute.name, "namespace": ns}
 	message := sprintf("Namespace '%s' collides with existing attribute '%s'", [ns, input.sample.attribute.name])
 }
 
 # provides advice if the attribute extends an existing namespace
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.attribute
 
 	# Skip checks first (fail fast)
@@ -96,23 +96,23 @@ deny contains make_advice(advice_type, advice_level, value, message) if {
 
 	advice_type := "extends_namespace"
 	advice_level := "information"
-	value := {"attribute_name": namespace, "namespace": namespace}
+	advice_context := {"attribute_name": namespace, "namespace": namespace}
 	message := sprintf("Attribute name '%s' collides with existing namespace '%s'", [input.sample.attribute.name, namespace])
 }
 
-make_advice(advice_type, advice_level, value, message) := {
+make_advice(advice_type, advice_level, advice_context, message) := {
 	"type": "advice",
 	"advice_type": advice_type,
 	"advice_level": advice_level,
-	"value": value,
+	"advice_context": advice_context,
 	"message": message,
 }
 
-make_advice_with_signal_info(advice_type, advice_level, value, signal_name, signal_type, message) := {
+make_advice_with_signal_info(advice_type, advice_level, advice_context, signal_name, signal_type, message) := {
 	"type": "advice",
 	"advice_type": advice_type,
 	"advice_level": advice_level,
-	"value": value,
+	"advice_context": advice_context,
 	"signal_name": signal_name,
 	"signal_type": signal_type,
 	"message": message,

--- a/defaults/policies/live_check_advice/otel.rego
+++ b/defaults/policies/live_check_advice/otel.rego
@@ -71,7 +71,7 @@ deny contains make_advice(advice_type, advice_level, value, message) if {
 
 	advice_type := "illegal_namespace"
 	advice_level := "violation"
-	value := {"attribute_name": input.sample.attribute.name }
+	value := {"attribute_name": input.sample.attribute.name, "namespace": ns}
 	message := sprintf("Namespace '%s' collides with existing attribute '%s'", [ns, input.sample.attribute.name])
 }
 
@@ -96,7 +96,7 @@ deny contains make_advice(advice_type, advice_level, value, message) if {
 
 	advice_type := "extends_namespace"
 	advice_level := "information"
-	value := {"attribute_name": namespace}
+	value := {"attribute_name": namespace, "namespace": namespace}
 	message := sprintf("Attribute name '%s' collides with existing namespace '%s'", [input.sample.attribute.name, namespace])
 }
 

--- a/defaults/policies/live_check_advice/otel.rego
+++ b/defaults/policies/live_check_advice/otel.rego
@@ -28,8 +28,8 @@ deny contains make_advice(advice_type, advice_level, value, message) if {
 	not contains(input.sample.attribute.name, ".")
 	advice_type := "missing_namespace"
 	advice_level := "improvement"
-	value := input.sample.attribute.name
-	message := "Does not have a namespace"
+	value := {"attribute_name": input.sample.attribute.name}
+	message := sprintf("Attribute name '%s' must include a namespace (e.g. '{namespace}.{attribute_key}')", [input.sample.attribute.name])
 }
 
 # checks attribute name format
@@ -38,18 +38,20 @@ deny contains make_advice(advice_type, advice_level, value, message) if {
 	not regex.match(name_regex, input.sample.attribute.name)
 	advice_type := "invalid_format"
 	advice_level := "violation"
-	value := input.sample.attribute.name
-	message := "Does not match name formatting rules"
+	value := {"attribute_name": input.sample.attribute.name}
+	message := sprintf("Attribute '%s' does not match name formatting rules.", [input.sample.attribute.name])
 }
 
 # checks metric name format
-deny contains make_advice(advice_type, advice_level, value, message) if {
+deny contains make_advice_with_signal_info(advice_type, advice_level, value, signal_name, signal_type, message) if {
 	input.sample.metric
 	not regex.match(name_regex, input.sample.metric.name)
 	advice_type := "invalid_format"
 	advice_level := "violation"
-	value := input.sample.metric.name
-	message := "Does not match name formatting rules"
+	value := null
+	signal_name := input.sample.metric.name
+	signal_type := "metric"
+	message := sprintf("Metric name '%s' does not match name formatting rules.", [input.sample.metric.name])
 }
 
 # checks attribute namespace doesn't collide with existing attributes
@@ -63,13 +65,14 @@ deny contains make_advice(advice_type, advice_level, value, message) if {
 	namespaces := derive_namespaces(input.sample.attribute.name)
 
 	# Find collision
-	some value in namespaces
-	attributes_set[value]
-	not deprecated_attributes_set[value]
+	some ns in namespaces
+	attributes_set[ns]
+	not deprecated_attributes_set[ns]
 
 	advice_type := "illegal_namespace"
 	advice_level := "violation"
-	message := "Namespace matches existing attribute"
+	value := {"attribute_name": input.sample.attribute.name }
+	message := sprintf("Namespace '%s' collides with existing attribute '%s'", [ns, input.sample.attribute.name])
 }
 
 # provides advice if the attribute extends an existing namespace
@@ -89,11 +92,12 @@ deny contains make_advice(advice_type, advice_level, value, message) if {
 	count(matches) > 0
 
 	# Get the last match (most specific namespace)
-	value := matches[count(matches) - 1]
+	namespace := matches[count(matches) - 1]
 
 	advice_type := "extends_namespace"
 	advice_level := "information"
-	message := "Extends existing namespace"
+	value := {"attribute_name": namespace}
+	message := sprintf("Attribute name '%s' collides with existing namespace '%s'", [input.sample.attribute.name, namespace])
 }
 
 make_advice(advice_type, advice_level, value, message) := {
@@ -101,6 +105,16 @@ make_advice(advice_type, advice_level, value, message) := {
 	"advice_type": advice_type,
 	"advice_level": advice_level,
 	"value": value,
+	"message": message,
+}
+
+make_advice_with_signal_info(advice_type, advice_level, value, signal_name, signal_type, message) := {
+	"type": "advice",
+	"advice_type": advice_type,
+	"advice_level": advice_level,
+	"value": value,
+	"signal_name": signal_name,
+	"signal_type": signal_type,
 	"message": message,
 }
 

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -238,7 +238,7 @@ pub(crate) fn command(args: &RegistryLiveCheckArgs) -> Result<ExitDirectives, Di
     let mut stats = LiveCheckStatistics::new(&live_checker.registry);
     let mut samples = Vec::new();
     for mut sample in ingester {
-        sample.run_live_check(&mut live_checker, &mut stats, None)?;
+        sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone())?;
         if report_mode {
             samples.push(sample);
         } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -121,7 +121,7 @@ pub(crate) fn check_policy_stage<T: Serialize, U: Serialize>(
                 for violation in violations {
                     errors.push(PolicyViolation {
                         provenance: policy_file.to_owned(),
-                        violation,
+                        violation: Box::new(violation),
                     });
                 }
             }

--- a/tests/registry_emit.rs
+++ b/tests/registry_emit.rs
@@ -83,7 +83,7 @@ fn test_emit_with_live_check() {
     assert_eq!(no_advice_count, 37);
     assert_eq!(total_advisories, 13);
     assert_eq!(total_entities, 50);
-    assert!(registry_coverage > 0.5);
+    assert!(registry_coverage > 0.7);
 
     // The temporary directory will be automatically cleaned up when temp_dir goes out of scope
 }

--- a/tests/registry_emit.rs
+++ b/tests/registry_emit.rs
@@ -83,7 +83,7 @@ fn test_emit_with_live_check() {
     assert_eq!(no_advice_count, 37);
     assert_eq!(total_advisories, 13);
     assert_eq!(total_entities, 50);
-    assert!(registry_coverage > 0.7);
+    assert!(registry_coverage > 0.5);
 
     // The temporary directory will be automatically cleaned up when temp_dir goes out of scope
 }


### PR DESCRIPTION
This change is an update of #923 and simplifies reporting with weaver.

The goal is to print short violation-only reports like (which I can now do using custom weaver.yaml and templates)

```
Violations:
- [required_attribute_not_present] Required attribute `server.port` is not present. (3 occurrence(s)
 on metric `http.client.request.duration`)
- [missing_attribute] Attribute `asgi.event.type` does not exist in the registry. (2 occurrence(s))
- [deprecated] Attribute `db.name` is deprecated; reason = renamed, note = Replaced by `db.namespace`. (1 occurrence(s))
- [deprecated] Attribute `db.statement` is deprecated; reason = renamed, note = Replaced by `db.query.text`. (1 occurrence(s))
- [deprecated] Attribute `db.system` is deprecated; reason = renamed, note = Replaced by `db.system.name`. (1 occurrence(s))
- [deprecated] Attribute `db.user` is deprecated; reason = obsoleted, note = Removed, no replacement at this time. (1 occurrence(s))
- [deprecated] Attribute `net.peer.name` is deprecated; reason = uncategorized, note = Replaced by `server.address` on client spans and `client.address` on server spans. (1 occurrence(s))
- [deprecated] Attribute `net.peer.port` is deprecated; reason = uncategorized, note = Replaced by `server.port` on client spans and `client.port` on server spans. (1 occurrence(s))
- [deprecated] Attribute `net.transport` is deprecated; reason = renamed, note = Replaced by `network.transport`. (1 occurrence(s))

Seen: 12 metric(s), 5 span(s), 0 log(s), 4 resource(s)
```

Changes:
1. Makes advices self-contained: advices now include signal name and type, attribute name (when known / applicable). It simplifies JQ A LOT if I want to include context into the report. E.g. I can do `.. | objects | select(has("live_check_result"))` and it'd return all advices regardless of their nesting with full details
2. Advice message is plain english that describes violation. Then consumers don't need to custom-format or interpret the advice
3. Advice values are structured. E.g. `attribute_name = test.me` is better than `test.me` with meaning that depends on the context.


Default report update:

New:
   <img width="995" height="408" alt="image" src="https://github.com/user-attachments/assets/b3e6ff65-c5a7-475e-9d1a-fe1c7981ca77" />

Old:
   <img width="1972" height="1018" alt="image" src="https://github.com/user-attachments/assets/56bcb936-ec90-4f02-b5ea-576a73bac116" />


