### PR TITLE
Add MUSL static binary targets to release process

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell", "msi"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Whether to install an updater program


### PR DESCRIPTION
Adds MUSL static binary targets (x86_64-unknown-linux-musl and aarch64-unknown-linux-musl) to the cargo-dist release configuration.

This enables building fully static Linux binaries compatible with older systems like Ubuntu 22 LTS that don't have GLIBC 2.39.

Fixes #1068