### PR TITLE
Fix global codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 
 # Global owners, will be the owners for everything in the repo
 
-* @open-telemetry/weaver-maintainers @open-telemetry/weaver-approvers
+* @open-telemetry/weaver-approvers
 
 # Semantic conventions schema
 /schemas/semconv.schema.json @open-telemetry/specs-semconv-approvers


### PR DESCRIPTION
> If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax