### PR TITLE
Use clean install, vs. install for npm dependencies in cargo.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -63,7 +63,7 @@ fn build_ui() -> Result<(), Box<dyn std::error::Error>> {
     if !status.success() {
         return Err("Failed to install UI dependencies".into());
     }
-    
+
     // Build the UI
     let status = Command::new(npm_cmd)
         .arg("run")


### PR DESCRIPTION
This will avoid recreating the package-lock.json file. Folks working on the UI will need to run  manually to update dependencies in the build.

cc @jerbly 