### PR TITLE
Ignore cargo dist created workflows in rennovate.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,10 @@
     'config:best-practices',
     'helpers:pinGitHubActionDigestsToSemver',
   ],
+  "ignorePaths": [
+    // cargo-dist manages this file, so we have to pin *its* dependency here.
+    ".github/workflows/release.yml"
+  ]
   packageRules: [
     {
       groupName: 'all patch versions',


### PR DESCRIPTION
This should clean up the PR queue of unmergable things.

We still need to figure out how to get cargo-dist to auto-upgrade workflows.  Debating moving *off* cargo dist as not providing enough hooks / features with other github utilities.