### PR TITLE
Make optional the target and the registry sub-directory for the weaver registry generate command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+# [TBD] - TDB
+
+- The target and the `registry` sub-directory are now optional for the
+  `weaver registry generate` command. ([#962](https://github.com/open-telemetry/weaver/pull/962) by @lquerel)
+
 # [0.18.0] - 2025-09-17
 
 - Fail when JQ filters fail ([#894](https://github.com/open-telemetry/weaver/pull/894) by @lmolkova)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -123,6 +123,8 @@ Usage: weaver registry generate [OPTIONS] <TARGET> [OUTPUT]
 Arguments:
   <TARGET>
           Target to generate the artifacts for
+          
+          [default: ]
 
   [OUTPUT]
           Path to the directory where the generated artifacts will be saved. Default is the `output` directory

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -100,7 +100,7 @@ pub(crate) fn command(args: &RegistryGenerateArgs) -> Result<ExitDirectives, Dia
             error: e.to_string(),
         })?;
     let loader =
-        FileSystemFileLoader::try_new(templates_dir.path().join("registry"), &args.target)?;
+        FileSystemFileLoader::try_new(resolve_templates_root(&templates_dir), &args.target)?;
     let config = if let Some(paths) = &args.config {
         WeaverConfig::try_from_config_files(paths)
     } else {
@@ -123,6 +123,19 @@ pub(crate) fn command(args: &RegistryGenerateArgs) -> Result<ExitDirectives, Dia
         exit_code: 0,
         warnings: None,
     })
+}
+
+/// Resolve the effective templates root.
+/// If a `registry` subdirectory exists under the provided templates directory,
+/// that subdirectory is returned, otherwise the original directory path is returned.
+fn resolve_templates_root(templates_dir: &VirtualDirectory) -> PathBuf {
+    let base = templates_dir.path();
+    let candidate = base.join("registry");
+    if candidate.is_dir() {
+        candidate
+    } else {
+        base.to_path_buf()
+    }
 }
 
 /// Generate the parameters to pass to the templates.

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -24,6 +24,7 @@ use weaver_common::vdir::VirtualDirectoryPath;
 #[derive(Debug, Args)]
 pub struct RegistryGenerateArgs {
     /// Target to generate the artifacts for.
+    #[arg(default_value = "")]
     pub target: String,
 
     /// Path to the directory where the generated artifacts will be saved.


### PR DESCRIPTION
Closes https://github.com/open-telemetry/weaver/issues/689

This PR aims to simplify the user experience of Weaver. Initially, Weaver required following a strict structure for templates (i.e. <template-dir>/registry/<target>/). With this PR, the registry subdirectory and the target are now optional.

For example, if you have your templates and the `weaver.yaml` file in the `my-templates` directory, the following command now allows you to generate the templates:

```
weaver registry generate --templates my-templates
```

In the same way, suppose your templates are in the `my-templates/registry/rust` directory (legacy style), the following 2 commands are equivalent.

```
weaver registry generate rust --templates my-templates
weaver registry generate --templates my-templates/registry/rust
```