### PR TITLE
chore: update url to OTEP 0243

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Weaver provides a _set of tools_ for working with **schematized telemetry**.
 
 Further reading:
 - [Weaver Architecture](docs/architecture.md): A document detailing the architecture of the project.
-- [Application Telemetry Schema OTEP](https://github.com/open-telemetry/oteps/blob/main/text/0243-app-telemetry-schema-vision-roadmap.md): A vision and roadmap for the concept of Application Telemetry Schema.
+- [Application Telemetry Schema OTEP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0243-app-telemetry-schema-vision-roadmap.md): A vision and roadmap for the concept of Application Telemetry Schema.
 
 ## Examples and How-Tos
 


### PR DESCRIPTION
I started reading the docs about weaver and saw that the OTEPs have been moved from [this archived repo](https://github.com/open-telemetry/oteps/blob/main/text/0243-app-telemetry-schema-vision-roadmap.md) to the [specification repo](https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/), so I've update the url.