### PR TITLE
Added generator for usage.md

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-markdown"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a2617956a06d4885b490697b5307ebb09fec10b088afc18c81762d848c2339"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,7 +891,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -968,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3480,7 +3489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -3502,7 +3511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3595,7 +3604,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3997,7 +4006,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4520,7 +4529,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5304,6 +5313,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "clap-markdown",
  "clap_complete",
  "env_logger",
  "include_dir",
@@ -5668,7 +5678,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ weaver_version = { path = "crates/weaver_version" }
 
 clap = { version = "4.5.41", features = ["derive"] }
 clap_complete = "4.5.55"
+clap-markdown = "0.1"
 rayon = "1.10.0"
 ratatui = { version = "0.29.0", features = ["serde"] }
 tui-textarea = "0.7.0"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,54 +1,72 @@
-# Usage
+# Command-Line Help for `weaver`
 
-```text
+This document contains the help content for the `weaver` command-line program.
+
+**Command Overview:**
+
+* [`weaver`↴](#weaver)
+* [`weaver registry`↴](#weaver-registry)
+* [`weaver registry check`↴](#weaver-registry-check)
+* [`weaver registry generate`↴](#weaver-registry-generate)
+* [`weaver registry resolve`↴](#weaver-registry-resolve)
+* [`weaver registry search`↴](#weaver-registry-search)
+* [`weaver registry stats`↴](#weaver-registry-stats)
+* [`weaver registry update-markdown`↴](#weaver-registry-update-markdown)
+* [`weaver registry json-schema`↴](#weaver-registry-json-schema)
+* [`weaver registry diff`↴](#weaver-registry-diff)
+* [`weaver registry emit`↴](#weaver-registry-emit)
+* [`weaver registry live-check`↴](#weaver-registry-live-check)
+* [`weaver registry mcp`↴](#weaver-registry-mcp)
+* [`weaver diagnostic`↴](#weaver-diagnostic)
+* [`weaver diagnostic init`↴](#weaver-diagnostic-init)
+* [`weaver completion`↴](#weaver-completion)
+* [`weaver serve`↴](#weaver-serve)
+
+## `weaver`
+
 Manage semantic convention registry and telemetry schema workflows (OpenTelemetry Project)
 
-Usage: weaver [OPTIONS] <COMMAND>
+**Usage:** `weaver [OPTIONS] <COMMAND>`
 
-Commands:
-  registry    Manage Semantic Convention Registry
-  diagnostic  Manage Diagnostic Messages
-  completion  Generate shell completions
-  help        Print this message or the help of the given subcommand(s)
+###### **Subcommands:**
 
-Options:
-      --debug...  Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
-      --quiet     Turn the quiet mode on (i.e., minimal output)
-      --future    Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
-  -h, --help      Print help
-  -V, --version   Print version
-```
+* `registry` — Manage Semantic Convention Registry
+* `diagnostic` — Manage Diagnostic Messages
+* `completion` — Generate shell completions
+* `serve` — Start the API server (Experimental)
 
-## registry
+###### **Options:**
 
-```text
+* `--debug` — Turn debugging information on. Use twice (--debug --debug) for trace-level logs
+* `--quiet` — Turn the quiet mode on (i.e., minimal output)
+* `--future` — Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
+
+
+
+## `weaver registry`
+
 Manage Semantic Convention Registry
 
-Usage: weaver registry [OPTIONS] <COMMAND>
+**Usage:** `weaver registry <COMMAND>`
 
-Commands:
-  check            Validates a semantic convention registry.
-  generate         Generates artifacts from a semantic convention registry.
-  resolve          Resolves a semantic convention registry.
-  search           Searches a registry (Note: Experimental and subject to change)
-  stats            Calculate a set of general statistics on a semantic convention registry
-  update-markdown  Update markdown files that contain markers indicating the templates used to update the specified sections
-  json-schema      Generate the JSON Schema of the resolved registry documents consumed by the template generator and the policy engine.
-  diff             Generate a diff between two versions of a semantic convention registry.
-  live-check       Check the conformance level of an OTLP stream against a semantic convention registry.
-  emit             Emits a semantic convention registry as example signals to your OTLP receiver.
-  help             Print this message or the help of the given subcommand(s)
+###### **Subcommands:**
 
-Options:
-      --debug...  Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
-      --quiet     Turn the quiet mode on (i.e., minimal output)
-      --future    Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
-  -h, --help      Print help
-```
+* `check` — Validates a semantic convention registry.
+* `generate` — Generates artifacts from a semantic convention registry.
+* `resolve` — Resolves a semantic convention registry.
+* `search` — DEPRECATED - Searches a registry. This command is deprecated and will be removed in a future version. It is not compatible with V2 schema. Please search the generated documentation instead
+* `stats` — Calculate a set of general statistics on a semantic convention registry
+* `update-markdown` — Update markdown files that contain markers indicating the templates used to update the specified sections
+* `json-schema` — Generate the JSON Schema of the resolved registry documents consumed by the template generator and the policy engine.
+* `diff` — Generate a diff between two versions of a semantic convention registry.
+* `emit` — Emits a semantic convention registry as example signals to your OTLP receiver.
+* `live-check` — Perform a live check on sample telemetry by comparing it to a semantic convention registry.
+* `mcp` — Run an MCP (Model Context Protocol) server for the semantic convention registry.
 
