### PR TITLE
Fixed missing template checks and schema errors

### DIFF
--- a/schemas/semconv.schema.json
+++ b/schemas/semconv.schema.json
@@ -91,7 +91,7 @@
 							"type": "string",
 							"description": "The new name of the telemetry object."
 						},
-						"note:": {
+						"note": {
 							"type": "string",
 							"description": "A note explaining the reason for the deprecation."
 						}
@@ -109,7 +109,7 @@
 						"reason": {
 							"const": "obsoleted"
 						},
-						"note:": {
+						"note": {
 							"type": "string",
 							"description": "A note explaining the reason for the deprecation."
 						}
@@ -126,7 +126,7 @@
 						"reason": {
 							"const": "uncategorized"
 						},
-						"note:": {
+						"note": {
 							"type": "string",
 							"description": "A note explaining the reason for the deprecation."
 						}
@@ -601,7 +601,7 @@
 							},
 							"annotations": {
 								"$ref": "#/$defs/annotations"
-							}							
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Fixed a couple of bugs I found during recent work:

1. TypeAdvisor was not considering template type attributes when checking for required, recommended, etc. attributes for a signal. It would therefore incorrectly flag an attribute not present if, for example, the model had `foo.bar.<key>` as a required attribute and the sample contained `foo.bar.baz`.
2. In the json schema, the notes fields for deprecated objects was defined with errant `:` suffixes, meaning plain `note` was flagged as an error.