### PR TITLE
Adds advice_message_counts to live-check stats

### DIFF
--- a/crates/weaver_live_check/data/attributes.json
+++ b/crates/weaver_live_check/data/attributes.json
@@ -1,66 +1,96 @@
 [
     {
-        "name": "http.request.method",
-        "value": "GET"
+        "attribute": {
+            "name": "http.request.method",
+            "value": "GET"
+        }
     },
     {
-        "name": "http.response.status_code",
-        "value": "hello"
+        "attribute": {
+            "name": "http.response.status_code",
+            "value": "200"
+        }
     },
     {
-        "name": "http.server_name",
-        "value": "example.com"
+        "attribute": {
+            "name": "service.name",
+            "value": "my_service"
+        }
     },
     {
-        "name": "aws.s3.bucket",
-        "value": "my-bucket"
+        "attribute": {
+            "name": "aws.s3.bucket",
+            "value": "my-bucket"
+        }
     },
     {
-        "name": "task.my-id",
-        "value": "12345"
+        "attribute": {
+            "name": "task.id",
+            "value": "12345"
+        }
     },
     {
-        "name": "TaskId",
-        "value": "12345"
+        "attribute": {
+            "name": "TaskId",
+            "value": "12345"
+        }
     },
     {
-        "name": "host.arch",
-        "value": "aarch64"
+        "attribute": {
+            "name": "host.arch",
+            "value": "aarch64"
+        }
     },
     {
-        "name": "host.name"
+        "attribute": {
+            "name": "host.name"
+        }
     },
     {
-        "name": "exception.message",
-        "type": "string[]"
+        "attribute": {
+            "name": "exception.message",
+            "type": "string[]"
+        }
     },
     {
-        "name": "aws.dynamodb.table_names",
-        "value": [
-            "table1",
-            "table2"
-        ]
+        "attribute": {
+            "name": "aws.dynamodb.table_names",
+            "value": [
+                "table1",
+                "table2"
+            ]
+        }
     },
     {
-        "name": "http.request.method",
-        "value": "OPEN"
+        "attribute": {
+            "name": "http.request.method",
+            "value": "OPEN"
+        }
     },
     {
-        "name": "http.request.method.not.allowed",
-        "value": "GET"
+        "attribute": {
+            "name": "http.request.method.not.allowed",
+            "value": "GET"
+        }
     },
     {
-        "name": "http.request.extension",
-        "value": 42
+        "attribute": {
+            "name": "http.request.extension",
+            "value": 42
+        }
     },
     {
-        "name": "http.request.header.content-type",
-        "value": [
-            "application/json"
-        ]
+        "attribute": {
+            "name": "http.request.header.content-type",
+            "value": [
+                "application/json"
+            ]
+        }
     },
     {
-        "name": "http.request.header.content.type",
-        "value": "application/json"
+        "attribute": {
+            "name": "http.request.header.content.type",
+            "value": "application/json"
+        }
     }
 ]

--- a/crates/weaver_live_check/src/lib.rs
+++ b/crates/weaver_live_check/src/lib.rs
@@ -302,6 +302,8 @@ pub struct LiveCheckStatistics {
     pub no_advice_count: usize,
     /// The number of entities with each advice type
     pub advice_type_counts: HashMap<String, usize>,
+    /// The number of entities with each advice message
+    pub advice_message_counts: HashMap<String, usize>,
     /// The number of each attribute seen from the registry
     pub seen_registry_attributes: HashMap<String, usize>,
     /// The number of each non-registry attribute seen
@@ -340,6 +342,7 @@ impl LiveCheckStatistics {
             highest_advice_level_counts: HashMap::new(),
             no_advice_count: 0,
             advice_type_counts: HashMap::new(),
+            advice_message_counts: HashMap::new(),
             seen_registry_attributes: seen_attributes,
             seen_non_registry_attributes: HashMap::new(),
             seen_registry_metrics: seen_metrics,
@@ -388,6 +391,10 @@ impl LiveCheckStatistics {
         *self
             .advice_type_counts
             .entry(advice.advice_type.clone())
+            .or_insert(0) += 1;
+        *self
+            .advice_message_counts
+            .entry(advice.message.clone())
             .or_insert(0) += 1;
         self.total_advisories += 1;
     }

--- a/defaults/live_check_templates/ansi/live_check_macros.j2
+++ b/defaults/live_check_templates/ansi/live_check_macros.j2
@@ -24,6 +24,10 @@
 {% for key, value in statistics.advice_type_counts.items() %}
     - {{ key }}: {{ value }}
 {% endfor %}
+  - advice message:
+{% for key, value in statistics.advice_message_counts.items() %}
+    - {{ key }}: {{ value }}
+{% endfor %}
 {% endif %}
 
 {{ ("Registry coverage") | ansi_blue | ansi_bold }}


### PR DESCRIPTION
Now that we have richer advice messages (thanks @lmolkova) it is useful to group by these messages and show them in the stats. For example:
```
Advisories given
  - total: 12256
  - advice level:
    - improvement: 12256
  - advice type:
    - not_stable: 12256
  - advice message:
    - Attribute 'rpc.method' is not stable; stability = development.: 6128
    - Attribute 'rpc.service' is not stable; stability = development.: 6128
```
I can see from the stats that I had 12256 `not_stable` advisories. And now I can see that it's these two `rpc` attributes causing the issue 6128 times each. For a large capture such as this, the full detail from every sample is somewhat overwhelming.

(While testing I found that the attributes.json test file was an old format, so that is also updated in this PR. This is useful to see lots of output: `cargo run -- registry live-check -r ../semantic-conventions/model --input-source crates/weaver_live_check/data/attributes.json`)