### PR TITLE
chore: Restore renovate scope

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,9 +8,6 @@
     // cargo-dist manages this file, so we have to pin *its* dependency here.
     ".github/workflows/release.yml"
   ],
-  includePaths: [
-    "ui/**"
-  ],
   packageRules: [
     {
       groupName: 'all patch versions',


### PR DESCRIPTION
Enable renovate to process all directories not just ui.

Note when you look at the renovate dashboard you would see that renovate is only managing the ui folder which was caused by the changes in #1173