### PR TITLE
Add nextest instructions to contrib.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@ Additionally, Weaver has its own CNCF slack channel at [#otel-weaver](https://cl
 
 ## Our Development Process
 
+For an overview of the project architecture and crate descriptions, see [docs/architecture.md](docs/architecture.md).
+For a guide on making schema changes, see [docs/developer-guide.md](docs/developer-guide.md).
+
 ### How to build  and test a change
 
 Run `cargo xtask validate` to check the structure of the project.
@@ -28,6 +31,14 @@ and run all tests with:
 ```bash
 cargo nextest run --all
 ```
+
+to run tests related to specific package, use `-p {package}`
+
+```bash
+cargo nextest run -p {package}
+```
+
+See [docs/architecture.md](docs/architecture.md) for the full list of packages and their descriptions.
 
 Run `cargo build` to build a local binary for any additional tests. The resulting binary will be placed in the `./output` directory.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,15 +39,21 @@ description and the current status of each crate:
 |--------------------------------------------------------------------|----------------------------------------------------------------------|------------------|
 | [weaver_semconv](/crates/weaver_semconv/README.md)                 | Semantic Convention Registry Data Model                              | Beta             |
 | [weaver_version](/crates/weaver_version/README.md)                 | OpenTelemetry Schema Versioning Data Model                           | Alpha            |
-| [weaver_common](/crates/weaver_common/README.md)             | Logging and error management                                         | Alpha            |
+| [weaver_common](/crates/weaver_common/README.md)                   | Logging and error management                                         | Alpha            |
 | [weaver_forge](/crates/weaver_forge/README.md)                     | Template engine used to generate artifacts from any serde json value | Alpha            |
 | [weaver_diff](/crates/weaver_diff/README.md)                       | Diffing tool to compare two versions of a text (used in unit tests)  | Alpha            |
 | [weaver_resolved_schema](/crates/weaver_resolved_schema/README.md) | Resolved Schema Data Model                                           | Work-In-Progress |
 | [weaver_resolver](/crates/weaver_resolver/README.md)               | Telemetry Schema Resolution Process + Lineage                        | Work-In-Progress |
-| [weaver_cache](/crates/weaver_cache/README.md)                     | Telemetry Schema and Semantic Convention Registry Cache              | Work-In-Progress |
 | [weaver_checker](/crates/weaver_checker/README.md)                 | Policy engine to enforce policies on telemetry data                  | Work-In-Progress |
-|                                                                    |                                                                      |                  |
+| [weaver_emit](/crates/weaver_emit/README.md)                       | Emit OTLP signals generated from registries                          | Work-In-Progress |
+| [weaver_live_check](/crates/weaver_live_check/README.md)           | Developer tool for assessing sample telemetry against conventions    | Work-In-Progress |
+| [weaver_mcp](/crates/weaver_mcp/README.md)                         | MCP server exposing semantic conventions to LLMs                     | Work-In-Progress |
+| [weaver_search](/crates/weaver_search/README.md)                   | Search engine for querying resolved semantic convention registries   | Work-In-Progress |
+| [weaver_otel_schema](/crates/weaver_otel_schema/README.md)         | OpenTelemetry Schema Data Model                                      | Work-In-Progress |
+| [weaver_semconv_gen](/crates/weaver_semconv_gen/README.md)         | Semantic convention markdown updater                                 | Work-In-Progress |
 | xtask                                                              | Set of tasks to validate the project                                 | Done             |
+
+The root `weaver` package contains the main CLI binary that ties all the above crates together.
 
 Note 1: Alpha status means that the crate is in a usable state but may have
 limited functionality and/or may not be fully tested.


### PR DESCRIPTION
## nexttest

`time cargo nextest run -p weaver`: 13.15s user 2.11s system 82% cpu 18.474 total)

<img width="1634" height="682" alt="image" src="https://github.com/user-attachments/assets/e7011983-6fa7-421f-aa81-c024201084f5" />

## plain test 

`time cargo test -p weaver`: 12.56s user 1.83s system 41% cpu 34.275 total)

<img width="1576" height="788" alt="image" src="https://github.com/user-attachments/assets/1f6cc434-12b3-4c7c-ad36-00e0ad9d776e" />