-### registry check
 
-```text
+
+## `weaver registry check`
+
 Validates a semantic convention registry.
 
 The validation process for a semantic convention registry involves several steps:
@@ -61,55 +79,38 @@ Note: The `-d` and `--registry-git-sub-dir` options are only used when the regis
 
 The process exits with a code of 0 if the registry validation is successful.
 
-Usage: weaver registry check [OPTIONS]
+**Usage:** `weaver registry check [OPTIONS]`
 
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
+###### **Options:**
 
-  -r, --registry <REGISTRY>
-          Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
 
-          [default: https://github.com/open-telemetry/semantic-conventions.git[model]]
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
 
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
+  Default value: `false`
+* `--baseline-registry <BASELINE_REGISTRY>` — Parameters to specify the baseline semantic convention registry
+* `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
+* `--skip-policies` — Skip the policy checks
 
-  -s, --follow-symlinks
-          Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+  Default value: `false`
+* `--display-policy-coverage` — Display the policy coverage report (useful for debugging)
 
-      --baseline-registry <BASELINE_REGISTRY>
-          Parameters to specify the baseline semantic convention registry
+  Default value: `false`
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
 
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
 
-  -p, --policy <POLICIES>
-          Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
 
-      --skip-policies
-          Skip the policy checks
 
-      --display-policy-coverage
-          Display the policy coverage report (useful for debugging)
 
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
+## `weaver registry generate`
 
-          [default: ansi]
-
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located
-
-          [default: diagnostic_templates]
-
-  -h, --help
-          Print help (see a summary with '-h')
-```
-
-### registry generate
-
-```text
 Generates artifacts from a semantic convention registry.
 
 Rego policies present in the registry or specified using -p or --policy will be automatically validated by the policy engine before the artifact generation phase.
@@ -118,77 +119,55 @@ Note: The `-d` and `--registry-git-sub-dir` options are only used when the regis
 
 The process exits with a code of 0 if the generation is successful.
 
-Usage: weaver registry generate [OPTIONS] <TARGET> [OUTPUT]
+**Usage:** `weaver registry generate [OPTIONS] [TARGET] [OUTPUT]`
 
-Arguments:
-  <TARGET>
-          Target to generate the artifacts for
+###### **Arguments:**
 
-          [default: ]
+* `<TARGET>` — Target to generate the artifacts for
 
-  [OUTPUT]
-          Path to the directory where the generated artifacts will be saved. Default is the `output` directory
+  Default value: ``
+* `<OUTPUT>` — Path to the directory where the generated artifacts will be saved. Default is the `output` directory
 
-          [default: output]
+  Default value: `output`
 
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
+###### **Options:**
 
-  -t, --templates <TEMPLATES>
-          Path to the directory where the templates are located. Default is the `templates` directory
+* `-t`, `--templates <TEMPLATES>` — Path to the directory where the templates are located. Default is the `templates` directory
 
-          [default: templates]
+  Default value: `templates`
+* `-c`, `--config <CONFIG>` — List of `weaver.yaml` configuration files to use. When there is a conflict, the last one will override the previous ones for the keys that are defined in both
+* `-D`, `--param <PARAM>` — Parameters key=value, defined in the command line, to pass to the templates. The value must be a valid YAML value
+* `--params <PARAMS>` — Parameters, defined in a YAML file, to pass to the templates
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
 
