### PR TITLE
Fix live-check ANSI output in report mode

### DIFF
--- a/defaults/live_check_templates/ansi/live_check.txt.j2
+++ b/defaults/live_check_templates/ansi/live_check.txt.j2
@@ -1,5 +1,5 @@
 {% import "live_check_macros.j2" as macros %}
-{% if ctx.attributes is defined %}
+{% if ctx.samples is defined %}
 {# This is a LiveCheckReport object #}
 {% for sample in ctx.samples %}
 {{ macros.display_sample(sample) }}


### PR DESCRIPTION
When `--no-stream` is set, the live-check output is written as a report at the end of the run. The default template for ANSI had a bug which meant no output would be produced.

(This mode is useful to avoid interleaving in your console output if you're running live-check in the background and tests in the foreground for example)