### PR TITLE
Prepare release v0.21.1

### DIFF
--- a/.github/build-setup.yml
+++ b/.github/build-setup.yml
@@ -1,0 +1,11 @@
+# Custom build setup steps for cargo-dist.
+# These steps are injected into the release workflow via the
+# github-build-setup option in dist-workspace.toml.
+# See: https://opensource.axo.dev/cargo-dist/book/ci/customizing.html
+
+- name: Setup Node.js
+  uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+  with:
+    node-version-file: '.nvmrc'
+    cache: 'npm'
+    cache-dependency-path: ui/package-lock.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,12 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - name: "Setup Node.js"
+        uses: "actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238"
+        with:
+          "cache": "npm"
+          "cache-dependency-path": "ui/package-lock.json"
+          "node-version-file": ".nvmrc"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-# [0.21.0] - 2026-02-02
+# [0.21.1] - 2026-02-02
 
 - New Experimental feature: `weaver serve` command to serve a REST API and web UI. ([#1076](https://github.com/open-telemetry/weaver/pull/1076) by @jerbly)
 - Add support for diff schemas in `registry json-schema`([#1105](https://github.com/open-telemetry/weaver/pull/1105) by @lmolkova)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "weaver"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "assert_cmd",
  "axum",
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_checker"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "globset",
  "miette",
@@ -5670,7 +5670,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_codegen_test"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "dirs",
  "log",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_common"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "dirs",
  "flate2",
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_diff"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "serde_json",
  "similar",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_emit"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "futures-util",
  "miette",
@@ -5738,7 +5738,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_forge"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "convert_case",
  "dirs",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_live_check"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "log",
  "miette",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_mcp"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "log",
  "miette",
@@ -5830,7 +5830,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_resolved_schema"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "log",
  "schemars",
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_resolver"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "glob",
  "globset",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_search"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "schemars",
  "serde",
@@ -5876,7 +5876,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_semconv"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "glob",
  "globset",
@@ -5899,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_semconv_gen"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "miette",
  "nom 8.0.0",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_version"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "schemars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ eula = false
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.21.1"
 authors = ["OpenTelemetry"]
 edition = "2021"
 repository = "https://github.com/open-telemetry/weaver"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -20,14 +20,8 @@ install-path = "CARGO_HOME"
 # Whether to enable GitHub Attestations
 github-attestations = true
 github-custom-runners = { global = "ubuntu-latest", x86_64-unknown-linux-gnu = "ubuntu-24.04", x86_64-pc-windows-msvc = "windows-2025", aarch64-unknown-linux-musl = "ubuntu-24.04-arm", aarch64-unknown-linux-gnu = "ubuntu-24.04-arm" }
+github-build-setup = "../build-setup.yml"
 
 [dist.dependencies.apt]
-nodejs = '24.*'
 musl-tools = '*'
 musl-dev = '*'
-
-[dist.dependencies.homebrew]
-node = '24'
-
-[dist.dependencies.chocolatey]
-nodejs = '24.*'


### PR DESCRIPTION
In v0.21.0, cargo-dist builds fail due to how we attempted to add dependencies i.e. node.

This PR changes to use an injected build-setup step following what we do in CI.