### PR TITLE
fix: Tackle renovate errors

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -110,7 +110,7 @@
     },
     {
       customType: "regex",
-      description: "Update Cargo Dist TOML CI Actions",
+      description: "Update Cargo Dist YAML CI Actions Template",
       managerFilePatterns: [
         ".github/build-setup.yml",
       ],


### PR DESCRIPTION
Address issues with cargo dist actions not being able to be updated.

This switches the package datasource to github-tags for dist-workspace.yaml as this enables the digest resolution. Although the Dashboard says otherwise.

To overcome not running dist plan, the inbuilt manager has been excluded from updating the release Workflow. Instead a custom manager is added which ensures that only digests are updated only when the version changes rather than every digest change.

This should hopefully address issues in #1226 