### PR TITLE
fix: allow loading registries and policies from hidden directories

### DIFF
--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -312,14 +312,6 @@ impl Engine {
         policy_dir: P,
         policy_glob_pattern: &str,
     ) -> Result<usize, Error> {
-        fn is_hidden(entry: &DirEntry) -> bool {
-            entry
-                .file_name()
-                .to_str()
-                .map(|s| s.starts_with('.'))
-                .unwrap_or(false)
-        }
-
         let mut errors = Vec::new();
         let mut added_policy_count = 0;
 
@@ -335,11 +327,8 @@ impl Engine {
             policy_glob.is_match(path.as_ref())
         };
 
-        // Visit recursively all the files in the policy directory
+        // Visit recursively all the files in the policy directory.
         for entry in walkdir::WalkDir::new(policy_dir).into_iter().flatten() {
-            if is_hidden(&entry) {
-                continue;
-            }
             if is_policy_file(&entry) {
                 if let Err(err) = self.add_policy_from_file(entry.path()) {
                     errors.push(err);

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -285,14 +285,7 @@ impl SchemaResolver {
         visited_registries: &mut HashSet<String>,
         dependency_chain: &mut Vec<String>,
     ) -> WResult<Vec<SemConvSpecWithProvenance>, weaver_semconv::Error> {
-        // Define helper functions for filtering files.
-        fn is_hidden(entry: &DirEntry) -> bool {
-            entry
-                .file_name()
-                .to_str()
-                .map(|s| s.starts_with('.'))
-                .unwrap_or(false)
-        }
+        // Define helper function for filtering files.
         fn is_semantic_convention_file(entry: &DirEntry) -> bool {
             let path = entry.path();
             let extension = path.extension().unwrap_or_else(|| std::ffi::OsStr::new(""));
@@ -331,7 +324,6 @@ impl SchemaResolver {
         let result = walkdir::WalkDir::new(local_path.clone())
             .follow_links(follow_symlinks)
             .into_iter()
-            .filter_entry(|e| !is_hidden(e))
             .par_bridge()
             .flat_map(|entry| {
                 match entry {

--- a/crates/weaver_semconv/src/v2/attribute_group.rs
+++ b/crates/weaver_semconv/src/v2/attribute_group.rs
@@ -173,19 +173,14 @@ impl AttributeGroup {
 }
 
 /// The group's visibility.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, JsonSchema, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum AttributeGroupVisibilitySpec {
     /// An internal group.
+    #[default]
     Internal,
     /// A public group.
     Public,
-}
-
-impl Default for AttributeGroupVisibilitySpec {
-    fn default() -> Self {
-        Self::Internal
-    }
 }
 
 impl std::fmt::Display for AttributeGroupVisibilitySpec {

--- a/test_data/.hidden_reg/.test.yaml
+++ b/test_data/.hidden_reg/.test.yaml
@@ -1,0 +1,8 @@
+groups:
+  - id: test.group
+    type: span
+    brief: Minimal test group for issue 958
+    attributes:
+      - id: test.attr
+        type: string
+        brief: Test attribute

--- a/tests/registry_generate.rs
+++ b/tests/registry_generate.rs
@@ -48,3 +48,22 @@ fn test_cli_interface() {
     // We expect 31 policy violations.
     assert_eq!(json_value.len(), 31);
 }
+
+/// Test for issue #958: Registry paths beginning with '.' should work
+#[test]
+fn test_hidden_directory() {
+    let mut cmd = Command::cargo_bin("weaver").unwrap();
+    let output = cmd
+        .arg("registry")
+        .arg("resolve")
+        .arg("-r")
+        .arg("test_data/.hidden_reg")
+        .timeout(std::time::Duration::from_secs(60))
+        .output()
+        .expect("failed to execute process");
+
+    assert!(output.status.success());
+
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(stderr.contains("loaded (1 files)"));
+}


### PR DESCRIPTION
## Summary
Removes unnecessary `is_hidden()` filter that prevented loading from directories starting with `.` (dot). The existing file type filters are sufficient to exclude problematic paths.

## Changes
- Removed `is_hidden()` function and filter from `weaver_resolver/src/lib.rs` (registry loading)
- Removed `is_hidden()` function and filter from `weaver_checker/src/lib.rs` (policy loading)
- Added integration test to verify hidden registry directories work correctly

## Test plan
- [x] Added test `test_hidden_directory` that verifies loading from `.hidden_reg/` directory
- [x] All existing tests pass
- [x] CI quality checks pass (fmt, clippy, doc)

Fixes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)