### PR TITLE
Adds id for semconv schema v1

### DIFF
--- a/schemas/semconv.schema.json
+++ b/schemas/semconv.schema.json
@@ -1,4 +1,5 @@
 {
+	"$id": "https://opentelemetry.io/schemas/v1/semconv.schema.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"type": "object",
 	"description": "YAML schema for semantic convention generator, use for example with VS Code.",


### PR DESCRIPTION
Similar to #952

Adds in an id for the semconv schema v1 document so that tooling can correctly handle the schema. Without the id visual studio code etc is generating warnings about the schema value but adding the id resolves the warnings and enables tooling to use the schema. Note not having an id is useful when using dynamicrefs rather than refs however dynamicrefs are not in use.