### PR TITLE
[DRAFT] Allow completely custom violations in Rego Policies

### DIFF
--- a/crates/weaver_checker/data/registries/otel_policies.rego
+++ b/crates/weaver_checker/data/registries/otel_policies.rego
@@ -12,11 +12,16 @@ import rego.v1
 
 # A registry `attribute_group` containing at least one `ref` attribute is
 # considered invalid.
-deny contains attr_registry_violation("registry_with_ref_attr", group.id, attr.ref) if {
+deny contains custom_violation("registry_with_ref_attr", message, ctx) if {
 	group := input.groups[_]
 	startswith(group.id, "registry.")
 	attr := group.attributes[_]
 	attr.ref != null
+	message := sprintf("Registry cannot contain ref attribute. Found group: %s, attr: %s", [group.id, attr.ref])
+	ctx := {
+		"group": group.id,
+		"attr": attr.ref,
+	}
 }
 
 # An attribute whose stability is not `deprecated` but has the deprecated field
@@ -76,5 +81,14 @@ schema_evolution_violation(violation_id, group_id, attr_id) := violation if {
 		"category": "schema_evolution",
 		"group": group_id,
 		"attr": attr_id,
+	}
+}
+
+custom_violation(id, message, ctx) := violation if {
+	violation := {
+		"id": id,
+		"type": "custom",
+		"message": message,
+		"context": ctx,
 	}
 }

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -465,6 +465,7 @@ impl Engine {
 mod tests {
     use std::collections::HashMap;
 
+    use serde_json::json;
     use serde_yaml::Value;
 
     use weaver_common::error::format_errors;
@@ -584,12 +585,14 @@ mod tests {
                 group: "registry.network1".to_owned(),
                 attr: "protocol.name.3".to_owned(),
             },
-            Violation::SemconvAttribute {
+            Violation::Custom(crate::violation::Custom {
                 id: "registry_with_ref_attr".to_owned(),
-                category: "attribute_registry".to_owned(),
-                group: "registry.network1".to_owned(),
-                attr: "protocol.port".to_owned(),
-            },
+                message: "Registry cannot contain ref attribute. Found group: registry.network1, attr: protocol.port".to_owned(),
+                context: json!({
+                    "attr": "protocol.port",
+                    "group": "registry.network1",
+                }),
+            }),
         ]
         .into_iter()
         .map(|v| (v.id().to_owned(), v))

--- a/crates/weaver_checker/src/violation.rs
+++ b/crates/weaver_checker/src/violation.rs
@@ -25,6 +25,8 @@ pub enum Violation {
     },
     /// Advice related to a policy violation.
     Advice(Advice),
+    /// A violation that is completely custom provided.
+    Custom(Custom),
 }
 
 impl Display for Violation {
@@ -54,6 +56,14 @@ impl Display for Violation {
                     "type={type}, context={advice_context}, message={message}, advice_level={advice_level:?}, signal_type={signal_type:?}, signal_name={signal_name:?}"
                 )
             }
+            Violation::Custom(Custom {
+                id,
+                message,
+                context,
+            }) => write!(
+                    f,
+                    "id={id}, context={context}, message={message}"
+                ),
         }
     }
 }
@@ -68,6 +78,7 @@ impl Violation {
                 advice_type: r#type,
                 ..
             }) => r#type,
+            Violation::Custom(Custom { id, .. }) => id,
         }
     }
 }
@@ -112,4 +123,21 @@ pub struct Advice {
 
     /// The signal name the advice applies to e.g. "http.server.request.duration".
     pub signal_name: Option<String>,
+}
+
+/// Represents custom rego policy violations.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Custom {
+    /// A unique id denoting the policy violation.
+    ///
+    /// Violations will be grouped by this value.
+    pub id: String,
+    /// The human readable message of the policy violation, e.g. "You may not use 'z' in metric names".
+    /// 
+    /// This will be used to display the violation when no templates have been provided.
+    pub message: String,
+    /// Additional context about the violation.
+    /// 
+    /// This will be used when rendering the violation via custom templates.
+    pub context: Value,
 }


### PR DESCRIPTION
TODAY - we have Live Check advice + SemconvAttribute.

Live Check advice makes sense for Live Check. Semconv Attribute is highly limited and basically abused for most semconv policies.

This PR demonstrates a purely custom violation, that ticks the following goals:

- Should includes "just enough" structure for filtering and grouping in presenting results
- Always requires a 'raw string' we can output in lieu of custom rendering templates
- Allows custom rendering (and reporting) by embedding  a full JSON object

I see two primary tasks to finish before taking this PR out of draft:

- [ ] Agree upon bare minimum filtering / grouping capabilities we want for violations
- [ ] Decide upon whether `Advice` should just be used as-is everywhere instead of a  separate `Advice` for Live check, and `Custom` for everywhere else.