### PR TITLE
[chore] Fix rennovate - don't fail in build.rs for UI.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -75,13 +75,13 @@ fn check_ui() -> Result<(), Box<dyn std::error::Error>> {
     // Check if UI is out of date before running.
     if is_ui_stale(ui_dir)? {
         println!("cargo::warning=Weaver UI is out of date. Please run `pnpm build` in the `ui` directory.");
-        return Ok(())
+        return Ok(());
     }
 
     // Check if we need to install packages.
     if is_package_lock_stale(ui_dir)? {
         println!("cargo::warning=Weaver `ui/pnpm-lock.yaml` is out of date. Please run `pnpm install` in the `ui` directory.");
-        return Ok(())
+        return Ok(());
     }
 
     Ok(())


### PR DESCRIPTION
This allows `cargo` commands to work without a UI - so rennovate can do dependency fixes.