-  -c, --config <CONFIG>
-          List of `weaver.yaml` configuration files to use. When there is a conflict, the last one will override the previous ones for the keys that are defined in both
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
 
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
+  Default value: `false`
+* `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
+* `--skip-policies` — Skip the policy checks
 
-  -D, --param <PARAM>
-          Parameters key=value, defined in the command line, to pass to the templates. The value must be a valid YAML value
+  Default value: `false`
+* `--display-policy-coverage` — Display the policy coverage report (useful for debugging)
 
-      --params <PARAMS>
-          Parameters, defined in a YAML file, to pass to the templates
+  Default value: `false`
+* `--future` — Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry
 
-  -r, --registry <REGISTRY>
-          Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
+  Default value: `false`
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
 
-          [default: https://github.com/open-telemetry/semantic-conventions.git[model]]
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
 
-  -s, --follow-symlinks
-          Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
 
-  -p, --policy <POLICIES>
-          Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
 
-      --skip-policies
-          Skip the policy checks
 
-      --display-policy-coverage
-          Display the policy coverage report (useful for debugging)
+## `weaver registry resolve`
 
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry
-
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
-
-          [default: ansi]
-
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located
-
-          [default: diagnostic_templates]
-
-  -h, --help
-          Print help (see a summary with '-h')
-```
-
-### registry resolve
-
-```text
 Resolves a semantic convention registry.
 
 Rego policies present in the registry or specified using -p or --policy will be automatically validated by the policy engine before the artifact generation phase.
@@ -197,209 +176,191 @@ Note: The `-d` and `--registry-git-sub-dir` options are only used when the regis
 
 The process exits with a code of 0 if the resolution is successful.
 
-Usage: weaver registry resolve [OPTIONS]
+**Usage:** `weaver registry resolve [OPTIONS]`
 
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
+###### **Options:**
 
-  -r, --registry <REGISTRY>
-          Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
 
-          [default: https://github.com/open-telemetry/semantic-conventions.git[model]]
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
 
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
+  Default value: `false`
+* `--lineage` — Flag to indicate if lineage information should be included in the resolved schema (not yet implemented)
 
-  -s, --follow-symlinks
-          Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+  Default value: `false`
+* `-o`, `--output <OUTPUT>` — Output file to write the resolved schema to If not specified, the resolved schema is printed to stdout
+* `-f`, `--format <FORMAT>` — Output format for the resolved schema If not specified, the resolved schema is printed in YAML format Supported formats: yaml, json Default format: yaml Example: `--format json`
 
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
+  Default value: `yaml`
 
-      --lineage
-          Flag to indicate if lineage information should be included in the resolved schema (not yet implemented)
+  Possible values:
+  - `yaml`:
+    YAML format
+  - `json`:
+    JSON format
 
-  -o, --output <OUTPUT>
-          Output file to write the resolved schema to If not specified, the resolved schema is printed to stdout
+* `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
+* `--skip-policies` — Skip the policy checks
 
-  -f, --format <FORMAT>
-          Output format for the resolved schema If not specified, the resolved schema is printed in YAML format Supported formats: yaml, json Default format: yaml Example: `--format json`
+  Default value: `false`
+* `--display-policy-coverage` — Display the policy coverage report (useful for debugging)
 
-          [default: yaml]
+  Default value: `false`
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
 
-          Possible values:
-          - yaml: YAML format
-          - json: JSON format
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
 
-  -p, --policy <POLICIES>
-          Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
 
-      --skip-policies
-          Skip the policy checks
 
-      --display-policy-coverage
-          Display the policy coverage report (useful for debugging)
 
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
+## `weaver registry search`
 
-          [default: ansi]
+DEPRECATED - Searches a registry. This command is deprecated and will be removed in a future version. It is not compatible with V2 schema. Please search the generated documentation instead
 
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located
+**Usage:** `weaver registry search [OPTIONS] [SEARCH_STRING]`
 
-          [default: diagnostic_templates]
+###### **Arguments:**
 
