### PR TITLE
Document generated file header best practice

### DIFF
--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -111,6 +111,10 @@ This output in turn is passed to the `metrics.md.j2` template, evaluated by the 
 
 ## Tips and Tricks
 
+#### Mark generated files
+
+Add a short header comment in each template output noting that the file is generated and which template produced it. This helps downstream users avoid hand-editing generated artifacts and makes it easier to trace changes back to the source template.
+
 #### Use `debug()`
 
 Jinja2 can be overwhelming and hard to discover. Try putting `debug()` somewhere in your code:


### PR DESCRIPTION
## Summary
- add guidance to code generation docs to include a header comment noting generated files and their source template

## Rationale
- issue #440 requests a best practice to mark generated code with its source; documenting it makes templates easier to audit and discourages manual edits

## Testing
- not run (docs-only change)

Fixes #440