### PR TITLE
Fixed undefined enum variant advice message

### DIFF
--- a/crates/weaver_live_check/src/advice.rs
+++ b/crates/weaver_live_check/src/advice.rs
@@ -68,16 +68,6 @@ fn deprecated_to_reason(deprecated: &Deprecated) -> String {
     }
 }
 
-/// Formats a JSON value for display without JSON quotes
-fn format_json_value(value: &serde_json::Value) -> String {
-    match value {
-        serde_json::Value::String(s) => s.clone(),
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::Bool(b) => b.to_string(),
-        _ => value.to_string(),
-    }
-}
-
 /// An advisor that checks if an attribute is deprecated
 pub struct DeprecatedAdvisor;
 impl Advisor for DeprecatedAdvisor {
@@ -511,7 +501,7 @@ impl Advisor for EnumAdvisor {
                                     }),
                                     message: format!("Enum attribute '{}' has value '{}' which is not documented.", 
                                         sample_attribute.name,
-                                        format_json_value(attribute_value)
+                                        attribute_value.as_str().unwrap_or(&attribute_value.to_string())
                                     ),
                                     advice_level: AdviceLevel::Information,
                                     signal_type: signal.signal_type(),

--- a/crates/weaver_live_check/src/advice.rs
+++ b/crates/weaver_live_check/src/advice.rs
@@ -499,7 +499,7 @@ impl Advisor for EnumAdvisor {
                                         ATTRIBUTE_NAME_ADVICE_CONTEXT_KEY: sample_attribute.name.clone(),
                                         ATTRIBUTE_VALUE_ADVICE_CONTEXT_KEY: attribute_value,
                                     }),
-                                    message: format!("Enum attribute '{}' has value '{}' which is not documented.", sample_attribute.name, attribute_value.as_str().unwrap_or("")),
+                                    message: format!("Enum attribute '{}' has value '{}' which is not documented.", sample_attribute.name, attribute_value),
                                     advice_level: AdviceLevel::Information,
                                     signal_type: signal.signal_type(),
                                     signal_name: signal.signal_name(),

--- a/crates/weaver_live_check/src/advice.rs
+++ b/crates/weaver_live_check/src/advice.rs
@@ -68,6 +68,16 @@ fn deprecated_to_reason(deprecated: &Deprecated) -> String {
     }
 }
 
+/// Formats a JSON value for display without JSON quotes
+fn format_json_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        _ => value.to_string(),
+    }
+}
+
 /// An advisor that checks if an attribute is deprecated
 pub struct DeprecatedAdvisor;
 impl Advisor for DeprecatedAdvisor {
@@ -499,7 +509,10 @@ impl Advisor for EnumAdvisor {
                                         ATTRIBUTE_NAME_ADVICE_CONTEXT_KEY: sample_attribute.name.clone(),
                                         ATTRIBUTE_VALUE_ADVICE_CONTEXT_KEY: attribute_value,
                                     }),
-                                    message: format!("Enum attribute '{}' has value '{}' which is not documented.", sample_attribute.name, attribute_value),
+                                    message: format!("Enum attribute '{}' has value '{}' which is not documented.", 
+                                        sample_attribute.name, 
+                                        format_json_value(attribute_value)
+                                    ),
                                     advice_level: AdviceLevel::Information,
                                     signal_type: signal.signal_type(),
                                     signal_name: signal.signal_name(),

--- a/crates/weaver_live_check/src/advice.rs
+++ b/crates/weaver_live_check/src/advice.rs
@@ -510,7 +510,7 @@ impl Advisor for EnumAdvisor {
                                         ATTRIBUTE_VALUE_ADVICE_CONTEXT_KEY: attribute_value,
                                     }),
                                     message: format!("Enum attribute '{}' has value '{}' which is not documented.", 
-                                        sample_attribute.name, 
+                                        sample_attribute.name,
                                         format_json_value(attribute_value)
                                     ),
                                     advice_level: AdviceLevel::Information,

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -159,6 +159,7 @@ mod tests {
             Sample::Attribute(SampleAttribute::try_from("test.extends=new_value").unwrap()),
             Sample::Attribute(SampleAttribute::try_from("test.template.my.key=42").unwrap()),
             Sample::Attribute(SampleAttribute::try_from("test.deprecated.allowed=42").unwrap()),
+            Sample::Attribute(SampleAttribute::try_from("test.enum=17").unwrap()),
         ];
 
         let advisors: Vec<Box<dyn Advisor>> = vec![
@@ -380,12 +381,24 @@ mod tests {
             "Attribute name 'test.deprecated.allowed' collides with existing namespace 'test'"
         );
 
+        let all_advice = get_all_advice(&mut samples[11]);
+        assert_eq!(all_advice.len(), 1);
+        assert_eq!(all_advice[0].advice_type, "undefined_enum_variant");
+        assert_eq!(
+            all_advice[0].advice_context,
+            json!({"attribute_name": "test.enum", "attribute_value": 17})
+        );
+        assert_eq!(
+            all_advice[0].message,
+            "Enum attribute 'test.enum' has value '17' which is not documented."
+        );
+
         // Check statistics
-        assert_eq!(stats.total_entities, 11);
-        assert_eq!(stats.total_advisories, 18);
+        assert_eq!(stats.total_entities, 12);
+        assert_eq!(stats.total_advisories, 19);
         assert_eq!(stats.advice_level_counts.len(), 3);
         assert_eq!(stats.advice_level_counts[&AdviceLevel::Violation], 11);
-        assert_eq!(stats.advice_level_counts[&AdviceLevel::Information], 5);
+        assert_eq!(stats.advice_level_counts[&AdviceLevel::Information], 6);
         assert_eq!(stats.advice_level_counts[&AdviceLevel::Improvement], 2);
         assert_eq!(stats.highest_advice_level_counts.len(), 2);
         assert_eq!(
@@ -394,11 +407,11 @@ mod tests {
         );
         assert_eq!(
             stats.highest_advice_level_counts[&AdviceLevel::Information],
-            1
+            2
         );
         assert_eq!(stats.no_advice_count, 2);
         assert_eq!(stats.seen_registry_attributes.len(), 3);
-        assert_eq!(stats.seen_registry_attributes["test.enum"], 3);
+        assert_eq!(stats.seen_registry_attributes["test.enum"], 4);
         assert_eq!(stats.seen_non_registry_attributes.len(), 6);
         assert_eq!(stats.registry_coverage, 1.0);
     }


### PR DESCRIPTION
There was a bug in the conversion from `Value` to `String` for this message.
Before:
```
rpc.system = 17
    - [information] Enum attribute 'rpc.system' has value '' which is not documented.
```
After:
```
rpc.system = 17
    - [information] Enum attribute 'rpc.system' has value '17' which is not documented.
```