-  -h, --help
-          Print help (see a summary with '-h')
-```
+* `<SEARCH_STRING>` — An (optional) search string to use.  If specified, will return matching values on the command line. Otherwise, runs an interactive terminal UI
 
-### registry search
+###### **Options:**
 
-> **DEPRECATED**: This command is deprecated and will be removed in a future version. It is not compatible with V2 schema. Please search the generated documentation instead.
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
 
-```text
-Usage: weaver registry search [OPTIONS] [SEARCH_STRING]
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
 
-Arguments:
-  [SEARCH_STRING]  An (optional) search string to use.  If specified, will return matching values on the command line. Otherwise, runs an interactive terminal UI
+  Default value: `false`
+* `--lineage` — Flag to indicate if lineage information should be included in the resolved schema (not yet implemented)
 
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
-  -r, --registry <REGISTRY>
-          Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL [default: https://github.com/open-telemetry/semantic-conventions.git[model]]
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
-  -s, --follow-symlinks
-          Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
-      --lineage
-          Flag to indicate if lineage information should be included in the resolved schema (not yet implemented)
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command [default: ansi]
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located [default: diagnostic_templates]
-  -h, --help
-          Print help
-```
+  Default value: `false`
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
 
-### registry stats
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
 
-```text
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
+
+
+
+## `weaver registry stats`
+
 Calculate a set of general statistics on a semantic convention registry
 
-Usage: weaver registry stats [OPTIONS]
+**Usage:** `weaver registry stats [OPTIONS]`
 
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
-  -r, --registry <REGISTRY>
-          Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL [default: https://github.com/open-telemetry/semantic-conventions.git[model]]
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
-  -s, --follow-symlinks
-          Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command [default: ansi]
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located [default: diagnostic_templates]
-  -h, --help
-          Print help
-```
+###### **Options:**
 
-### registry update-markdown
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
 
-```text
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
+
+  Default value: `false`
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
+
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
+
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
+
+
+
+## `weaver registry update-markdown`
+
 Update markdown files that contain markers indicating the templates used to update the specified sections
 
-Usage: weaver registry update-markdown [OPTIONS] --target <TARGET> <MARKDOWN_DIR>
+**Usage:** `weaver registry update-markdown [OPTIONS] --target <TARGET> <MARKDOWN_DIR>`
 
-Arguments:
-  <MARKDOWN_DIR>  Path to the directory where the markdown files are located
+###### **Arguments:**
 
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
-  -r, --registry <REGISTRY>
-          Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL [default: https://github.com/open-telemetry/semantic-conventions.git[model]]
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
-  -s, --follow-symlinks
-          Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
-      --dry-run
-          Whether or not to run updates in dry-run mode
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
-      --attribute-registry-base-url <ATTRIBUTE_REGISTRY_BASE_URL>
-          Optional path to the attribute registry. If provided, all attributes will be linked here
-  -t, --templates <TEMPLATES>
-          Path to the directory where the templates are located. Default is the `templates` directory. Note: `registry update-markdown` will look for a specific jinja template: {templates}/{target}/snippet.md.j2 [default: templates]
-      --target <TARGET>
-          If provided, the target to generate snippets with. Note: `registry update-markdown` will look for a specific jinja template: {templates}/{target}/snippet.md.j2
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command [default: ansi]
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located [default: diagnostic_templates]
-  -h, --help
-          Print help
-```
+* `<MARKDOWN_DIR>` — Path to the directory where the markdown files are located
 
-### registry json-schema
+###### **Options:**
 
-```text
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
+
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
+
+  Default value: `false`
+* `--dry-run` — Whether or not to run updates in dry-run mode
+
+  Default value: `false`
+* `--attribute-registry-base-url <ATTRIBUTE_REGISTRY_BASE_URL>` — Optional path to the attribute registry. If provided, all attributes will be linked here
+* `-D`, `--param <PARAM>` — Parameters key=value, defined in the command line, to pass to the templates. The value must be a valid YAML value
+* `--params <PARAMS>` — Parameters, defined in a YAML file, to pass to the templates
+* `-t`, `--templates <TEMPLATES>` — Path to the directory where the templates are located. Default is the `templates` directory. Note: `registry update-markdown` will look for a specific jinja template: {templates}/{target}/snippet.md.j2
+
+  Default value: `templates`
+* `--target <TARGET>` — If provided, the target to generate snippets with. Note: `registry update-markdown` will look for a specific jinja template: {templates}/{target}/snippet.md.j2
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
+
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
+
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
+
+
+
+## `weaver registry json-schema`
+
 Generate the JSON Schema of the resolved registry documents consumed by the template generator and the policy engine.
 
 The produced JSON Schema can be used to generate documentation of the resolved registry format or to generate code in your language of choice if you need to interact with the resolved registry format for any reason.
 
-Usage: weaver registry json-schema [OPTIONS]
+**Usage:** `weaver registry json-schema [OPTIONS]`
 
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
+###### **Options:**
 
-  -j, --json-schema <JSON_SCHEMA>
-          The type of JSON schema to generate
+* `-j`, `--json-schema <JSON_SCHEMA>` — The type of JSON schema to generate
 
-          Possible values:
-          - resolved-registry:     The JSON schema of a resolved registry
-          - semconv-group:         The JSON schema of a semantic convention group
-          - semconv-definition-v2: The JSON schema of the V2 definition
-          - resolved-registry-v2:  The JSON schema of the V2 resolved registry
-          - forge-registry-v2:     The JSON schema we send to Rego / Jinja
-          - diff:                  The JSON schema of the diff
-          - diff-v2:               The JSON schema of the diff V2
+  Default value: `resolved-registry`
 
-  -o, --output <OUTPUT>
-          Output file to write the JSON schema to If not specified, the JSON schema is printed to stdout
+  Possible values:
+  - `resolved-registry`:
+    The JSON schema of a resolved registry
+  - `semconv-group`:
+    The JSON schema of a semantic convention group
+  - `semconv-definition-v2`:
+    The JSON schema of the V2 definition
+  - `resolved-registry-v2`:
+    The JSON schema of the V2 resolved registry
+  - `forge-registry-v2`:
+    The JSON schema we send to Rego / Jinja
+  - `diff`:
+    The JSON schema of the diff
+  - `diff-v2`:
+    The JSON schema of the diff V2
 
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
+* `-o`, `--output <OUTPUT>` — Output file to write the JSON schema to If not specified, the JSON schema is printed to stdout
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
 
-          [default: ansi]
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
 
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
 
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located
 
-          [default: diagnostic_templates]
 
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
+## `weaver registry diff`
 
-  -h, --help
-          Print help (see a summary with '-h')
-```
-
-### registry diff
-
-```text
 Generate a diff between two versions of a semantic convention registry.
 
 This diff can then be rendered in multiple formats:
@@ -407,240 +368,287 @@ This diff can then be rendered in multiple formats:
 - a structured document in JSON format,
 - ...
 
-Usage: weaver registry diff [OPTIONS] --baseline-registry <BASELINE_REGISTRY>
+**Usage:** `weaver registry diff [OPTIONS] --baseline-registry <BASELINE_REGISTRY>`
 
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
+###### **Options:**
 
-  -r, --registry <REGISTRY>
-          Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
 
-          [default: https://github.com/open-telemetry/semantic-conventions.git[model]]
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
 
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
+  Default value: `false`
+* `--baseline-registry <BASELINE_REGISTRY>` — Parameters to specify the baseline semantic convention registry
+* `--diff-format <DIFF_FORMAT>` — Format used to render the schema changes. Predefined formats are: ansi, json, and markdown
 
-  -s, --follow-symlinks
-          Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+  Default value: `ansi`
+* `--diff-template <DIFF_TEMPLATE>` — Path to the directory where the schema changes templates are located
 
-      --baseline-registry <BASELINE_REGISTRY>
-          Parameters to specify the baseline semantic convention registry
+  Default value: `diff_templates`
+* `-o`, `--output <OUTPUT>` — Path to the directory where the generated artifacts will be saved. If not specified, the diff report is printed to stdout
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
 
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
 
-      --diff-format <DIFF_FORMAT>
-          Format used to render the schema changes. Predefined formats are: ansi, json, and markdown
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
 
-          [default: ansi]
 
-      --diff-template <DIFF_TEMPLATE>
-          Path to the directory where the schema changes templates are located
 
-          [default: diff_templates]
+## `weaver registry emit`
 
-  -o, --output <OUTPUT>
-          Path to the directory where the generated artifacts will be saved. If not specified, the diff report is printed to stdout
-
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
-
-          [default: ansi]
-
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located
-
-          [default: diagnostic_templates]
-
-  -h, --help
-          Print help (see a summary with '-h')
-```
-
-### registry live-check
-
-```text
-Check the conformance level of an OTLP stream against a semantic convention registry.
-
-This command starts an OTLP listener and compares each received OTLP message with the
-registry provided as a parameter. When the command is stopped (see stop conditions),
-a conformance/coverage report is generated. The purpose of this command is to be used
-in a CI/CD pipeline to validate the telemetry stream from an application or service
-against a registry.
-
-The currently supported stop conditions are: CTRL+C (SIGINT), SIGHUP, the HTTP /stop
-endpoint, and a maximum duration of no OTLP message reception.
-
-Usage: weaver registry live-check [OPTIONS]
-
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
-
-  -r, --registry <REGISTRY>
-          Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
-
-          [default: https://github.com/open-telemetry/semantic-conventions.git[model]]
-
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
-
-  -s, --follow-symlinks
-          Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
-
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
-
-      --otlp-grpc-address <OTLP_GRPC_ADDRESS>
-          Address used by the gRPC OTLP listener
-
-          [default: 0.0.0.0]
-
-  -p, --otlp-grpc-port <OTLP_GRPC_PORT>
-          Port used by the gRPC OTLP listener
-
-          [default: 4317]
-
-  -a, --admin-port <ADMIN_PORT>
-          Port used by the HTTP admin port (endpoints: /stop)
-
-          [default: 4320]
-
-  -t, --inactivity-timeout <INACTIVITY_TIMEOUT>
-          Max inactivity time in seconds before stopping the listener
-
-          [default: 10]
-
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
-
-          [default: ansi]
-
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located
-
-          [default: diagnostic_templates]
-
-  -h, --help
-          Print help (see a summary with '-h')
-```
-
-### registry emit
-
-```text
 Emits a semantic convention registry as example signals to your OTLP receiver.
 
 This uses the standard OpenTelemetry SDK, defaulting to OTLP gRPC on localhost:4317.
 
-Usage: weaver registry emit [OPTIONS]
+**Usage:** `weaver registry emit [OPTIONS]`
 
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
+###### **Options:**
 
-  -r, --registry <REGISTRY>
-          Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
 
-          [default: https://github.com/open-telemetry/semantic-conventions.git[model]]
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
 
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
+  Default value: `false`
+* `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
+* `--skip-policies` — Skip the policy checks
 
-  -s, --follow-symlinks
-          Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+  Default value: `false`
+* `--display-policy-coverage` — Display the policy coverage report (useful for debugging)
 
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
+  Default value: `false`
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
 
-  -p, --policy <POLICIES>
-          Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
 
-      --skip-policies
-          Skip the policy checks
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
+* `--stdout` — Write the telemetry to standard output
+* `--endpoint <ENDPOINT>` — Endpoint for the OTLP receiver. OTEL_EXPORTER_OTLP_ENDPOINT env var will override this
 
-      --display-policy-coverage
-          Display the policy coverage report (useful for debugging)
+  Default value: `http://localhost:4317`
 
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
 
-          [default: ansi]
 
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located
+## `weaver registry live-check`
 
-          [default: diagnostic_templates]
+Perform a live check on sample telemetry by comparing it to a semantic convention registry.
 
-      --stdout
-          Write the telemetry to standard output
+Includes: Flexible input ingestion, configurable assessment, and template-based output.
 
-      --endpoint <ENDPOINT>
-          Endpoint for the OTLP receiver. OTEL_EXPORTER_OTLP_ENDPOINT env var will override this
+**Usage:** `weaver registry live-check [OPTIONS]`
 
-          [default: http://localhost:4317]
+###### **Options:**
 
-  -h, --help
-          Print help (see a summary with '-h')
-```
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
 
-## diagnostic
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
 
-```text
+  Default value: `false`
+* `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
+* `--skip-policies` — Skip the policy checks
+
+  Default value: `false`
+* `--display-policy-coverage` — Display the policy coverage report (useful for debugging)
+
+  Default value: `false`
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
+
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
+
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
+* `--input-source <INPUT_SOURCE>` — Where to read the input telemetry from. {file path} | stdin | otlp
+
+  Default value: `otlp`
+* `--input-format <INPUT_FORMAT>` — The format of the input telemetry. (Not required for OTLP). text | json
+
+  Default value: `json`
+* `--format <FORMAT>` — Format used to render the report. Predefined formats are: ansi, json
+
+  Default value: `ansi`
+* `--templates <TEMPLATES>` — Path to the directory where the templates are located
+
+  Default value: `live_check_templates`
+* `--no-stream` — Disable stream mode. Use this flag to disable streaming output.
+
+   When the output is STDOUT, Ingesters that support streaming (STDIN and OTLP), by default output the live check results for each entity as they are ingested.
+
+  Default value: `false`
+* `--no-stats` — Disable statistics accumulation. This is useful for long-running live check sessions. Typically combined with --emit-otlp-logs and --output=none
+
+  Default value: `false`
+* `-o`, `--output <OUTPUT>` — Path to the directory where the generated artifacts will be saved. If not specified, the report is printed to stdout. Use "none" to disable all template output rendering (useful when emitting OTLP logs)
+* `--otlp-grpc-address <OTLP_GRPC_ADDRESS>` — Address used by the gRPC OTLP listener
+
+  Default value: `0.0.0.0`
+* `--otlp-grpc-port <OTLP_GRPC_PORT>` — Port used by the gRPC OTLP listener
+
+  Default value: `4317`
+* `--emit-otlp-logs` — Enable OTLP log emission for live check policy findings
+
+  Default value: `false`
+* `--otlp-logs-endpoint <OTLP_LOGS_ENDPOINT>` — OTLP endpoint for log emission
+
+  Default value: `http://localhost:4317`
+* `--otlp-logs-stdout` — Use stdout for OTLP log emission (debug mode)
+
+  Default value: `false`
+* `--admin-port <ADMIN_PORT>` — Port used by the HTTP admin port (endpoints: /stop)
+
+  Default value: `4320`
+* `--inactivity-timeout <INACTIVITY_TIMEOUT>` — Max inactivity time in seconds before stopping the listener
+
+  Default value: `10`
+* `--advice-policies <ADVICE_POLICIES>` — Advice policies directory. Set this to override the default policies
+* `--advice-preprocessor <ADVICE_PREPROCESSOR>` — Advice preprocessor. A jq script to preprocess the registry data before passing to rego.
+
+   Rego policies are run for each sample as it arrives in a stream. The preprocessor can be used to create a new data structure that is more efficient for the rego policies versus processing the data for every sample.
+
+
+
+## `weaver registry mcp`
+
+Run an MCP (Model Context Protocol) server for the semantic convention registry.
+
+This server exposes the registry to LLMs, enabling natural language
+queries for finding and understanding semantic conventions while writing
+instrumentation code.
+
+The server communicates over stdio using JSON-RPC.
+
+**Usage:** `weaver registry mcp [OPTIONS]`
+
+###### **Options:**
+
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
+
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
+
+  Default value: `false`
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
+
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
+
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
+* `--advice-policies <ADVICE_POLICIES>` — Advice policies directory. Set this to override the default policies
+* `--advice-preprocessor <ADVICE_PREPROCESSOR>` — Advice preprocessor. A jq script to preprocess the registry data before passing to rego.
+
+   Rego policies are run for each sample as it arrives. The preprocessor can be used to create a new data structure that is more efficient for the rego policies versus processing the data for every sample.
+
+
+
+## `weaver diagnostic`
+
 Manage Diagnostic Messages
 
-Usage: weaver diagnostic [OPTIONS] <COMMAND>
+**Usage:** `weaver diagnostic <COMMAND>`
 
-Commands:
-  init  Initializes a `diagnostic_templates` directory to define or override diagnostic output formats
-  help  Print this message or the help of the given subcommand(s)
+###### **Subcommands:**
 
-Options:
-      --debug...  Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
-      --quiet     Turn the quiet mode on (i.e., minimal output)
-      --future    Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
-  -h, --help      Print help
-```
+* `init` — Initializes a `diagnostic_templates` directory to define or override diagnostic output formats
 
-### diagnostic init
 
-```text
+
+## `weaver diagnostic init`
+
 Initializes a `diagnostic_templates` directory to define or override diagnostic output formats
 
-Usage: weaver diagnostic init [OPTIONS] [TARGET]
+**Usage:** `weaver diagnostic init [OPTIONS] [TARGET]`
 
-Arguments:
-  [TARGET]  Optional target to initialize the diagnostic templates for. If empty, all default templates will be extracted [default: ]
+###### **Arguments:**
 
-Options:
-      --debug...
-          Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
-  -t, --diagnostic-templates-dir <DIAGNOSTIC_TEMPLATES_DIR>
-          Optional path where the diagnostic templates directory should be created [default: diagnostic_templates]
-      --diagnostic-format <DIAGNOSTIC_FORMAT>
-          Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command [default: ansi]
-      --quiet
-          Turn the quiet mode on (i.e., minimal output)
-      --diagnostic-template <DIAGNOSTIC_TEMPLATE>
-          Path to the directory where the diagnostic templates are located [default: diagnostic_templates]
-      --future
-          Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
-  -h, --help
-          Print help
-```
+* `<TARGET>` — Optional target to initialize the diagnostic templates for. If empty, all default templates will be extracted
 
-## completion
+  Default value: ``
 
-```text
+###### **Options:**
+
+* `-t`, `--diagnostic-templates-dir <DIAGNOSTIC_TEMPLATES_DIR>` — Optional path where the diagnostic templates directory should be created
+
+  Default value: `diagnostic_templates`
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
+
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
+
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
+
+
+
+## `weaver completion`
+
 Generate shell completions
 
-Usage: weaver completion [OPTIONS] <SHELL>
+**Usage:** `weaver completion <SHELL>`
 
-Arguments:
-  <SHELL>  The shell to generate the completions for [possible values: bash, elvish, fish, powershell, zsh]
+###### **Arguments:**
 
-Options:
-      --debug...  Turn debugging information on. Use twice (--debug --debug) for trace-level logs.
-      --quiet     Turn the quiet mode on (i.e., minimal output)
-      --future    Enable the most recent validation rules for the semconv registry. It is recommended to enable this flag when checking a new registry. Note: `semantic_conventions` main branch should always enable this flag
-  -h, --help      Print help
-```
+* `<SHELL>` — The shell to generate the completions for
+
+  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
+
+
+
+
+## `weaver serve`
+
+Start the API server (Experimental)
+
+**Usage:** `weaver serve [OPTIONS]`
+
+###### **Options:**
+
+* `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a sub-folder can be specified using the `[sub-folder]` syntax after the URL
+
+  Default value: `https://github.com/open-telemetry/semantic-conventions.git[model]`
+* `-s`, `--follow-symlinks` — Boolean flag to specify whether to follow symlinks when loading the registry. Default is false
+* `--include-unreferenced` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry
+* `--v2` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies
+
+  Default value: `false`
+* `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
+* `--skip-policies` — Skip the policy checks
+
+  Default value: `false`
+* `--display-policy-coverage` — Display the policy coverage report (useful for debugging)
+
+  Default value: `false`
+* `--bind <BIND>` — Address to bind the server to
+
+  Default value: `127.0.0.1:8080`
+* `--cors-origins <CORS_ORIGINS>` — Allowed CORS origins (comma-separated). Use '*' for any origin. If not specified, CORS is disabled (same-origin only)
+* `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command
+
+  Default value: `ansi`
+* `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located
+
+  Default value: `diagnostic_templates`
+* `--diagnostic-stdout` — Send the output to stdout instead of stderr
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,9 @@ pub enum Commands {
     Completion(CompletionCommand),
     /// Start the API server (Experimental)
     Serve(ServeCommand),
+    /// Generate markdown help documentation
+    #[command(hide = true)]
+    MarkdownHelp,
 }
 
 #[derive(Args)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,14 @@ fn run_command(cli: &Cli) -> ExitDirectives {
                 warnings: None,
             };
         }
+        Some(Commands::MarkdownHelp) => {
+            // Generate: cargo run -- --quiet markdown-help > docs/usage.md
+            clap_markdown::print_help_markdown::<Cli>();
+            return ExitDirectives {
+                exit_code: 0,
+                warnings: None,
+            };
+        }
         None => {
             return ExitDirectives {
                 exit_code: 0,


### PR DESCRIPTION
Added [clap-markdown](https://github.com/ConnorGray/clap-markdown) to generate our docs/usage.md.

```sh
cargo run -- --quiet markdown-help > docs/usage.md
```

Fixes #1164 