### PR TITLE
[chore] Update entity example in the language v2 doc

### DIFF
--- a/schemas/semconv-syntax.v2.md
+++ b/schemas/semconv-syntax.v2.md
@@ -374,12 +374,11 @@ entities:
     stability: stable
     identity:
       - ref: service.name
-        requirement_level: required
       - ref: service.namespace
       - ref: service.instance.id
     description:
       - ref: service.version
-        role: descriptive
+        requirement_level: required
 ```
 
 ### `events` definition


### PR DESCRIPTION
- `role` field shouldn't be allowed since it's defined by the group role
- `requirement_level` shouldn't be used in the identity group since all of them should be required

Related to https://github.com/open-telemetry/weaver/issues/986