### PR TITLE
Tolerate unknown properties in resolved schema / published manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Tolerate unknown fields in resolved schema and publication manifest on newer-minor `file_format` with a warning; same/older minor and any major mismatch remain fatal. ([#1365](https://github.com/open-telemetry/weaver/pull/1365) by @lmolkova)
 - Add a tree view to the `serve` UI's search page, grouping results by namespace with expand/collapse controls, and a "Hide deprecated" toggle (on by default) for both the list and tree views. ([#1595](https://github.com/open-telemetry/weaver/pull/1595) by @jerbly)
 - Support signal refinements over a published dependency. ([#1587](https://github.com/open-telemetry/weaver/pull/1587) by @lmolkova)
 - 💥 BREAKING CHANGE 💥 Preserve per-attribute `requirement_level` on attribute refs of public attribute groups in the v2 resolved and materialized schemas. Each entry in an attribute group's `attributes` is now an object (`{ base, requirement_level }`) instead of a bare `attribute_catalog` index. ([#1584](https://github.com/open-telemetry/weaver/pull/1584) by @lmolkova)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6453,6 +6453,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror 2.0.18",
  "utoipa",
  "weaver_common",

--- a/crates/weaver_common/src/file_format.rs
+++ b/crates/weaver_common/src/file_format.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! File-format version identifiers of the form `"prefix/MAJOR.MINOR"`,
+//! shared by manifest and resolved-schema files.
+
+use crate::Error;
+use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Cow;
+use std::str::FromStr;
+
+/// A file-format identifier of the form `"prefix/MAJOR.MINOR"`, e.g. `"manifest/2.0"`.
+///
+/// Serializes and deserializes as the string form (e.g. `"resolved/2.0"`).
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct FileFormat {
+    /// The format prefix (e.g. `"manifest"`, `"resolved"`).
+    pub prefix: Cow<'static, str>,
+    /// The major version.
+    pub major: u32,
+    /// The minor version.
+    pub minor: u32,
+}
+
+impl FileFormat {
+    /// Construct a [`FileFormat`] from its parts.
+    #[must_use]
+    pub const fn new(prefix: &'static str, major: u32, minor: u32) -> Self {
+        Self {
+            prefix: Cow::Borrowed(prefix),
+            major,
+            minor,
+        }
+    }
+
+    /// Validate `found` against this expected version, logging a warning for newer-minor
+    /// versions and returning a structured [`Error`] for incompatible prefix or major.
+    ///
+    /// Both inputs are already parsed [`FileFormat`]s — typically `self` is the build's
+    /// expected constant and `found` comes from deserializing the file's `file_format` field.
+    pub fn validate(&self, found: &FileFormat, path: &std::path::Path) -> Result<(), Error> {
+        if found.prefix != self.prefix {
+            return Err(Error::UnrecognizedFileFormat {
+                path: path.to_path_buf(),
+                found: found.to_string(),
+                expected: self.clone(),
+            });
+        }
+        if found.major != self.major {
+            return Err(Error::IncompatibleFileFormatMajorVersion {
+                path: path.to_path_buf(),
+                found: found.clone(),
+                expected: self.clone(),
+            });
+        }
+        if found.minor > self.minor {
+            log::warn!(
+                "File format '{found}' in {path:?} is newer than the supported format '{}'. \
+                 Some fields may be ignored — update weaver to a newer version to consume them.",
+                self,
+            );
+        }
+        Ok(())
+    }
+
+    /// Returns `true` when `other` is a known minor version of `self` (the expected minor
+    /// or older, with matching prefix and major).
+    ///
+    /// Callers use this after [`Self::validate`] succeeds to decide whether to reject
+    /// unknown fields (known minor: yes; newer minor: tolerate).
+    #[must_use]
+    pub fn is_known_minor(&self, other: &FileFormat) -> bool {
+        self.prefix == other.prefix && self.major == other.major && other.minor <= self.minor
+    }
+}
+
+impl std::fmt::Display for FileFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}.{}", self.prefix, self.major, self.minor)
+    }
+}
+
+impl std::fmt::Debug for FileFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+impl FromStr for FileFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (prefix, major, minor) = parse_file_format_version(s)
+            .ok_or_else(|| format!("invalid file_format '{s}': expected 'prefix/MAJOR.MINOR'"))?;
+        Ok(Self {
+            prefix: Cow::Owned(prefix.to_owned()),
+            major,
+            minor,
+        })
+    }
+}
+
+impl Serialize for FileFormat {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for FileFormat {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(de::Error::custom)
+    }
+}
+
+impl JsonSchema for FileFormat {
+    fn schema_name() -> Cow<'static, str> {
+        "FileFormat".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        concat!(module_path!(), "::FileFormat").into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "pattern": r"^[A-Za-z][A-Za-z0-9_-]*/\d+\.\d+$",
+            "description": "A file-format identifier of the form 'prefix/MAJOR.MINOR'.",
+        })
+    }
+}
+
+/// Parses a `"type/MAJOR.MINOR"` file-format string.
+///
+/// Returns `Some((prefix, major, minor))` or `None` if the string doesn't match the pattern.
+#[must_use]
+pub fn parse_file_format_version(s: &str) -> Option<(&str, u32, u32)> {
+    let (prefix, ver) = s.split_once('/')?;
+    let (major_s, minor_s) = ver.split_once('.')?;
+    Some((prefix, major_s.parse().ok()?, minor_s.parse().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_and_display_roundtrip() {
+        let v: FileFormat = "resolved/2.5".parse().expect("parse");
+        assert_eq!(v.prefix, "resolved");
+        assert_eq!(v.major, 2);
+        assert_eq!(v.minor, 5);
+        assert_eq!(v.to_string(), "resolved/2.5");
+    }
+
+    #[test]
+    fn from_str_rejects_garbage() {
+        assert!("garbage".parse::<FileFormat>().is_err());
+        assert!("resolved/2".parse::<FileFormat>().is_err());
+        assert!("resolved/x.y".parse::<FileFormat>().is_err());
+    }
+
+    #[test]
+    fn serialize_as_string() {
+        let v = FileFormat::new("manifest", 2, 0);
+        let json = serde_json::to_string(&v).expect("serialize");
+        assert_eq!(json, r#""manifest/2.0""#);
+    }
+
+    #[test]
+    fn deserialize_from_string() {
+        let v: FileFormat = serde_json::from_str(r#""resolved/2.0""#).expect("deserialize");
+        assert_eq!(v, FileFormat::new("resolved", 2, 0));
+    }
+
+    #[test]
+    fn deserialize_rejects_non_string() {
+        let err = serde_json::from_str::<FileFormat>(r#"{"prefix":"resolved"}"#);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn debug_matches_display() {
+        let v = FileFormat::new("manifest", 2, 0);
+        assert_eq!(format!("{v:?}"), "manifest/2.0");
+        assert_eq!(format!("{v:?}"), format!("{v}"));
+    }
+
+    #[test]
+    fn json_schema_metadata() {
+        assert_eq!(FileFormat::schema_name(), "FileFormat");
+        assert!(FileFormat::schema_id().ends_with("::FileFormat"));
+    }
+
+    #[test]
+    fn json_schema_shape() {
+        let schema = FileFormat::json_schema(&mut SchemaGenerator::default());
+        let json = serde_json::to_value(&schema).expect("schema to json");
+        assert_eq!(json["type"], "string");
+        assert_eq!(json["pattern"], r"^[A-Za-z][A-Za-z0-9_-]*/\d+\.\d+$");
+        assert!(json["description"].is_string());
+
+        let pattern = json["pattern"].as_str().expect("pattern is string");
+        let re = regex::Regex::new(pattern).expect("pattern compiles");
+        assert!(re.is_match("manifest/2.0"));
+        assert!(re.is_match("resolved/10.123"));
+        assert!(!re.is_match("manifest/2"));
+        assert!(!re.is_match("manifest/x.y"));
+        assert!(!re.is_match("1bad/2.0"));
+    }
+}

--- a/crates/weaver_common/src/file_format.rs
+++ b/crates/weaver_common/src/file_format.rs
@@ -137,16 +137,6 @@ impl JsonSchema for FileFormat {
 #[must_use]
 pub fn parse_file_format_version(s: &str) -> Option<(&str, u32, u32)> {
     let (prefix, ver) = s.split_once('/')?;
-    // Enforce the JSON schema pattern `^[A-Za-z][A-Za-z0-9_-]*`: the prefix must start
-    // with a letter and contain only letters, digits, `_` or `-`.
-    let mut chars = prefix.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() => {}
-        _ => return None,
-    }
-    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
-        return None;
-    }
     let (major_s, minor_s) = ver.split_once('.')?;
     Some((prefix, major_s.parse().ok()?, minor_s.parse().ok()?))
 }
@@ -169,10 +159,6 @@ mod tests {
         assert!("garbage".parse::<FileFormat>().is_err());
         assert!("resolved/2".parse::<FileFormat>().is_err());
         assert!("resolved/x.y".parse::<FileFormat>().is_err());
-        // Prefix must match the JSON schema pattern (letter-led, no leading digit).
-        assert!("1bad/2.0".parse::<FileFormat>().is_err());
-        assert!("bad prefix/2.0".parse::<FileFormat>().is_err());
-        assert!("/2.0".parse::<FileFormat>().is_err());
     }
 
     #[test]

--- a/crates/weaver_common/src/file_format.rs
+++ b/crates/weaver_common/src/file_format.rs
@@ -137,6 +137,16 @@ impl JsonSchema for FileFormat {
 #[must_use]
 pub fn parse_file_format_version(s: &str) -> Option<(&str, u32, u32)> {
     let (prefix, ver) = s.split_once('/')?;
+    // Enforce the JSON schema pattern `^[A-Za-z][A-Za-z0-9_-]*`: the prefix must start
+    // with a letter and contain only letters, digits, `_` or `-`.
+    let mut chars = prefix.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() => {}
+        _ => return None,
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
+        return None;
+    }
     let (major_s, minor_s) = ver.split_once('.')?;
     Some((prefix, major_s.parse().ok()?, minor_s.parse().ok()?))
 }
@@ -159,6 +169,10 @@ mod tests {
         assert!("garbage".parse::<FileFormat>().is_err());
         assert!("resolved/2".parse::<FileFormat>().is_err());
         assert!("resolved/x.y".parse::<FileFormat>().is_err());
+        // Prefix must match the JSON schema pattern (letter-led, no leading digit).
+        assert!("1bad/2.0".parse::<FileFormat>().is_err());
+        assert!("bad prefix/2.0".parse::<FileFormat>().is_err());
+        assert!("/2.0".parse::<FileFormat>().is_err());
     }
 
     #[test]

--- a/crates/weaver_common/src/lib.rs
+++ b/crates/weaver_common/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod diagnostic;
 pub mod error;
+pub mod file_format;
 pub mod http_auth;
 pub mod ordered_float;
 pub mod result;
@@ -13,12 +14,13 @@ pub mod vdir;
 
 use crate::diagnostic::{DiagnosticMessage, DiagnosticMessages};
 use crate::error::{format_errors, WeaverError};
+use crate::file_format::FileFormat;
 use crate::Error::CompoundError;
 use miette::Diagnostic;
 use paris::formatter::colorize_string;
 use serde::Serialize;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -96,6 +98,30 @@ pub enum Error {
     UnsupportedRegistryArchive {
         /// The registry archive path
         archive: String,
+    },
+
+    /// The file_format major version is incompatible with this version of weaver.
+    #[error("Incompatible file_format '{found}' in {path:?}: does not match supported file format '{expected}'.")]
+    #[diagnostic(severity(Error))]
+    IncompatibleFileFormatMajorVersion {
+        /// Path to the file containing the incompatible file_format.
+        path: PathBuf,
+        /// The file format found in the file.
+        found: FileFormat,
+        /// The file format this build of weaver supports.
+        expected: FileFormat,
+    },
+
+    /// The `file_format` string could not be parsed or has an unexpected prefix.
+    #[error("Unknown file_format '{found}' in {path:?}. Expected '{expected}'.")]
+    #[diagnostic(severity(Error))]
+    UnrecognizedFileFormat {
+        /// Path to the file containing the unrecognized file_format.
+        path: PathBuf,
+        /// The file_format string found in the file.
+        found: String,
+        /// The file format this build of weaver supports.
+        expected: FileFormat,
     },
 
     /// A container for multiple errors.

--- a/crates/weaver_forge/src/v2/registry.rs
+++ b/crates/weaver_forge/src/v2/registry.rs
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn test_try_from_resolved_schema() {
         let resolved_schema = ResolvedTelemetrySchema {
-            file_format: "2.0.0".to_owned(),
+            file_format: "resolved/2.0".parse().unwrap(),
             schema_url: "https://example.com/schema".try_into().unwrap(),
             attribute_catalog: vec![attribute::Attribute {
                 key: "test.attr".to_owned(),
@@ -706,7 +706,7 @@ mod tests {
     #[test]
     fn test_try_from_resolved_schema_with_missing_attribute() {
         let resolved_schema = ResolvedTelemetrySchema {
-            file_format: "2.0.0".to_owned(),
+            file_format: "resolved/2.0".parse().unwrap(),
             schema_url: "https://example.com/schema".try_into().unwrap(),
             attribute_catalog: vec![],
             dependencies: std::collections::BTreeSet::new(),

--- a/crates/weaver_resolved_schema/Cargo.toml
+++ b/crates/weaver_resolved_schema/Cargo.toml
@@ -18,6 +18,7 @@ weaver_semconv = { path = "../weaver_semconv" }
 
 thiserror.workspace = true
 serde.workspace = true
+serde_yaml.workspace = true
 schemars.workspace = true
 log.workspace = true
 utoipa = { workspace = true, optional = true }

--- a/crates/weaver_resolved_schema/allowed-external-types.toml
+++ b/crates/weaver_resolved_schema/allowed-external-types.toml
@@ -5,6 +5,7 @@
 allowed_external_types = [
     "serde_core::ser::Serialize",
     "serde_core::de::Deserialize",
+    "serde_yaml::value::Value",
     "weaver_common::*",
     "weaver_semconv::*",
     "weaver_version::*",

--- a/crates/weaver_resolved_schema/src/lib.rs
+++ b/crates/weaver_resolved_schema/src/lib.rs
@@ -12,6 +12,7 @@ use crate::registry::{Group, Registry};
 use crate::resource::Resource;
 use serde::Serialize;
 use std::collections::{BTreeSet, HashMap};
+use weaver_common::file_format::FileFormat;
 use weaver_semconv::deprecated::Deprecated;
 use weaver_semconv::group::GroupType;
 use weaver_semconv::manifest::RegistryManifest;
@@ -38,10 +39,10 @@ pub use error::Error;
 /// This ID is reserved and should not be used by any other registry.
 pub const OTEL_REGISTRY_ID: &str = "OTEL";
 
-/// Version string denoting V1 resolved schema.
-pub(crate) const V1_RESOLVED_FILE_FORMAT: &str = "resolved/1.0";
-/// Version string denoting V2 resolved schema.
-pub(crate) const V2_RESOLVED_FILE_FORMAT: &str = "resolved/2.0";
+/// V1 resolved schema file format.
+pub const V1_RESOLVED_FILE_FORMAT: FileFormat = FileFormat::new("resolved", 1, 0);
+/// V2 resolved schema file format supported by this build.
+pub const V2_RESOLVED_FILE_FORMAT: FileFormat = FileFormat::new("resolved", 2, 0);
 
 /// A Resolved Telemetry Schema.
 /// A Resolved Telemetry Schema is self-contained and doesn't contain any
@@ -49,7 +50,7 @@ pub(crate) const V2_RESOLVED_FILE_FORMAT: &str = "resolved/2.0";
 #[derive(Debug, Clone)]
 pub struct ResolvedTelemetrySchema {
     /// Version of the file structure.
-    pub file_format: String,
+    pub file_format: FileFormat,
     /// Schema URL that this file is published at.
     pub schema_url: String,
     /// The ID of the registry that this schema belongs to.
@@ -91,7 +92,7 @@ impl ResolvedTelemetrySchema {
     /// Create a new resolved telemetry schema.
     pub fn new<S: AsRef<str>>(schema_url: S, registry_id: S, registry_url: S) -> Self {
         Self {
-            file_format: V1_RESOLVED_FILE_FORMAT.to_owned(),
+            file_format: V1_RESOLVED_FILE_FORMAT.clone(),
             schema_url: schema_url.as_ref().to_owned(),
             registry_id: registry_id.as_ref().to_owned(),
             registry: Registry::new(registry_url),

--- a/crates/weaver_resolved_schema/src/v2/attribute.rs
+++ b/crates/weaver_resolved_schema/src/v2/attribute.rs
@@ -14,8 +14,8 @@ use crate::v2::{provenance::Provenance, Signal};
 /// The definition of an Attribute.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Hash, Eq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
+#[schemars(deny_unknown_fields)]
 pub struct Attribute {
     /// String that uniquely identifies the attribute.
     pub key: String,

--- a/crates/weaver_resolved_schema/src/v2/attribute_group.rs
+++ b/crates/weaver_resolved_schema/src/v2/attribute_group.rs
@@ -42,7 +42,7 @@ pub struct AttributeGroup {
 /// group-specific requirement level refinement.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct AttributeGroupAttributeRef {
     /// Reference, by index, to the attribute catalog.
     pub base: AttributeRef,

--- a/crates/weaver_resolved_schema/src/v2/attribute_group.rs
+++ b/crates/weaver_resolved_schema/src/v2/attribute_group.rs
@@ -19,8 +19,8 @@ use crate::v2::{attribute::AttributeRef, provenance::Provenance, Signal};
 /// the bundle as a group to different signals.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
+#[schemars(deny_unknown_fields)]
 pub struct AttributeGroup {
     /// The name of the attribute group, must be unique.
     pub id: SignalId,

--- a/crates/weaver_resolved_schema/src/v2/entity.rs
+++ b/crates/weaver_resolved_schema/src/v2/entity.rs
@@ -13,7 +13,7 @@ use crate::v2::{attribute::AttributeRef, provenance::Provenance, Signal};
 /// The definition of an Entity signal.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct Entity {
     /// The type of the Entity.
     pub r#type: SignalId,
@@ -42,7 +42,7 @@ pub struct Entity {
 /// A special type of reference to attributes that remembers entity-specicific information.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct EntityAttributeRef {
     /// Reference, by index, to the attribute catalog.
     pub base: AttributeRef,

--- a/crates/weaver_resolved_schema/src/v2/event.rs
+++ b/crates/weaver_resolved_schema/src/v2/event.rs
@@ -14,7 +14,7 @@ use crate::v2::{attribute::AttributeRef, provenance::Provenance, Signal};
 /// The definition of an Event signal.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct Event {
     /// The name of the event.
     pub name: SignalId,
@@ -50,7 +50,7 @@ pub struct Event {
 /// A special type of reference to attributes that remembers event-specicific information.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct EventAttributeRef {
     /// Reference, by index, to the attribute catalog.
     pub base: AttributeRef,

--- a/crates/weaver_resolved_schema/src/v2/metric.rs
+++ b/crates/weaver_resolved_schema/src/v2/metric.rs
@@ -14,7 +14,7 @@ use weaver_semconv::{
 /// The definition of a metric signal.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct Metric {
     /// The name of the metric.
     pub name: SignalId,
@@ -57,7 +57,7 @@ pub struct Metric {
 /// A special type of reference to attributes that remembers metric-specicific information.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct MetricAttributeRef {
     /// Reference, by index, to the attribute catalog.
     pub base: AttributeRef,

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -84,6 +84,12 @@ struct ResolvedTelemetrySchemaRaw {
     dependencies: BTreeSet<SchemaUrl>,
 }
 
+/// Keep [`ResolvedTelemetrySchemaRaw`] in sync with [`ResolvedTelemetrySchema`] — same
+/// fields AND same serde attributes. Two tests guard against drift: this `From` impl
+/// fails to compile if a field is added to one struct but not the other, and
+/// `mirror_serializes_identically_to_public_schema` fails if their serde attributes diverge.
+/// When adding a new field here, add it to mirror_serializes_identically_to_public_schema 
+/// with non-default values
 impl From<ResolvedTelemetrySchemaRaw> for ResolvedTelemetrySchema {
     fn from(raw: ResolvedTelemetrySchemaRaw) -> Self {
         Self {
@@ -1593,6 +1599,62 @@ mod tests {
             },
             dependencies: BTreeSet::new(),
         }
+    }
+
+    /// A valid schema with the top-level non-required field (`dependencies`) populated.
+    ///
+    /// Only ResolvedTelemetrySchema's own top-level fields can drift from the mirror:
+    /// every nested type (Attribute, Registry, Deprecated, ...) is the same Rust type in
+    /// both structs and serializes identically, so nested fields need not be populated
+    /// here. When you add a non-required field directly to ResolvedTelemetrySchema, set
+    /// it here too so the two structs keep serializing identically, i.e. the shape check
+    /// validates against is the same shape weaver reads and writes.
+    fn populated_schema_yaml() -> serde_yaml::Value {
+        yaml(
+            r#"
+file_format: resolved/2.0
+schema_url: http://test/schemas/1.0
+attribute_catalog: []
+registry:
+  attributes: []
+  attribute_groups: []
+  spans: []
+  metrics: []
+  events: []
+  entities: []
+refinements:
+  spans: []
+  metrics: []
+  events: []
+dependencies:
+- http://dependency/url/1.0.0
+"#,
+        )
+    }
+
+    /// `ResolvedTelemetrySchemaRaw` is a hand-maintained deserialize mirror of
+    /// `ResolvedTelemetrySchema`. A missing *field* is caught at compile time by the
+    /// exhaustive `From<ResolvedTelemetrySchemaRaw>` impl, but a diverging serde
+    /// attribute (`default`, `skip_serializing_if`, `rename`, ...) is not — and
+    /// `unexpected_fields::check` diffs the raw YAML against the *mirror's*
+    /// serialization, so such drift breaks typo detection. This guards
+    /// the invariant that both types serialize identically.
+    #[test]
+    fn mirror_serializes_identically_to_public_schema() {
+        let value = populated_schema_yaml();
+        let public = ResolvedTelemetrySchema::from_yaml_value(
+            value.clone(),
+            std::path::Path::new("test.yaml"),
+        )
+        .expect("populated schema should load");
+        let mirror: ResolvedTelemetrySchemaRaw =
+            serde_yaml::from_value(value).expect("populated schema should deserialize into mirror");
+        assert_eq!(
+            serde_yaml::to_value(&public).expect("serialize public"),
+            serde_yaml::to_value(&mirror).expect("serialize mirror"),
+            "ResolvedTelemetrySchemaRaw drifted from ResolvedTelemetrySchema: their \
+             fields and serde attributes must stay identical"
+        );
     }
 
     fn yaml(s: &str) -> serde_yaml::Value {

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -88,7 +88,7 @@ struct ResolvedTelemetrySchemaRaw {
 /// fields AND same serde attributes. Two tests guard against drift: this `From` impl
 /// fails to compile if a field is added to one struct but not the other, and
 /// `mirror_serializes_identically_to_public_schema` fails if their serde attributes diverge.
-/// When adding a new field here, add it to mirror_serializes_identically_to_public_schema 
+/// When adding a new field here, add it to mirror_serializes_identically_to_public_schema
 /// with non-default values
 impl From<ResolvedTelemetrySchemaRaw> for ResolvedTelemetrySchema {
     fn from(raw: ResolvedTelemetrySchemaRaw) -> Self {
@@ -116,13 +116,14 @@ impl ResolvedTelemetrySchema {
         raw: serde_yaml::Value,
         path: &std::path::Path,
     ) -> Result<Self, weaver_semconv::Error> {
-        let raw_schema: ResolvedTelemetrySchemaRaw =
-            serde_yaml::from_value(raw.clone()).map_err(|e| {
-                weaver_semconv::Error::DeserializationError {
-                    path_or_url: path.display().to_string(),
-                    error: format!("Unable to read resolved schema: {e}"),
-                }
-            })?;
+        // Deserialize by reference so `raw` stays available for the unknown-field
+        // check below without cloning the whole tree.
+        let raw_schema = ResolvedTelemetrySchemaRaw::deserialize(&raw).map_err(|e| {
+            weaver_semconv::Error::DeserializationError {
+                path_or_url: path.display().to_string(),
+                error: format!("Unable to read resolved schema: {e}"),
+            }
+        })?;
 
         weaver_semconv::unexpected_fields::check(
             &raw,

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use weaver_common::file_format::FileFormat;
 use weaver_semconv::{
     deprecated::Deprecated,
     group::GroupType,
@@ -45,14 +46,16 @@ pub mod stats;
 /// A Resolved Telemetry Schema.
 /// A Resolved Telemetry Schema is self-contained and doesn't contain any
 /// external references to other schemas or semantic conventions.
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct ResolvedTelemetrySchema {
-    /// Version of the file structure.
-    /// Always `"resolved/2.0"` in this version.
-    #[schemars(extend("const" = "resolved/2.0"))]
-    pub file_format: String,
+    /// File-format version of the form `prefix/MAJOR.MINOR`. Always `resolved/2.0`
+    /// for this schema. A different prefix or a different major version (in either
+    /// direction) is rejected; newer minor versions are tolerated for forward
+    /// compatibility (unknown fields are ignored, with a warning).
+    #[schemars(with = "String", extend("const" = "resolved/2.0"))]
+    pub file_format: FileFormat,
     /// Schema URL that this file is published at.
     pub schema_url: SchemaUrl,
     /// Catalog of attributes. Note: this will include duplicates for the same key.
@@ -66,7 +69,65 @@ pub struct ResolvedTelemetrySchema {
     pub dependencies: BTreeSet<SchemaUrl>,
 }
 
+/// Private deserialization mirror for [`ResolvedTelemetrySchema`]. Mirrors all fields
+/// so [`ResolvedTelemetrySchema::from_yaml_value`] can route serde through this struct,
+/// keeping the public type non-`Deserialize`. Also `Serialize` so
+/// [`weaver_semconv::unexpected_fields::check`] can round-trip it for the unknown-field diff.
+#[derive(Deserialize, Serialize)]
+struct ResolvedTelemetrySchemaRaw {
+    file_format: FileFormat,
+    schema_url: SchemaUrl,
+    attribute_catalog: Vec<Attribute>,
+    registry: Registry,
+    refinements: Refinements,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    dependencies: BTreeSet<SchemaUrl>,
+}
+
+impl From<ResolvedTelemetrySchemaRaw> for ResolvedTelemetrySchema {
+    fn from(raw: ResolvedTelemetrySchemaRaw) -> Self {
+        Self {
+            file_format: raw.file_format,
+            schema_url: raw.schema_url,
+            attribute_catalog: raw.attribute_catalog,
+            registry: raw.registry,
+            refinements: raw.refinements,
+            dependencies: raw.dependencies,
+        }
+    }
+}
+
 impl ResolvedTelemetrySchema {
+    /// Parse a [`ResolvedTelemetrySchema`] from a raw YAML value, validating its
+    /// `file_format` against [`V2_RESOLVED_FILE_FORMAT`].
+    ///
+    /// Mirrors `RawManifestFields::into_manifest` in `weaver_semconv`: deserializes via
+    /// the private `ResolvedTelemetrySchemaRaw` mirror, then [`weaver_semconv::unexpected_fields::check`]
+    /// validates the declared file format and rejects unknown fields when the minor
+    /// version is known/past (typo protection). Newer-minor versions tolerate unknowns
+    /// for forward compatibility (a warning is logged).
+    pub fn from_yaml_value(
+        raw: serde_yaml::Value,
+        path: &std::path::Path,
+    ) -> Result<Self, weaver_semconv::Error> {
+        let raw_schema: ResolvedTelemetrySchemaRaw =
+            serde_yaml::from_value(raw.clone()).map_err(|e| {
+                weaver_semconv::Error::DeserializationError {
+                    path_or_url: path.display().to_string(),
+                    error: format!("Unable to read resolved schema: {e}"),
+                }
+            })?;
+
+        weaver_semconv::unexpected_fields::check(
+            &raw,
+            &raw_schema,
+            &V2_RESOLVED_FILE_FORMAT,
+            &raw_schema.file_format,
+            path,
+        )?;
+        Ok(raw_schema.into())
+    }
+
     /// Statistics about this schema.
     pub fn stats(&self) -> Stats {
         Stats {
@@ -143,7 +204,7 @@ impl TryFrom<crate::ResolvedTelemetrySchema> for ResolvedTelemetrySchema {
                 })?;
 
         Ok(ResolvedTelemetrySchema {
-            file_format: V2_RESOLVED_FILE_FORMAT.to_owned(),
+            file_format: V2_RESOLVED_FILE_FORMAT.clone(),
             schema_url,
             attribute_catalog,
             registry,
@@ -671,9 +732,12 @@ fn diff_signals_by_hash<T: Signal>(
 mod tests {
 
     use crate::v2::attribute::{Attribute as AttributeV2, AttributeRef};
-    use crate::v2::event::Event;
+    use crate::v2::entity::EntityAttributeRef;
+    use crate::v2::event::{Event, EventAttributeRef};
+    use crate::v2::span::SpanAttributeRef;
     use crate::V1_RESOLVED_FILE_FORMAT;
     use crate::{attribute::Attribute, lineage::GroupLineage, registry::Group};
+    use weaver_semconv::v2::span::SpanName;
     use weaver_semconv::{provenance::Provenance, stability::Stability};
 
     use crate::lineage::AttributeLineage;
@@ -1261,7 +1325,7 @@ mod tests {
         let _ = dependencies.insert("http://dependency/url/1.0.0".try_into().unwrap());
 
         let v1_schema = crate::ResolvedTelemetrySchema {
-            file_format: V1_RESOLVED_FILE_FORMAT.to_owned(),
+            file_format: V1_RESOLVED_FILE_FORMAT.clone(),
             schema_url: "http://test/schemas/1.0.0".to_owned(),
             registry_id: "my-registry".to_owned(),
             catalog: crate::catalog::Catalog::default(),
@@ -1507,7 +1571,7 @@ mod tests {
     // create an empty schema for testing.
     fn empty_v2_schema() -> ResolvedTelemetrySchema {
         ResolvedTelemetrySchema {
-            file_format: V2_RESOLVED_FILE_FORMAT.to_owned(),
+            file_format: V2_RESOLVED_FILE_FORMAT.clone(),
             schema_url: "http://test/schemas/1.0"
                 .try_into()
                 .expect("Should be valid schema url"),
@@ -1527,5 +1591,450 @@ mod tests {
             },
             dependencies: BTreeSet::new(),
         }
+    }
+
+    fn yaml(s: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(s).expect("valid yaml")
+    }
+
+    #[test]
+    fn from_yaml_value_reports_deserialization_error_with_path() {
+        // `attribute_catalog` is typed as Vec<Attribute>, so a string here should
+        // fail at serde stage and surface as DeserializationError carrying the path.
+        let raw = yaml(
+            r#"
+file_format: resolved/2.0
+schema_url: http://test/schemas/1.0
+attribute_catalog: "not a list"
+registry:
+  attributes: []
+  attribute_groups: []
+  spans: []
+  metrics: []
+  events: []
+  entities: []
+refinements:
+  spans: []
+  metrics: []
+  events: []
+"#,
+        );
+        let err =
+            ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("schema.yaml"))
+                .expect_err("should fail to deserialize");
+        match err {
+            weaver_semconv::Error::DeserializationError { path_or_url, error } => {
+                assert_eq!(path_or_url, "schema.yaml");
+                assert!(
+                    error.contains("Unable to read resolved schema"),
+                    "error message missing context: {error}"
+                );
+            }
+            _ => panic!("expected DeserializationError, got: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn from_yaml_value_rejects_unknown_top_level_field() {
+        let raw = yaml(
+            r#"
+file_format: resolved/2.0
+schema_url: http://test/schemas/1.0
+attribute_catalog: []
+registry:
+  attributes: []
+  attribute_groups: []
+  spans: []
+  metrics: []
+  events: []
+  entities: []
+refinements:
+  spans: []
+  metrics: []
+  events: []
+unexpected_top: true
+"#,
+        );
+        let err = ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("test.yaml"))
+            .expect_err("should reject unknown field");
+        match err {
+            weaver_semconv::Error::UnexpectedFields {
+                fields,
+                file_format,
+                ..
+            } => {
+                assert_eq!(file_format.to_string(), "resolved/2.0");
+                assert_eq!(fields, vec!["unexpected_top".to_owned()]);
+            }
+            _ => panic!("expected UnexpectedFields, got: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn from_yaml_value_rejects_unknown_nested_field() {
+        let raw = yaml(
+            r#"
+file_format: resolved/2.0
+schema_url: http://test/schemas/1.0
+attribute_catalog: []
+registry:
+  attributes: []
+  attribute_groups: []
+  spans: []
+  metrics: []
+  events: []
+  entities: []
+  bogus_registry_field: 42
+refinements:
+  spans: []
+  metrics: []
+  events: []
+"#,
+        );
+        let err = ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("test.yaml"))
+            .expect_err("should reject unknown nested field");
+        match err {
+            weaver_semconv::Error::UnexpectedFields {
+                fields,
+                file_format,
+                ..
+            } => {
+                assert_eq!(file_format.to_string(), "resolved/2.0");
+                assert_eq!(fields, vec!["registry.bogus_registry_field".to_owned()]);
+            }
+            _ => panic!("expected UnexpectedFields, got: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn from_yaml_value_tolerates_unknown_on_newer_minor() {
+        let raw = yaml(
+            r#"
+file_format: resolved/2.99
+schema_url: http://test/schemas/1.0
+attribute_catalog: []
+registry:
+  attributes: []
+  attribute_groups: []
+  spans: []
+  metrics: []
+  events: []
+  entities: []
+refinements:
+  spans: []
+  metrics: []
+  events: []
+unexpected_top: true
+"#,
+        );
+        let _ = ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("test.yaml"))
+            .expect("newer minor should tolerate unknowns");
+    }
+
+    #[test]
+    fn from_yaml_value_tolerates_explicit_default_values_on_skip_serializing_if_fields() {
+        // Fields like `Span.attributes` use `#[serde(skip_serializing_if = "Vec::is_empty")]`,
+        // so an empty Vec is dropped on re-serialize. A user that writes the default value
+        // explicitly (e.g. `attributes: []`, `entity_associations: []`, `sampling_relevant: null`)
+        // should NOT trigger a false-positive unknown-field error.
+        let raw = yaml(
+            r#"
+file_format: resolved/2.0
+schema_url: http://test/schemas/1.0
+attribute_catalog: []
+registry:
+  attributes: []
+  attribute_groups: []
+  spans:
+    - type: test.span
+      kind: client
+      name: { note: x }
+      brief: A test span.
+      stability: stable
+      attributes: []
+      entity_associations: []
+  metrics: []
+  events: []
+  entities: []
+refinements:
+  spans: []
+  metrics: []
+  events: []
+"#,
+        );
+        let _ = ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("test.yaml"))
+            .expect("explicit default values should not be flagged as unknown");
+    }
+
+    #[test]
+    fn from_yaml_value_rejects_incompatible_major() {
+        let raw = yaml(
+            r#"
+file_format: resolved/3.0
+schema_url: http://test/schemas/1.0
+attribute_catalog: []
+registry:
+  attributes: []
+  attribute_groups: []
+  spans: []
+  metrics: []
+  events: []
+  entities: []
+refinements:
+  spans: []
+  metrics: []
+  events: []
+"#,
+        );
+        let err = ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("test.yaml"))
+            .expect_err("should reject incompatible major");
+        assert!(matches!(
+            err,
+            weaver_semconv::Error::VirtualDirectoryError(
+                weaver_common::Error::IncompatibleFileFormatMajorVersion { .. }
+            )
+        ));
+    }
+
+    /// Builds a minimal resolved schema with one signal of each kind, where the
+    /// requested per-signal `attribute_ref_extra` YAML snippet is injected into
+    /// the named ref site. `file_format` controls whether unknowns should be
+    /// tolerated (e.g. `resolved/2.99`) or rejected (e.g. `resolved/2.0`).
+    ///
+    /// `ref_site` selects which ref site is exercised; the others are left empty.
+    fn yaml_with_attr_ref_unknown(file_format: &str, ref_site: &str) -> serde_yaml::Value {
+        let unknown = "future_attr_ref_field: some_value";
+        let mut span_attrs = String::from("attributes: []");
+        let mut metric_attrs = String::from("attributes: []");
+        let mut event_attrs = String::from("attributes: []");
+        let mut entity_identity = String::from("identity: []");
+        let mut entity_description = String::from("description: []");
+        let attr_ref_with_unknown = format!(
+            "attributes:\n      - base: 0\n        requirement_level: required\n        {unknown}"
+        );
+        let identity_ref_with_unknown = format!(
+            "identity:\n      - base: 0\n        requirement_level: required\n        {unknown}"
+        );
+        let description_ref_with_unknown = format!(
+            "description:\n      - base: 0\n        requirement_level: required\n        {unknown}"
+        );
+        match ref_site {
+            "span" => span_attrs = attr_ref_with_unknown,
+            "metric" => metric_attrs = attr_ref_with_unknown,
+            "event" => event_attrs = attr_ref_with_unknown,
+            "entity_identity" => entity_identity = identity_ref_with_unknown,
+            "entity_description" => {
+                // identity must be non-empty per schema, so seed it with a clean ref
+                entity_identity =
+                    String::from("identity:\n      - base: 0\n        requirement_level: required");
+                entity_description = description_ref_with_unknown;
+            }
+            other => panic!("unknown ref_site: {other}"),
+        }
+        let s = format!(
+            r#"
+file_format: {file_format}
+schema_url: http://test/schemas/1.0
+attribute_catalog:
+- key: test.attr
+  type: string
+  brief: ""
+  stability: stable
+registry:
+  attributes: [0]
+  attribute_groups: []
+  spans:
+  - type: test.span
+    kind: client
+    name:
+      note: a name
+    brief: ""
+    stability: stable
+    note: ""
+    {span_attrs}
+  metrics:
+  - name: test.metric
+    instrument: counter
+    unit: "1"
+    brief: ""
+    stability: stable
+    note: ""
+    {metric_attrs}
+  events:
+  - name: test.event
+    brief: ""
+    stability: stable
+    note: ""
+    {event_attrs}
+  entities:
+  - type: test.entity
+    brief: ""
+    stability: stable
+    note: ""
+    {entity_identity}
+    {entity_description}
+refinements:
+  spans: []
+  metrics: []
+  events: []
+"#
+        );
+        yaml(&s)
+    }
+
+    // ---- Tolerance on a future minor: deserialize must succeed for every ----
+    // ---- attribute-ref site across all signal kinds. ----
+
+    #[test]
+    fn future_minor_tolerates_unknown_on_span_attribute_ref() {
+        let raw = yaml_with_attr_ref_unknown("resolved/2.99", "span");
+        let _ = ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("test.yaml"))
+            .expect("future minor should tolerate unknown on span attribute ref");
+    }
+
+    #[test]
+    fn future_minor_tolerates_unknown_on_metric_attribute_ref() {
+        let raw = yaml_with_attr_ref_unknown("resolved/2.99", "metric");
+        let _ = ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("test.yaml"))
+            .expect("future minor should tolerate unknown on metric attribute ref");
+    }
+
+    #[test]
+    fn future_minor_tolerates_unknown_on_event_attribute_ref() {
+        let raw = yaml_with_attr_ref_unknown("resolved/2.99", "event");
+        let _ = ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("test.yaml"))
+            .expect("future minor should tolerate unknown on event attribute ref");
+    }
+
+    #[test]
+    fn future_minor_tolerates_unknown_on_entity_identity_attribute_ref() {
+        let raw = yaml_with_attr_ref_unknown("resolved/2.99", "entity_identity");
+        let _ = ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("test.yaml"))
+            .expect("future minor should tolerate unknown on entity identity ref");
+    }
+
+    #[test]
+    fn future_minor_tolerates_unknown_on_entity_description_attribute_ref() {
+        let raw = yaml_with_attr_ref_unknown("resolved/2.99", "entity_description");
+        let _ = ResolvedTelemetrySchema::from_yaml_value(raw, std::path::Path::new("test.yaml"))
+            .expect("future minor should tolerate unknown on entity description ref");
+    }
+
+    // ---- Rejection on a current minor: an unknown field in any attribute-ref ----
+    // ---- site must be reported by `from_yaml_value`. ----
+
+    fn assert_rejects_unknown_with_path(ref_site: &str, expected_path_fragment: &str) {
+        let raw = yaml_with_attr_ref_unknown("resolved/2.0", ref_site);
+        let expected = format!("{expected_path_fragment}.future_attr_ref_field");
+        match ResolvedTelemetrySchema::from_yaml_value(
+            raw.clone(),
+            std::path::Path::new("test.yaml"),
+        ) {
+            Ok(_) => {
+                panic!(
+                    "current minor should reject unknown field on {ref_site}; \
+                     parsed successfully. Expected an error mentioning '{expected}'."
+                );
+            }
+            Err(weaver_semconv::Error::UnexpectedFields {
+                fields,
+                file_format,
+                ..
+            }) => {
+                assert_eq!(
+                    file_format.to_string(),
+                    "resolved/2.0",
+                    "ref_site={ref_site}"
+                );
+                assert_eq!(
+                    fields,
+                    vec![expected.clone()],
+                    "ref_site={ref_site}: expected exactly one unknown field"
+                );
+            }
+            Err(err) => {
+                panic!("expected UnexpectedFields for {ref_site}, got: {err:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn current_minor_rejects_unknown_on_span_attribute_ref() {
+        assert_rejects_unknown_with_path("span", "registry.spans[0].attributes[0]");
+    }
+
+    #[test]
+    fn current_minor_rejects_unknown_on_metric_attribute_ref() {
+        assert_rejects_unknown_with_path("metric", "registry.metrics[0].attributes[0]");
+    }
+
+    #[test]
+    fn current_minor_rejects_unknown_on_event_attribute_ref() {
+        assert_rejects_unknown_with_path("event", "registry.events[0].attributes[0]");
+    }
+
+    #[test]
+    fn current_minor_rejects_unknown_on_entity_identity_attribute_ref() {
+        assert_rejects_unknown_with_path("entity_identity", "registry.entities[0].identity[0]");
+    }
+
+    #[test]
+    fn current_minor_rejects_unknown_on_entity_description_attribute_ref() {
+        assert_rejects_unknown_with_path(
+            "entity_description",
+            "registry.entities[0].description[0]",
+        );
+    }
+
+    // ---- Struct-level unknown-field tolerance: raw serde checks that each ----
+    // ---- signal type accepts unknown keys at deserialize time, independent ----
+    // ---- of the version-aware loader. These guard against accidentally adding ----
+    // ---- `#[serde(deny_unknown_fields)]` to a type, which would break forward ----
+    // ---- compatibility with newer-minor schemas. ----
+
+    #[test]
+    fn attribute_tolerates_unknown_fields() {
+        let yaml =
+            "key: test.attr\ntype: string\nbrief: A test.\nstability: stable\nfuture_field: value";
+        let result: Result<AttributeV2, _> = serde_yaml::from_str(yaml);
+        assert!(
+            result.is_ok(),
+            "Attribute should tolerate unknown fields for vNext compat, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn span_name_tolerates_unknown_fields() {
+        // SpanName is a weaver_semconv type reused in resolved schema.
+        // A vNext resolved schema may add fields to the name object.
+        let yaml = "note: 'test span'\nfuture_name_field: value";
+        let result: Result<SpanName, _> = serde_yaml::from_str(yaml);
+        assert!(
+            result.is_ok(),
+            "SpanName should tolerate unknown fields for vNext compat, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn span_attribute_ref_tolerates_unknown_fields() {
+        let yaml = "base: 0\nrequirement_level: required\nfuture_field: value";
+        let _ =
+            serde_yaml::from_str::<SpanAttributeRef>(yaml).expect("should tolerate unknown fields");
+    }
+
+    #[test]
+    fn event_attribute_ref_tolerates_unknown_fields() {
+        let yaml = "base: 0\nrequirement_level: required\nfuture_field: value";
+        let _ = serde_yaml::from_str::<EventAttributeRef>(yaml)
+            .expect("should tolerate unknown fields");
+    }
+
+    #[test]
+    fn entity_attribute_ref_tolerates_unknown_fields() {
+        let yaml = "base: 0\nrequirement_level: required\nfuture_field: value";
+        let _ = serde_yaml::from_str::<EntityAttributeRef>(yaml)
+            .expect("should tolerate unknown fields");
     }
 }

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -124,6 +124,7 @@ impl ResolvedTelemetrySchema {
             &V2_RESOLVED_FILE_FORMAT,
             &raw_schema.file_format,
             path,
+            &[],
         )?;
         Ok(raw_schema.into())
     }
@@ -732,6 +733,7 @@ fn diff_signals_by_hash<T: Signal>(
 mod tests {
 
     use crate::v2::attribute::{Attribute as AttributeV2, AttributeRef};
+    use crate::v2::attribute_group::AttributeGroupAttributeRef;
     use crate::v2::entity::EntityAttributeRef;
     use crate::v2::event::{Event, EventAttributeRef};
     use crate::v2::span::SpanAttributeRef;
@@ -2035,6 +2037,13 @@ refinements:
     fn entity_attribute_ref_tolerates_unknown_fields() {
         let yaml = "base: 0\nrequirement_level: required\nfuture_field: value";
         let _ = serde_yaml::from_str::<EntityAttributeRef>(yaml)
+            .expect("should tolerate unknown fields");
+    }
+
+    #[test]
+    fn attribute_group_attribute_ref_tolerates_unknown_fields() {
+        let yaml = "base: 0\nrequirement_level: required\nfuture_field: value";
+        let _ = serde_yaml::from_str::<AttributeGroupAttributeRef>(yaml)
             .expect("should tolerate unknown fields");
     }
 }

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -84,7 +84,7 @@ struct ResolvedTelemetrySchemaRaw {
     dependencies: BTreeSet<SchemaUrl>,
 }
 
-/// Keep [`ResolvedTelemetrySchemaRaw`] in sync with [`ResolvedTelemetrySchema`] — same
+/// Keep `ResolvedTelemetrySchemaRaw` in sync with [`ResolvedTelemetrySchema`] — same
 /// fields AND same serde attributes. Two tests guard against drift: this `From` impl
 /// fails to compile if a field is added to one struct but not the other, and
 /// `mirror_serializes_identically_to_public_schema` fails if their serde attributes diverge.

--- a/crates/weaver_resolved_schema/src/v2/refinements.rs
+++ b/crates/weaver_resolved_schema/src/v2/refinements.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 ///       provide optimised methods for generating telemetry signals.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct Refinements {
     /// A  list of span refinements.
     pub spans: Vec<SpanRefinement>,

--- a/crates/weaver_resolved_schema/src/v2/registry.rs
+++ b/crates/weaver_resolved_schema/src/v2/registry.rs
@@ -28,7 +28,7 @@ use crate::v2::{
 /// Note: The registry does not include signal refinements.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct Registry {
     /// Catalog of attributes definitions.
     pub attributes: Vec<AttributeRef>,

--- a/crates/weaver_resolved_schema/src/v2/span.rs
+++ b/crates/weaver_resolved_schema/src/v2/span.rs
@@ -15,7 +15,7 @@ use crate::v2::{attribute::AttributeRef, provenance::Provenance, Signal};
 /// The definition of a Span signal.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct Span {
     /// The type of the Span. This denotes the identity
     /// of the "shape" of this span, and must be unique.
@@ -56,7 +56,7 @@ pub struct Span {
 /// A special type of reference to attributes that remembers span-specicific information.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 pub struct SpanAttributeRef {
     /// Reference, by index, to the attribute catalog.
     pub base: AttributeRef,

--- a/crates/weaver_resolver/data/registry-test-manifest-unknown-field/published/manifest.yaml
+++ b/crates/weaver_resolver/data/registry-test-manifest-unknown-field/published/manifest.yaml
@@ -1,0 +1,21 @@
+# Typo-protection fixture for the manifest itself at a known minor: declares
+# `manifest/2.0` and carries unknown fields at two levels — top-level (`not`)
+# and inside a dependency entry (`dependencies[0].not`). `RegistryRepo::try_new`
+# must reject this with `UnexpectedFields` listing both paths *before* the
+# resolved schema is even loaded, so the schema here is otherwise clean.
+#
+# Used by:
+#   weaver_resolver::loader::tests::test_manifest_unknown_field_in_current_version_fails
+#     (crates/weaver_resolver/src/loader.rs)
+file_format: manifest/2.0
+stability: stable
+schema_url: https://opentelemetry.io/schemas/1.0.0
+resolved_schema_uri: resolved_schema.yaml
+description: Test repository whose manifest contains an unknown field at a known minor.
+# mistyped 'note', but also it's not defined at the manifest level
+not: some value
+dependencies:
+  - schema_url: https://example.com/registry/schemas/1.0.0
+    registry_path: data/registry-test-v2-dep/published
+    # mistyped 'note', but also it's not defined at the manifest level
+    not: "some value"

--- a/crates/weaver_resolver/data/registry-test-manifest-unknown-field/published/resolved_schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-manifest-unknown-field/published/resolved_schema.yaml
@@ -1,0 +1,9 @@
+file_format: resolved/2.0
+schema_url: https://opentelemetry.io/schemas/1.0.0
+attribute_catalog:
+- key: server.port
+  type: int
+  brief: Server port number.
+  stability: stable
+registry:
+  attributes: [0]

--- a/crates/weaver_resolver/data/registry-test-resolved-major-mismatch/published/manifest.yaml
+++ b/crates/weaver_resolver/data/registry-test-resolved-major-mismatch/published/manifest.yaml
@@ -1,0 +1,12 @@
+# Major-version incompatibility fixture: the manifest is on `manifest/2.0` but
+# the referenced resolved schema declares `resolved/99.0`. Loading must fail
+# fatally with `IncompatibleFileFormatMajorVersion`.
+#
+# Used by:
+#   weaver_resolver::loader::tests::test_resolved_schema_major_version_mismatch_fails
+#     (crates/weaver_resolver/src/loader.rs)
+file_format: manifest/2.0
+stability: stable
+schema_url: https://opentelemetry.io/schemas/1.0.0
+resolved_schema_uri: resolved_schema.yaml
+description: Test repository with resolved schema using a mismatched major version.

--- a/crates/weaver_resolver/data/registry-test-resolved-major-mismatch/published/resolved_schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-resolved-major-mismatch/published/resolved_schema.yaml
@@ -1,0 +1,18 @@
+file_format: resolved/99.0
+schema_url: https://opentelemetry.io/schemas/1.0.0
+attribute_catalog:
+- key: server.port
+  type: int
+  brief: Server port number.
+  stability: stable
+registry:
+  attributes: [0]
+  attribute_groups: []
+  spans: []
+  metrics: []
+  events: []
+  entities: []
+refinements:
+  spans: []
+  metrics: []
+  events: []

--- a/crates/weaver_resolver/data/registry-test-resolved-minor-ahead/published/manifest.yaml
+++ b/crates/weaver_resolver/data/registry-test-resolved-minor-ahead/published/manifest.yaml
@@ -1,0 +1,17 @@
+# Forward-compatibility fixture: future minor (`manifest/2.9999`, `resolved/2.9999`)
+# with unknown fields sprinkled across every level of both files. Loading must
+# succeed and silently tolerate the unknowns.
+#
+# Used by:
+#   weaver_resolver::loader::tests::test_resolved_schema_minor_version_ahead_succeeds
+#     (crates/weaver_resolver/src/loader.rs)
+file_format: manifest/2.9999
+stability: stable
+schema_url: https://opentelemetry.io/schemas/1.0.0
+resolved_schema_uri: resolved_schema.yaml
+description: Test repository with resolved schema using a future minor version.
+future_top_level_field: "some new top-level string"
+dependencies:
+  - schema_url: https://example.com/registry/schemas/1.0.0
+    registry_path: data/registry-test-v2-dep/published
+    future_dependency_field: "some new dependency field"

--- a/crates/weaver_resolver/data/registry-test-resolved-minor-ahead/published/resolved_schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-resolved-minor-ahead/published/resolved_schema.yaml
@@ -1,0 +1,141 @@
+file_format: resolved/2.9999
+schema_url: https://opentelemetry.io/schemas/1.0.0
+future_top_level_field: "some new top-level string"
+attribute_catalog:
+- key: server.port
+  type: int
+  brief: Server port number.
+  stability: stable
+  future_attribute_field: "new per-attribute string"
+- key: http.request.method
+  type: string
+  brief: HTTP request method.
+  stability: stable
+  deprecated:
+    reason: obsoleted
+    note: a note
+    future_deprecated_field: "new per-attribute deprecated string"
+# Enum-typed attribute with a future field on a member entry.
+- key: db.system.name
+  type:
+    members:
+    - id: postgres
+      value: postgres
+      brief: PostgreSQL
+      stability: stable
+      future_member_field: 123
+    - id: mysql
+      value: mysql
+      brief: MySQL
+      stability: stable
+  brief: Database system.
+  stability: stable
+# Renamed deprecation variant with a future sibling.
+- key: legacy.attr.renamed
+  type: string
+  brief: A legacy attribute that has been renamed.
+  stability: stable
+  deprecated:
+    reason: renamed
+    renamed_to: new.attr.name
+    future_renamed_field: "some value"
+# Uncategorized deprecation variant with a future sibling.
+- key: legacy.attr.uncategorized
+  type: string
+  brief: A legacy attribute deprecated for uncategorized reasons.
+  stability: stable
+  deprecated:
+    reason: uncategorized
+    note: deprecated for complex reasons
+    future_uncategorized_field: "new per-attribute uncategorized string"
+registry:
+  attributes: [0, 1]
+  attribute_groups:
+  - id: server.attrs
+    brief: Server attribute group.
+    stability: stable
+    note: ""
+    attributes: [0, 1]
+    future_group_map:
+      flag: true
+      extra_data: [1, 2, 3]
+  spans:
+  - type: server.request
+    kind: server
+    name:
+      note: The name of the server request.
+      future_name_field: "future name field value"
+    brief: Incoming server request.
+    stability: stable
+    attributes:
+    - base: 0
+      requirement_level: required
+      future_ref_in_span: "future span attribute ref string"
+    future_span_array: [a, b, c]
+  metrics:
+  - name: server.request.duration
+    instrument: histogram
+    unit: s
+    brief: Server request duration.
+    stability: stable
+    note: ""
+    attributes:
+    - base: 0
+      requirement_level: required
+      future_attr_ref_field: some_value
+    future_metric_field:
+      config:
+        buckets: [0.1, 0.5, 1.0]
+  events:
+  - name: server.error
+    brief: A server error event.
+    stability: development
+    note: ""
+    attributes:
+    # Exercises the complex (single-key map) variant of RequirementLevel with
+    # an extra future field — must be tolerated as forward-compat.
+    - base: 0
+      requirement_level:
+        conditionally_required: "some condition"
+        future_req_level_field: "future requirement level string"
+    future_event_field: 99
+  entities:
+  - type: server.entity
+    brief: A server entity.
+    stability: stable
+    note: ""
+    identity:
+    - base: 0
+      requirement_level: required
+      future_ref_in_entity_identity: "future entity identity ref string"
+    future_entity_field: {k: v}
+refinements:
+  spans:
+  - id: server.request
+    type: server.request
+    kind: server
+    name:
+      note: The name of the server request.
+    brief: Incoming server request.
+    stability: stable
+    note: ""
+    attributes: []
+    future_span_ref_field: true
+  metrics:
+  - id: server.request.duration
+    name: server.request.duration
+    instrument: histogram
+    unit: s
+    brief: Server request duration.
+    stability: stable
+    note: ""
+    attributes: []
+    future_metric_ref_list: [x, y]
+  # Events refinements with a future field (existing fixture had `events: []`).
+  events:
+  - id: server.error
+    name: server.error
+    brief: Refinement of the server error event.
+    stability: development
+    attributes: []
+    future_event_refinement_field: "future event refinement string"

--- a/crates/weaver_resolver/data/registry-test-resolved-minor-ahead/published/resolved_schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-resolved-minor-ahead/published/resolved_schema.yaml
@@ -55,7 +55,12 @@ registry:
     brief: Server attribute group.
     stability: stable
     note: ""
-    attributes: [0, 1]
+    attributes:
+    - base: 0
+      requirement_level: recommended
+    - base: 1
+      requirement_level: recommended
+      future_attr_group_ref_field: "unknown on an attribute-group attribute ref"
     future_group_map:
       flag: true
       extra_data: [1, 2, 3]
@@ -71,6 +76,9 @@ registry:
     - base: 0
       requirement_level: required
       future_ref_in_span: "future span attribute ref string"
+    # Present so `Provenance` is instantiated somewhere in this fixture — the
+    # injection test can only cover types the fixture actually builds.
+    provenance: {}
     future_span_array: [a, b, c]
   metrics:
   - name: server.request.duration

--- a/crates/weaver_resolver/data/registry-test-resolved-unknown-field/published/manifest.yaml
+++ b/crates/weaver_resolver/data/registry-test-resolved-unknown-field/published/manifest.yaml
@@ -1,0 +1,18 @@
+# Typo-protection fixture for the resolved schema at a known minor: the
+# manifest itself is clean, but the referenced `resolved_schema.yaml` declares
+# `resolved/2.0` and seeds typos (mostly `not` for `note`) at every level —
+# top-level, attribute catalog, deprecated, attribute group, span name, span,
+# metric, metric attribute-ref, event, entity, span/metric refinements.
+# Loading must fail fatally with `UnexpectedFields` listing every reportable
+# typo. Note: `not: ""` entries are intentionally suppressed by the walker's
+# default-equivalent guard (empty string round-trips like a `skip_serializing_if`
+# field), so only typos with non-default values appear in the reported list.
+#
+# Used by:
+#   weaver_resolver::loader::tests::test_resolved_schema_unknown_field_in_current_version_fails
+#     (crates/weaver_resolver/src/loader.rs)
+file_format: manifest/2.0
+stability: stable
+schema_url: https://opentelemetry.io/schemas/1.0.0
+resolved_schema_uri: resolved_schema.yaml
+description: Test repository with resolved schema containing misspelled fields at every level.

--- a/crates/weaver_resolver/data/registry-test-resolved-unknown-field/published/resolved_schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-resolved-unknown-field/published/resolved_schema.yaml
@@ -1,0 +1,165 @@
+# Mirrors `registry-test-resolved-minor-ahead/.../resolved_schema.yaml` in
+# structure but declares `resolved/2.0` (the current/known minor), so every
+# unknown field below must be flagged by the unknown-field walker. The
+# companion test asserts the EXACT set of dotted paths reported, so any
+# structural change here must be reflected in the test's expected list.
+#
+# Note: a value that round-trips as a "default" (null, empty string, empty
+# seq, empty map) is intentionally suppressed by the walker as a false-positive
+# guard for `skip_serializing_if` fields. So every unknown below uses a
+# non-default value.
+#
+# Used by:
+#   weaver_resolver::loader::tests::test_resolved_schema_unknown_field_in_current_version_fails
+#     (crates/weaver_resolver/src/loader.rs)
+file_format: resolved/2.0
+schema_url: https://opentelemetry.io/schemas/1.0.0
+# misspelled 'note' at the top level, but also it's not defined at this level
+not: "some new top-level string"
+attribute_catalog:
+- key: server.port
+  type: int
+  brief: Server port number.
+  stability: stable
+  # misspelled 'note'
+  not: "new per-attribute string"
+- key: http.request.method
+  type: string
+  brief: HTTP request method.
+  stability: stable
+  deprecated:
+    reason: obsoleted
+    note: a note
+    # misspelled 'note' alongside the legit field — `Deprecated::Obsoleted.note`
+    # is required, so removing the real one breaks deserialize before the
+    # unknown-field walker runs.
+    not: a note
+# Enum-typed attribute with a typo on a member entry.
+- key: db.system.name
+  type:
+    members:
+    - id: postgres
+      value: postgres
+      brief: PostgreSQL
+      stability: stable
+      # misspelled 'note'
+      not: "non-default member typo"
+    - id: mysql
+      value: mysql
+      brief: MySQL
+      stability: stable
+  brief: Database system.
+  stability: stable
+# Renamed deprecation variant
+- key: legacy.attr.renamed
+  type: string
+  brief: A legacy attribute that has been renamed.
+  stability: stable
+  deprecated:
+    reason: renamed
+    renamed_to: new.attr.name
+    # misspelled 'note' alongside the legit fields
+    not: "non-default renamed typo"
+# Uncategorized deprecation variant — same shape as Renamed.
+- key: legacy.attr.uncategorized
+  type: string
+  brief: A legacy attribute deprecated for uncategorized reasons.
+  stability: stable
+  deprecated:
+    reason: uncategorized
+    note: deprecated for complex reasons
+    # some non-existing field
+    does_not_exist: "a value"
+registry:
+  attributes: [0, 1]
+  attribute_groups:
+  - id: server.attrs
+    brief: Server attribute group.
+    stability: stable
+    # misspelled 'note'
+    not: ""
+    attributes: [0, 1]
+  spans:
+  - type: server.request
+    kind: server
+    name:
+      note: The name of the server request.
+      # some random error
+      does_not_exist: "a value"
+    brief: Incoming server request.
+    stability: stable
+    # `not` is a typo of `note` — typical real-world misspelling.
+    not: "this is a note"
+    attributes:
+    # Typo on a span attribute-ref entry.
+    - base: 0
+      requirement_level: required
+      not: "non-default span attribute ref typo"
+  metrics:
+  - name: server.request.duration
+    instrument: histogram
+    unit: s
+    brief: Server request duration.
+    stability: stable
+    # misspelled 'note'
+    not: ""
+    attributes:
+    - base: 0
+      requirement_level: required
+      # misspelled 'note', also isn't supported here
+      not: some_value
+  events:
+  - name: server.error
+    brief: A server error event.
+    stability: development
+    # misspelled 'note'
+    not: ""
+    attributes:
+    - base: 0
+      requirement_level:
+        conditionally_required: "when error.recoverable is false"
+        # misspelled 'not', also isn't supported here
+        not: "non-default complex requirement_level typo"
+      not: "non-default event attribute ref typo"
+  entities:
+  - type: server.entity
+    brief: A server entity.
+    stability: stable
+    # misspelled 'note'
+    not: ""
+    identity:
+    # EntityAttributeRef typo on identity[].
+    - base: 0
+      requirement_level: required
+      not: "non-default entity identity ref typo"
+refinements:
+  spans:
+  - id: server.request
+    type: server.request
+    kind: server
+    name:
+      note: The name of the server request.
+    brief: Incoming server request.
+    stability: stable
+    # misspelled 'note'
+    not: ""
+    attributes: []
+  metrics:
+  - id: server.request.duration
+    name: server.request.duration
+    instrument: histogram
+    unit: s
+    brief: Server request duration.
+    stability: stable
+    # misspelled 'note'
+    not: ""
+    attributes: []
+  # Events refinement with a typo (existing fixture had `events: []`).
+  events:
+  - id: server.error
+    name: server.error
+    brief: Refinement of the server error event.
+    stability: development
+    # misspelled 'note'
+    not: "non-default event refinement typo"
+    attributes: []

--- a/crates/weaver_resolver/data/registry-test-resolved-unknown-field/published/resolved_schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-resolved-unknown-field/published/resolved_schema.yaml
@@ -78,7 +78,13 @@ registry:
     stability: stable
     # misspelled 'note'
     not: ""
-    attributes: [0, 1]
+    attributes:
+    - base: 0
+      requirement_level: recommended
+    # Typo on an attribute-group attribute-ref entry.
+    - base: 1
+      requirement_level: recommended
+      not: "non-default attribute group attribute ref typo"
   spans:
   - type: server.request
     kind: server

--- a/crates/weaver_resolver/src/attribute.rs
+++ b/crates/weaver_resolver/src/attribute.rs
@@ -804,7 +804,7 @@ mod tests {
         };
 
         let schema1 = V2Schema {
-            file_format: "resolved/2.0".to_owned(),
+            file_format: "resolved/2.0".parse().unwrap(),
             schema_url: "http://test/schema/1.0.0".try_into().unwrap(),
             attribute_catalog: vec![attr1.clone()],
             registry: weaver_resolved_schema::v2::registry::Registry {
@@ -824,7 +824,7 @@ mod tests {
         };
 
         let schema2 = V2Schema {
-            file_format: "resolved/2.0".to_owned(),
+            file_format: "resolved/2.0".parse().unwrap(),
             schema_url: "http://test/schema/2.0.0".try_into().unwrap(),
             attribute_catalog: vec![attr1.clone()],
             registry: weaver_resolved_schema::v2::registry::Registry {
@@ -888,7 +888,7 @@ mod tests {
         _ = root_attributes.insert(attr_name.to_owned(), (attr_v1.clone(), "group1".to_owned()));
 
         let schema_v1 = V1Schema {
-            file_format: "resolved/1.0".to_owned(),
+            file_format: "resolved/1.0".parse().unwrap(),
             schema_url: "http://test/schema/1.0.0".to_owned(),
             registry_id: "test-registry".to_owned(),
             registry: weaver_resolved_schema::registry::Registry {
@@ -913,7 +913,7 @@ mod tests {
         };
 
         let schema_v2 = V2Schema {
-            file_format: "resolved/2.0".to_owned(),
+            file_format: "resolved/2.0".parse().unwrap(),
             schema_url: "http://test/schema/2.0.0".try_into().unwrap(),
             attribute_catalog: vec![attr_v2],
             registry: weaver_resolved_schema::v2::registry::Registry {
@@ -979,7 +979,7 @@ mod tests {
             provenance: Default::default(),
         };
         V2Schema {
-            file_format: "resolved/2.0".to_owned(),
+            file_format: "resolved/2.0".parse().unwrap(),
             schema_url: url.try_into().expect("valid url"),
             attribute_catalog: vec![attr],
             registry: weaver_resolved_schema::v2::registry::Registry {

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -1287,7 +1287,7 @@ mod tests {
 
     fn example_v1_schema() -> V1Schema {
         V1Schema {
-            file_format: "resolved/1.0.0".to_owned(),
+            file_format: "resolved/1.0".parse().unwrap(),
             schema_url: "http://test/schemas/1.0.0".to_owned(),
             registry_id: "test-registry".to_owned(),
             registry: weaver_resolved_schema::registry::Registry {
@@ -1379,7 +1379,7 @@ mod tests {
 
     fn example_v2_schema() -> weaver_resolved_schema::v2::ResolvedTelemetrySchema {
         weaver_resolved_schema::v2::ResolvedTelemetrySchema {
-            file_format: "resolved/2.0".to_owned(),
+            file_format: "resolved/2.0".parse().unwrap(),
             schema_url: "http://test/schemas/2.0.0".try_into().unwrap(),
             registry: weaver_resolved_schema::v2::registry::Registry {
                 attribute_groups: vec![

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use weaver_common::http_auth::HttpAuthResolver;
 use weaver_common::result::WResult;
 use weaver_resolved_schema::v2::ResolvedTelemetrySchema as V2Schema;
-use weaver_resolved_schema::ResolvedTelemetrySchema;
+use weaver_resolved_schema::{ResolvedTelemetrySchema, V1_RESOLVED_FILE_FORMAT};
 use weaver_semconv::group::ImportsWithProvenance;
 use weaver_semconv::registry_repo::RegistryRepo;
 use weaver_semconv::schema_url::SchemaUrl;
@@ -400,7 +400,7 @@ impl WeaverResolver {
             &lookup_ctx,
         )
         .map(move |resolved_registry| ResolvedTelemetrySchema {
-            file_format: "1.0.0".to_owned(),
+            file_format: V1_RESOLVED_FILE_FORMAT.clone(),
             schema_url: schema_url.as_str().to_owned(),
             registry_id: schema_url.name().to_owned(),
             registry: resolved_registry,
@@ -879,8 +879,11 @@ mod tests {
 
         let expected_yaml = std::fs::read_to_string(format!("{test_dir}/expected-schema.yaml"))
             .expect("Failed to read expected schema");
-        let expected_schema: weaver_resolved_schema::v2::ResolvedTelemetrySchema =
-            serde_yaml::from_str(&expected_yaml).expect("Failed to deserialize expected schema");
+        let expected_schema = weaver_resolved_schema::v2::ResolvedTelemetrySchema::from_yaml_value(
+            serde_yaml::from_str(&expected_yaml).expect("Failed to parse expected schema"),
+            std::path::Path::new(&format!("{test_dir}/expected-schema.yaml")),
+        )
+        .expect("Failed to deserialize expected schema");
 
         assert_eq!(
             serde_json::to_value(&observed_schema).unwrap(),
@@ -1667,7 +1670,7 @@ groups:
         let url_base_v1_1 = SchemaUrl::try_from("https://example.com/base/1.1.0").unwrap();
 
         let base_v1_0 = ResolvedDependency::V1(Box::new(ResolvedTelemetrySchema {
-            file_format: "resolved/1.0".to_owned(),
+            file_format: "resolved/1.0".parse().unwrap(),
             schema_url: "https://example.com/base/1.0.0".to_owned(),
             registry_id: "base".to_owned(),
             registry: weaver_resolved_schema::registry::Registry {
@@ -1683,7 +1686,7 @@ groups:
         }));
 
         let base_v1_1 = ResolvedDependency::V1(Box::new(ResolvedTelemetrySchema {
-            file_format: "resolved/1.0".to_owned(),
+            file_format: "resolved/1.0".parse().unwrap(),
             schema_url: "https://example.com/base/1.1.0".to_owned(),
             registry_id: "base".to_owned(),
             registry: weaver_resolved_schema::registry::Registry {
@@ -1699,7 +1702,7 @@ groups:
         }));
 
         let layer1_a = ResolvedDependency::V1(Box::new(ResolvedTelemetrySchema {
-            file_format: "resolved/1.0".to_owned(),
+            file_format: "resolved/1.0".parse().unwrap(),
             schema_url: "https://example.com/layer1_a/0.1.0".to_owned(),
             registry_id: "layer1_a".to_owned(),
             registry: weaver_resolved_schema::registry::Registry {
@@ -1715,7 +1718,7 @@ groups:
         }));
 
         let layer1_b = ResolvedDependency::V1(Box::new(ResolvedTelemetrySchema {
-            file_format: "resolved/1.0".to_owned(),
+            file_format: "resolved/1.0".parse().unwrap(),
             schema_url: "https://example.com/layer1_b/0.1.0".to_owned(),
             registry_id: "layer1_b".to_owned(),
             registry: weaver_resolved_schema::registry::Registry {
@@ -1757,7 +1760,7 @@ groups:
 
         // Create an empty schema for c/1.2.0 where `c.removed_attr` does not exist.
         let schema_v1_2 = Arc::new(WeaverResolvedSchema::V1(ResolvedTelemetrySchema {
-            file_format: "resolved/1.0".to_owned(),
+            file_format: "resolved/1.0".parse().unwrap(),
             schema_url: "https://example.com/c/1.2.0".to_owned(),
             registry_id: "c".to_owned(),
             registry: weaver_resolved_schema::registry::Registry {

--- a/crates/weaver_resolver/src/loader.rs
+++ b/crates/weaver_resolver/src/loader.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
-use std::collections::HashSet;
 use rayon::iter::ParallelIterator;
 use rayon::iter::{IntoParallelIterator, ParallelBridge};
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::path::MAIN_SEPARATOR;
 use weaver_common::http_auth::HttpAuthResolver;
@@ -657,7 +657,11 @@ mod tests {
             path: "data/registry-test-resolved-minor-ahead/published".to_owned(),
         };
         let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
-        let result = load_semconv_repository(registry_repo, false, &weaver_common::http_auth::HttpAuthResolver::empty());
+        let result = load_semconv_repository(
+            registry_repo,
+            false,
+            &weaver_common::http_auth::HttpAuthResolver::empty(),
+        );
         match result {
             WResult::Ok(LoadedSemconvRegistry::ResolvedV2(_)) => {}
             WResult::OkWithNFEs(LoadedSemconvRegistry::ResolvedV2(_), _) => {}
@@ -666,13 +670,125 @@ mod tests {
         Ok(())
     }
 
+    /// Collects the path of every mapping node in `value`, as a list of steps
+    /// that [`insert_at`] can replay.
+    fn mapping_paths(value: &serde_yaml::Value, path: Vec<Step>, out: &mut Vec<Vec<Step>>) {
+        match value {
+            serde_yaml::Value::Mapping(map) => {
+                out.push(path.clone());
+                for (key, val) in map {
+                    if let Some(key) = key.as_str() {
+                        let mut sub = path.clone();
+                        sub.push(Step::Key(key.to_owned()));
+                        mapping_paths(val, sub, out);
+                    }
+                }
+            }
+            serde_yaml::Value::Sequence(seq) => {
+                for (i, val) in seq.iter().enumerate() {
+                    let mut sub = path.clone();
+                    sub.push(Step::Index(i));
+                    mapping_paths(val, sub, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    enum Step {
+        Key(String),
+        Index(usize),
+    }
+
+    fn render_path(path: &[Step]) -> String {
+        if path.is_empty() {
+            return "<root>".to_owned();
+        }
+        path.iter()
+            .map(|step| match step {
+                Step::Key(k) => format!(".{k}"),
+                Step::Index(i) => format!("[{i}]"),
+            })
+            .collect()
+    }
+
+    /// Inserts `key: value` into the mapping at `path`.
+    fn insert_at(root: &mut serde_yaml::Value, path: &[Step], key: &str) {
+        let mut node = root;
+        for step in path {
+            node = match (step, node) {
+                (Step::Key(k), serde_yaml::Value::Mapping(map)) => map
+                    .get_mut(serde_yaml::Value::String(k.clone()))
+                    .expect("path was collected from this tree"),
+                (Step::Index(i), serde_yaml::Value::Sequence(seq)) => {
+                    seq.get_mut(*i).expect("path was collected from this tree")
+                }
+                _ => panic!("path does not match tree shape"),
+            };
+        }
+        let serde_yaml::Value::Mapping(map) = node else {
+            panic!("path does not point at a mapping");
+        };
+        let _ = map.insert(
+            serde_yaml::Value::String(key.to_owned()),
+            serde_yaml::Value::String("injected".to_owned()),
+        );
+    }
+
+    /// Forward compatibility must hold at *every* level of a resolved schema, not
+    /// just the levels a fixture happens to seed with a `future_*` key. This walks
+    /// the minor-ahead fixture and injects an unknown key into each mapping node in
+    /// turn, asserting the schema still parses.
+    ///
+    /// A failure here means some type on the resolved-schema path carries
+    /// `#[serde(deny_unknown_fields)]`. Use `#[schemars(deny_unknown_fields)]`
+    /// instead: it keeps the published JSON schema strict while leaving the
+    /// deserializer tolerant of fields added by a newer minor version.
+    #[test]
+    fn resolved_schema_tolerates_an_unknown_field_at_every_level() {
+        let path = std::path::Path::new(
+            "data/registry-test-resolved-minor-ahead/published/resolved_schema.yaml",
+        );
+        let raw: serde_yaml::Value = serde_yaml::from_str(
+            &std::fs::read_to_string(path).expect("fixture should be readable"),
+        )
+        .expect("fixture should parse as YAML");
+
+        let mut paths = Vec::new();
+        mapping_paths(&raw, Vec::new(), &mut paths);
+        assert!(
+            paths.len() > 20,
+            "fixture got thin ({} mapping nodes) — it should exercise every signal kind",
+            paths.len()
+        );
+
+        for node in &paths {
+            let mut mutated = raw.clone();
+            insert_at(&mut mutated, node, "injected_unknown_field");
+            if let Err(err) = crate::loader::V2Schema::from_yaml_value(mutated, path) {
+                panic!(
+                    "unknown field at `{}` was rejected: {err}\n\
+                     The type at this path denies unknown fields, which breaks forward \
+                     compatibility with newer minor versions. Replace \
+                     `#[serde(deny_unknown_fields)]` with `#[schemars(deny_unknown_fields)]`.",
+                    render_path(node)
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_resolved_schema_major_version_mismatch_fails() -> Result<(), Error> {
         let registry_path = VirtualDirectoryPath::LocalFolder {
             path: "data/registry-test-resolved-major-mismatch/published".to_owned(),
         };
         let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
-        let result = load_semconv_repository(registry_repo, false, &weaver_common::http_auth::HttpAuthResolver::empty());
+        let result = load_semconv_repository(
+            registry_repo,
+            false,
+            &weaver_common::http_auth::HttpAuthResolver::empty(),
+        );
         match result {
             WResult::FatalErr(err) => {
                 let msg = err.to_string();
@@ -692,7 +808,11 @@ mod tests {
             path: "data/registry-test-resolved-unknown-field/published".to_owned(),
         };
         let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
-        let result = load_semconv_repository(registry_repo, false, &weaver_common::http_auth::HttpAuthResolver::empty());
+        let result = load_semconv_repository(
+            registry_repo,
+            false,
+            &weaver_common::http_auth::HttpAuthResolver::empty(),
+        );
         // The fixture seeds typos at every recursable level. Only entries with
         // non-default-equivalent values are reported — the walker suppresses
         // null/""/[]/{} as a false-positive guard for `skip_serializing_if`
@@ -707,6 +827,7 @@ mod tests {
             // Typos on `Renamed` and `Uncategorized` deprecation variants.
             "attribute_catalog[3].deprecated.not",
             "attribute_catalog[4].deprecated.does_not_exist",
+            "registry.attribute_groups[0].attributes[1].not",
             "registry.spans[0].name.does_not_exist",
             "registry.spans[0].not",
             // Typos on attribute-ref entries inside each signal kind.

--- a/crates/weaver_resolver/src/loader.rs
+++ b/crates/weaver_resolver/src/loader.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;
+use std::collections::HashSet;
 use rayon::iter::ParallelIterator;
 use rayon::iter::{IntoParallelIterator, ParallelBridge};
 use std::fmt::Display;
@@ -178,7 +179,7 @@ pub(crate) fn load_semconv_repository_with_cache(
     auth: &HttpAuthResolver,
 ) -> WResult<LoadedSemconvRegistry, Error> {
     // This method simply sets up the resolution state and delegates to the actual work.
-    let mut visited_registries = std::collections::HashSet::new();
+    let mut visited_registries = HashSet::new();
     let mut chosen_versions = std::collections::HashMap::new();
     let mut dependency_chain = Vec::new();
 
@@ -235,7 +236,7 @@ fn load_semconv_repository_recursive(
     registry_repo: RegistryRepo,
     follow_symlinks: bool,
     max_dependency_depth: u32,
-    visited_registries: &mut std::collections::HashSet<String>,
+    visited_registries: &mut HashSet<String>,
     chosen_versions: &mut std::collections::HashMap<String, SchemaUrl>,
     dependency_chain: &mut Vec<String>,
     auth: &HttpAuthResolver,
@@ -397,9 +398,14 @@ fn load_resolved_repository(
     auth: &HttpAuthResolver,
 ) -> WResult<LoadedSemconvRegistry, Error> {
     // TODO - should we handle V1 and V2?
-    match from_vdir(path, auth) {
-        Ok(resolved) => WResult::Ok(LoadedSemconvRegistry::ResolvedV2(resolved)),
-        Err(err) => WResult::FatalErr(err),
+    let raw: serde_yaml::Value = match from_vdir(path, auth) {
+        Ok(v) => v,
+        Err(err) => return WResult::FatalErr(err),
+    };
+    let path_buf = std::path::PathBuf::from(path.to_string());
+    match V2Schema::from_yaml_value(raw, &path_buf) {
+        Ok(schema) => WResult::Ok(LoadedSemconvRegistry::ResolvedV2(schema)),
+        Err(err) => WResult::FatalErr(err.into()),
     }
 }
 
@@ -549,6 +555,7 @@ fn check_version_compatibility(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
 
     use weaver_common::{
         diagnostic::DiagnosticMessages, result::WResult, vdir::VirtualDirectoryPath,
@@ -614,7 +621,7 @@ mod tests {
         let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
 
         // Try with depth limit of 1 - should fail at acme->otel transition
-        let mut visited_registries = std::collections::HashSet::new();
+        let mut visited_registries = HashSet::new();
         let mut chosen_versions = std::collections::HashMap::new();
         let mut dependency_chain = Vec::new();
         let result = load_semconv_repository_recursive(
@@ -642,6 +649,133 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_resolved_schema_minor_version_ahead_succeeds() -> Result<(), Error> {
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/registry-test-resolved-minor-ahead/published".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let result = load_semconv_repository(registry_repo, false, &weaver_common::http_auth::HttpAuthResolver::empty());
+        match result {
+            WResult::Ok(LoadedSemconvRegistry::ResolvedV2(_)) => {}
+            WResult::OkWithNFEs(LoadedSemconvRegistry::ResolvedV2(_), _) => {}
+            _ => panic!("Expected ResolvedV2 success"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolved_schema_major_version_mismatch_fails() -> Result<(), Error> {
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/registry-test-resolved-major-mismatch/published".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let result = load_semconv_repository(registry_repo, false, &weaver_common::http_auth::HttpAuthResolver::empty());
+        match result {
+            WResult::FatalErr(err) => {
+                let msg = err.to_string();
+                assert!(
+                    msg.contains("Incompatible file_format"),
+                    "Expected major version error, got: {msg}"
+                );
+            }
+            _ => panic!("Expected fatal error for major version mismatch"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolved_schema_unknown_field_in_current_version_fails() -> Result<(), Error> {
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/registry-test-resolved-unknown-field/published".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let result = load_semconv_repository(registry_repo, false, &weaver_common::http_auth::HttpAuthResolver::empty());
+        // The fixture seeds typos at every recursable level. Only entries with
+        // non-default-equivalent values are reported — the walker suppresses
+        // null/""/[]/{} as a false-positive guard for `skip_serializing_if`
+        // fields, so the many `not: ""` entries in the fixture are intentionally
+        // *not* in this list.
+        let expected = [
+            "not",
+            "attribute_catalog[0].not",
+            "attribute_catalog[1].deprecated.not",
+            // Typo on an enum-typed attribute member entry.
+            "attribute_catalog[2].type.members[0].not",
+            // Typos on `Renamed` and `Uncategorized` deprecation variants.
+            "attribute_catalog[3].deprecated.not",
+            "attribute_catalog[4].deprecated.does_not_exist",
+            "registry.spans[0].name.does_not_exist",
+            "registry.spans[0].not",
+            // Typos on attribute-ref entries inside each signal kind.
+            "registry.spans[0].attributes[0].not",
+            "registry.metrics[0].attributes[0].not",
+            "registry.events[0].attributes[0].not",
+            // Typo on the complex single-key-map variant of RequirementLevel.
+            "registry.events[0].attributes[0].requirement_level.not",
+            "registry.entities[0].identity[0].not",
+            // Typo on an event refinement entry.
+            "refinements.events[0].not",
+        ];
+        match result {
+            WResult::FatalErr(Error::FailToResolveDefinition(
+                weaver_semconv::Error::UnexpectedFields {
+                    fields,
+                    file_format,
+                    ..
+                },
+            )) => {
+                assert_eq!(file_format.to_string(), "resolved/2.0");
+                let actual: HashSet<&str> = fields.iter().map(String::as_str).collect();
+                let expected_set: HashSet<&str> = expected.iter().copied().collect();
+                let missing: Vec<&&str> = expected_set.difference(&actual).collect();
+                let extra: Vec<&&str> = actual.difference(&expected_set).collect();
+                assert!(
+                    missing.is_empty() && extra.is_empty(),
+                    "Unexpected-field set mismatch.\n  missing: {missing:?}\n  extra:   {extra:?}\n  actual:  {fields:?}"
+                );
+            }
+            WResult::FatalErr(other) => {
+                panic!("Expected FailToResolveDefinition(UnexpectedFields), got fatal: {other}")
+            }
+            WResult::Ok(_) | WResult::OkWithNFEs(_, _) => {
+                panic!("Expected fatal error for unknown fields in current minor, got Ok")
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_manifest_unknown_field_in_current_version_fails() {
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/registry-test-manifest-unknown-field/published".to_owned(),
+        };
+        let err = RegistryRepo::try_new(None, &registry_path, &mut vec![])
+            .expect_err("expected manifest unknown-field rejection");
+        // The fixture seeds an unknown both at the top of the manifest and inside
+        // a dependency entry, so the walker must recurse into `dependencies[i]`
+        // and surface the nested typo too — not just the top-level one.
+        let expected = ["not", "dependencies[0].not"];
+        match err {
+            weaver_semconv::Error::UnexpectedFields {
+                fields,
+                file_format,
+                ..
+            } => {
+                assert_eq!(file_format.to_string(), "manifest/2.0");
+                let actual: HashSet<&str> = fields.iter().map(String::as_str).collect();
+                let expected_set: HashSet<&str> = expected.iter().copied().collect();
+                let missing: Vec<&&str> = expected_set.difference(&actual).collect();
+                let extra: Vec<&&str> = actual.difference(&expected_set).collect();
+                assert!(
+                    missing.is_empty() && extra.is_empty(),
+                    "Unexpected-field set mismatch.\n  missing: {missing:?}\n  extra:   {extra:?}\n  actual:  {fields:?}"
+                );
+            }
+            other => panic!("expected UnexpectedFields, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -1123,6 +1123,11 @@ mod tests {
             // "registry-test-v2-2-multifile",
             "registry-test-v2-dep",        // tested separately in lib.rs
             "registry-test-dep-exclusion", // multi-registry; tested separately in lib.rs
+            // These tests use published resolved schemas and are tested in loader.rs
+            "registry-test-resolved-minor-ahead",
+            "registry-test-resolved-major-mismatch",
+            "registry-test-resolved-unknown-field",
+            "registry-test-manifest-unknown-field",
         ];
         // Iterate over all directories in the data directory and
         // starting with registry-test-*
@@ -1257,11 +1262,16 @@ mod tests {
                     .expect("Failed to write observed output.");
 
                 // Check that the resolved registry matches the expected registry.
-                let expected_schema: ResolvedTelemetrySchema = serde_yaml::from_reader(
-                    std::fs::File::open(format!("{test_dir}/{EXPECTED_V2_SCHEMA_FILE}"))
-                        .expect("Failed to open expected schema"),
+                let expected_path = format!("{test_dir}/{EXPECTED_V2_SCHEMA_FILE}");
+                let expected_raw: serde_yaml::Value = serde_yaml::from_reader(
+                    std::fs::File::open(&expected_path).expect("Failed to open expected schema"),
                 )
-                .expect("Failed to deserialize expected schema");
+                .expect("Failed to parse expected schema as YAML");
+                let expected_schema = ResolvedTelemetrySchema::from_yaml_value(
+                    expected_raw,
+                    std::path::Path::new(&expected_path),
+                )
+                .expect("Failed to load expected schema");
 
                 assert_eq!(
                     to_json(&observed_schema),

--- a/crates/weaver_semconv/src/attribute.rs
+++ b/crates/weaver_semconv/src/attribute.rs
@@ -388,7 +388,6 @@ impl Display for TemplateTypeSpec {
     Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash, JsonSchema, PartialOrd, Ord,
 )]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[schemars(deny_unknown_fields)]
 #[serde(from = "EnumEntriesSpecDeserialize")]
 pub struct EnumEntriesSpec {
     /// String that uniquely identifies the enum entry.
@@ -423,7 +422,7 @@ pub struct EnumEntriesSpec {
 /// (including doc comments) so the generated JSON schema retains field
 /// descriptions when `#[serde(from = "...")]` redirects schema derivation here.
 #[derive(Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 struct EnumEntriesSpecDeserialize {
     /// String that uniquely identifies the enum entry.
     id: String,

--- a/crates/weaver_semconv/src/attribute.rs
+++ b/crates/weaver_semconv/src/attribute.rs
@@ -388,7 +388,7 @@ impl Display for TemplateTypeSpec {
     Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash, JsonSchema, PartialOrd, Ord,
 )]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
+#[schemars(deny_unknown_fields)]
 #[serde(from = "EnumEntriesSpecDeserialize")]
 pub struct EnumEntriesSpec {
     /// String that uniquely identifies the enum entry.

--- a/crates/weaver_semconv/src/deprecated.rs
+++ b/crates/weaver_semconv/src/deprecated.rs
@@ -101,11 +101,13 @@ where
                     "reason" => action = Some(map.next_value::<String>()?),
                     "renamed_to" => new_name = Some(map.next_value()?),
                     "note" => note = Some(map.next_value()?),
+                    // Silently drop unknowns so newer-minor schemas stay
+                    // forward-compatible. The outer-document parsers
+                    // (resolved schema, publication manifest) re-check raw
+                    // vs. round-tripped YAML via `unexpected_fields::check`
+                    // for known minors and surface these as typos there.
                     _ => {
-                        return Err(de::Error::unknown_field(
-                            &key,
-                            &["reason", "note", "renamed_to"],
-                        ))
+                        let _ = map.next_value::<de::IgnoredAny>()?;
                     }
                 }
             }

--- a/crates/weaver_semconv/src/lib.rs
+++ b/crates/weaver_semconv/src/lib.rs
@@ -11,6 +11,7 @@ use std::hash::Hasher;
 use std::path::PathBuf;
 use weaver_common::diagnostic::{DiagnosticMessage, DiagnosticMessages};
 use weaver_common::error::{format_errors, WeaverError};
+use weaver_common::file_format::FileFormat;
 
 pub mod any_value;
 pub mod attribute;
@@ -27,6 +28,7 @@ pub mod semconv;
 pub mod signal_requirement_level;
 pub mod stability;
 pub mod stats;
+pub mod unexpected_fields;
 pub mod v2;
 
 /// An error that can occur while loading a semantic convention registry.
@@ -398,6 +400,20 @@ pub enum Error {
         schema_url: String,
         /// The semver parsing error.
         err: String,
+    },
+
+    /// Unknown fields were encountered when parsing a file whose minor version
+    /// is known/past. Used for typo protection — newer minor versions tolerate
+    /// unknowns for forward compatibility.
+    #[error("Unexpected fields for {file_format} at {path_or_url:?}: {}", fields.join(", "))]
+    #[diagnostic(severity(Error))]
+    UnexpectedFields {
+        /// The path or URL of the file being parsed.
+        path_or_url: String,
+        /// The file format declaration (e.g. `resolved/2.0`) the unknowns were checked against.
+        file_format: FileFormat,
+        /// The dotted paths of fields not recognized by the typed schema.
+        fields: Vec<String>,
     },
 
     /// A container for multiple errors.

--- a/crates/weaver_semconv/src/manifest.rs
+++ b/crates/weaver_semconv/src/manifest.rs
@@ -20,10 +20,11 @@ use crate::Error::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
+use weaver_common::file_format::FileFormat;
 use weaver_common::vdir::VirtualDirectoryPath;
 
-/// The file format version of the publication manifest.
-pub const PUBLICATION_MANIFEST_FILE_FORMAT: &str = "manifest/2.0";
+/// The publication manifest file format supported by this build.
+pub const PUBLICATION_MANIFEST_FILE_FORMAT: FileFormat = FileFormat::new("manifest", 2, 0);
 
 /// Represents the definition manifest for a semantic convention registry.
 ///
@@ -148,7 +149,7 @@ impl<'de> Deserialize<'de> for Dependency {
 /// All fields are optional so we can decide on the variant first, then validate.
 #[derive(Deserialize)]
 struct RawManifestFields {
-    file_format: Option<String>,
+    file_format: Option<FileFormat>,
     schema_url: Option<SchemaUrl>,
     description: Option<String>,
     #[allow(deprecated)]
@@ -166,8 +167,13 @@ struct RawManifestFields {
 
 impl RawManifestFields {
     /// Convert to [`RegistryManifest`], reporting errors relative to `path`.
-    fn into_manifest(self, path: &std::path::Path) -> Result<RegistryManifest, Error> {
-        if self.file_format.as_deref() == Some(PUBLICATION_MANIFEST_FILE_FORMAT) {
+    /// `raw` is the original YAML tree, used for typo-protection on known minor versions.
+    fn into_manifest(
+        self,
+        path: &std::path::Path,
+        raw: &serde_yaml::Value,
+    ) -> Result<RegistryManifest, Error> {
+        if let Some(file_format) = self.file_format {
             let schema_url = self
                 .schema_url
                 .ok_or_else(|| Error::InvalidPublicationManifest {
@@ -192,25 +198,26 @@ impl RawManifestFields {
                     });
                 }
             };
-            Ok(RegistryManifest::Publication(PublicationRegistryManifest {
-                file_format: PUBLICATION_MANIFEST_FILE_FORMAT.to_owned(),
+            let manifest = PublicationRegistryManifest {
+                file_format,
                 schema_url,
                 description: self.description,
                 dependencies: self.dependencies,
                 stability: self.stability,
                 resolved_registry_uri,
                 deserialization_warnings: warnings,
-            }))
+            };
+            crate::unexpected_fields::check(
+                raw,
+                &manifest,
+                &PUBLICATION_MANIFEST_FILE_FORMAT,
+                &manifest.file_format,
+                path,
+            )?;
+            Ok(RegistryManifest::Publication(manifest))
         } else {
             let mut warnings = vec![];
-            if let Some(ref fmt) = self.file_format {
-                return Err(InvalidRegistryManifest {
-                    path: path.to_path_buf(),
-                    error: format!(
-                        "Unknown file_format '{fmt}'. Expected '{PUBLICATION_MANIFEST_FILE_FORMAT}' or no file_format for a definition manifest."
-                    ),
-                });
-            }
+            // file_format is absent — this is a definition manifest
             let schema_url = if let Some(url) = self.schema_url {
                 url
             } else {
@@ -276,17 +283,25 @@ impl RegistryManifest {
             });
         }
 
-        let file = std::fs::File::open(path).map_err(|e| InvalidRegistryManifest {
+        // Read once as text so we can deserialize twice — directly into the typed
+        // `RawManifestFields` (which leverages serde_yaml's type coercions, e.g.
+        // numeric `1.1` → `"1.1"` for a `String` field) AND into a `Value` tree
+        // for the unknown-field walker.
+        let yaml_str = std::fs::read_to_string(path).map_err(|e| InvalidRegistryManifest {
             path: manifest_path_buf.clone(),
             error: e.to_string(),
         })?;
-        let reader = std::io::BufReader::new(file);
-        let raw: RawManifestFields =
-            serde_yaml::from_reader(reader).map_err(|e| InvalidRegistryManifest {
+        let raw_fields: RawManifestFields =
+            serde_yaml::from_str(&yaml_str).map_err(|e| InvalidRegistryManifest {
                 path: manifest_path_buf.clone(),
                 error: e.to_string(),
             })?;
-        let manifest = raw.into_manifest(&manifest_path_buf)?;
+        let raw_value: serde_yaml::Value =
+            serde_yaml::from_str(&yaml_str).map_err(|e| InvalidRegistryManifest {
+                path: manifest_path_buf.clone(),
+                error: e.to_string(),
+            })?;
+        let manifest = raw_fields.into_manifest(&manifest_path_buf, &raw_value)?;
 
         // Check if this is a legacy manifest file
         let is_legacy = if let Some(file_name) = manifest_path_buf.file_name() {
@@ -355,10 +370,12 @@ impl RegistryManifest {
 /// registry artifact (`resolved.yaml`).
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 pub struct PublicationRegistryManifest {
-    /// The file format version of this publication manifest.
-    /// Always `"manifest/2.0"`in this version.
-    #[schemars(extend("const" = "manifest/2.0"))]
-    pub file_format: String,
+    /// File-format version of the form `prefix/MAJOR.MINOR`. Always `manifest/2.0`
+    /// for this schema. A different prefix or a different major version (in either
+    /// direction) is rejected; newer minor versions are tolerated for forward
+    /// compatibility (unknown fields are ignored, with a warning).
+    #[schemars(with = "String", extend("const" = "manifest/2.0"))]
+    pub file_format: FileFormat,
 
     /// The schema URL for this registry.
     /// Uniquely identifies the registry and its version.
@@ -393,7 +410,7 @@ impl PublicationRegistryManifest {
         resolved_registry_uri: String,
     ) -> Self {
         Self {
-            file_format: PUBLICATION_MANIFEST_FILE_FORMAT.to_owned(),
+            file_format: PUBLICATION_MANIFEST_FILE_FORMAT.clone(),
             schema_url: registry_manifest.schema_url.clone(),
             description: registry_manifest.description.clone(),
             dependencies: registry_manifest.dependencies.clone(),
@@ -632,10 +649,13 @@ registry_path: "./registry"
 
     #[test]
     fn test_unknown_file_format_is_rejected() {
+        // Wrong prefix but valid `prefix/MAJOR.MINOR` syntax: deserializes successfully,
+        // then `unexpected_fields::check` rejects it via `FileFormat::validate`.
         let result = manifest_from_yaml(
             r#"
-file_format: "garbage/1.0.0"
+file_format: "garbage/1.0"
 schema_url: "https://example.com/schemas/1.0.0"
+resolved_schema_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
 "#,
             &mut vec![],
         );
@@ -644,6 +664,19 @@ schema_url: "https://example.com/schemas/1.0.0"
             .unwrap_err()
             .to_string()
             .contains("Unknown file_format"));
+    }
+
+    #[test]
+    fn test_malformed_file_format_is_rejected() {
+        // Syntactically broken `prefix/MAJOR.MINOR`: rejected at deserialize by `FromStr`.
+        let result = manifest_from_yaml(
+            r#"
+file_format: "garbage/1.0.0"
+schema_url: "https://example.com/schemas/1.0.0"
+"#,
+            &mut vec![],
+        );
+        assert!(matches!(result, Err(InvalidRegistryManifest { .. })));
     }
 
     #[test]
@@ -680,6 +713,43 @@ resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
             matches!(manifest, RegistryManifest::Publication(_)),
             "expected Publication variant, got {manifest:?}"
         );
+    }
+
+    #[test]
+    fn test_publication_manifest_missing_resolved_registry_uri_is_rejected() {
+        // file_format selects the publication branch; resolved_registry_uri is required there.
+        let err = manifest_from_yaml(
+            r#"
+file_format: "manifest/2.0"
+schema_url: "https://example.com/schemas/1.0.0"
+"#,
+            &mut vec![],
+        )
+        .expect_err("missing resolved_registry_uri should be rejected");
+        match err {
+            Error::InvalidPublicationManifest { details, .. } => {
+                assert_eq!(details, "missing required field 'resolved_registry_uri'");
+            }
+            _ => panic!("expected InvalidPublicationManifest, got: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn test_publication_manifest_missing_schema_url_is_rejected() {
+        let err = manifest_from_yaml(
+            r#"
+file_format: "manifest/2.0"
+resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
+"#,
+            &mut vec![],
+        )
+        .expect_err("missing schema_url should be rejected");
+        match err {
+            Error::InvalidPublicationManifest { details, .. } => {
+                assert_eq!(details, "missing required field 'schema_url'");
+            }
+            _ => panic!("expected InvalidPublicationManifest, got: {err:?}"),
+        }
     }
 }
 
@@ -803,6 +873,50 @@ resolved_schema_uri: "https://example.com/resolved/old.yaml"
         );
     }
 
+    #[test]
+    fn test_manifest_minor_version_ahead_succeeds() {
+        // A manifest with file_format "manifest/2.99" should parse successfully,
+        // treating unknown fields as forward-compatible additions.
+        let result = manifest_from_yaml(
+            r#"
+schema_url: "https://example.com/schemas/1.0.0"
+file_format: "manifest/2.99"
+resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
+future_field: "this field does not exist in 2.0"
+"#,
+            &mut vec![],
+        );
+        assert!(
+            result.is_ok(),
+            "Expected Ok for manifest/2.99 with unknown field, got: {result:?}"
+        );
+        let manifest = result.unwrap();
+        assert!(
+            matches!(manifest, RegistryManifest::Publication(_)),
+            "expected Publication variant, got {manifest:?}"
+        );
+    }
+
+    #[test]
+    fn test_manifest_major_version_mismatch_fails() {
+        // A manifest with file_format "manifest/99.0" should fail with a major-version error.
+        let result = manifest_from_yaml(
+            r#"
+schema_url: "https://example.com/schemas/1.0.0"
+file_format: "manifest/99.0"
+resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
+"#,
+            &mut vec![],
+        );
+        assert!(result.is_err(), "Expected Err for manifest/99.0, got Ok");
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Incompatible file_format"),
+            "Expected major version error message, got: {msg}"
+        );
+    }
+
     /// A publication manifest that omits both the new and deprecated names
     /// is rejected with `InvalidPublicationManifest`.
     #[test]
@@ -819,5 +933,57 @@ schema_url: "https://example.com/schemas/1.0.0"
             Err(Error::InvalidPublicationManifest { details, .. })
                 if details.contains("resolved_registry_uri")
         ));
+    }
+
+    #[test]
+    fn test_manifest_known_minor_rejects_unknown_top_level_field() {
+        let result = manifest_from_yaml(
+            r#"
+file_format: "manifest/2.0"
+schema_url: "https://example.com/schemas/1.0.0"
+resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
+typo_field: "not in schema"
+"#,
+            &mut vec![],
+        );
+        let err = result.expect_err("expected unknown-field rejection");
+        match err {
+            Error::UnexpectedFields {
+                fields,
+                file_format,
+                ..
+            } => {
+                assert_eq!(file_format.to_string(), "manifest/2.0");
+                assert_eq!(fields, vec!["typo_field".to_owned()]);
+            }
+            _ => panic!("expected UnexpectedFields, got: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn test_manifest_known_minor_rejects_unknown_field_in_dependency() {
+        let result = manifest_from_yaml(
+            r#"
+file_format: "manifest/2.0"
+schema_url: "https://example.com/schemas/1.0.0"
+resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
+dependencies:
+  - schema_url: "https://example.com/dep/1.0.0"
+    bogus_field: 42
+"#,
+            &mut vec![],
+        );
+        let err = result.expect_err("expected unknown-field rejection in dependency");
+        match err {
+            Error::UnexpectedFields {
+                fields,
+                file_format,
+                ..
+            } => {
+                assert_eq!(file_format.to_string(), "manifest/2.0");
+                assert_eq!(fields, vec!["dependencies[0].bogus_field".to_owned()]);
+            }
+            _ => panic!("expected UnexpectedFields, got: {err:?}"),
+        }
     }
 }

--- a/crates/weaver_semconv/src/manifest.rs
+++ b/crates/weaver_semconv/src/manifest.rs
@@ -289,9 +289,9 @@ impl RegistryManifest {
         }
 
         // Read once as text so we can deserialize twice — directly into the typed
-        // `RawManifestFields` (which leverages serde_yaml's type coercions, e.g.
-        // numeric `1.1` → `"1.1"` for a `String` field) AND into a `Value` tree
-        // for the unknown-field walker.
+        // `RawManifestFields` (which leverages serde_yaml's type coercions, e.g. a
+        // YAML numeric `semconv_version: 1.1` coerced to the `String` `"1.1"`) AND
+        // into a `Value` tree for the unknown-field walker.
         let yaml_str = std::fs::read_to_string(path).map_err(|e| InvalidRegistryManifest {
             path: manifest_path_buf.clone(),
             error: e.to_string(),

--- a/crates/weaver_semconv/src/manifest.rs
+++ b/crates/weaver_semconv/src/manifest.rs
@@ -26,6 +26,10 @@ use weaver_common::vdir::VirtualDirectoryPath;
 /// The publication manifest file format supported by this build.
 pub const PUBLICATION_MANIFEST_FILE_FORMAT: FileFormat = FileFormat::new("manifest", 2, 0);
 
+/// Keys the publication manifest still accepts but no longer serializes;
+/// used by unknown-field check.
+const DEPRECATED_MANIFEST_KEYS: &[&str] = &["resolved_schema_uri", "name"];
+
 /// Represents the definition manifest for a semantic convention registry.
 ///
 /// This is used when developing a registry before it is published.
@@ -213,6 +217,7 @@ impl RawManifestFields {
                 &PUBLICATION_MANIFEST_FILE_FORMAT,
                 &manifest.file_format,
                 path,
+                DEPRECATED_MANIFEST_KEYS,
             )?;
             Ok(RegistryManifest::Publication(manifest))
         } else {
@@ -368,7 +373,7 @@ impl RegistryManifest {
 /// This is produced by `weaver registry package` and describes the contents of
 /// a self-contained registry artifact, including the URI of the resolved
 /// registry artifact (`resolved.yaml`).
-#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[derive(Serialize, Debug, Clone, JsonSchema)]
 pub struct PublicationRegistryManifest {
     /// File-format version of the form `prefix/MAJOR.MINOR`. Always `manifest/2.0`
     /// for this schema. A different prefix or a different major version (in either
@@ -394,7 +399,6 @@ pub struct PublicationRegistryManifest {
     pub stability: Stability,
 
     /// URI pointing to the resolved registry artifact included in this package.
-    #[serde(alias = "resolved_schema_uri")]
     pub resolved_registry_uri: String,
 
     #[serde(skip)]
@@ -818,6 +822,50 @@ resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
         );
     }
 
+    #[test]
+    fn test_manifest_minor_version_ahead_succeeds() {
+        // A manifest with file_format "manifest/2.99" should parse successfully,
+        // treating unknown fields as forward-compatible additions.
+        let result = manifest_from_yaml(
+            r#"
+schema_url: "https://example.com/schemas/1.0.0"
+file_format: "manifest/2.99"
+resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
+future_field: "this field does not exist in 2.0"
+"#,
+            &mut vec![],
+        );
+        assert!(
+            result.is_ok(),
+            "Expected Ok for manifest/2.99 with unknown field, got: {result:?}"
+        );
+        let manifest = result.unwrap();
+        assert!(
+            matches!(manifest, RegistryManifest::Publication(_)),
+            "expected Publication variant, got {manifest:?}"
+        );
+    }
+
+    #[test]
+    fn test_manifest_major_version_mismatch_fails() {
+        // A manifest with file_format "manifest/3.0" should fail with a major-version error.
+        let result = manifest_from_yaml(
+            r#"
+schema_url: "https://example.com/schemas/1.0.0"
+file_format: "manifest/99.0"
+resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
+"#,
+            &mut vec![],
+        );
+        assert!(result.is_err(), "Expected Err for manifest/99.0, got Ok");
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Incompatible file_format"),
+            "Expected major version error message, got: {msg}"
+        );
+    }
+
     /// A publication YAML using the deprecated `resolved_schema_uri` field name
     /// must still deserialize correctly into the renamed `resolved_registry_uri`
     /// field, and surface a deprecation warning via `nfes`.
@@ -870,50 +918,6 @@ resolved_schema_uri: "https://example.com/resolved/old.yaml"
         assert_eq!(
             pubm.resolved_registry_uri,
             "https://example.com/resolved/new.yaml"
-        );
-    }
-
-    #[test]
-    fn test_manifest_minor_version_ahead_succeeds() {
-        // A manifest with file_format "manifest/2.99" should parse successfully,
-        // treating unknown fields as forward-compatible additions.
-        let result = manifest_from_yaml(
-            r#"
-schema_url: "https://example.com/schemas/1.0.0"
-file_format: "manifest/2.99"
-resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
-future_field: "this field does not exist in 2.0"
-"#,
-            &mut vec![],
-        );
-        assert!(
-            result.is_ok(),
-            "Expected Ok for manifest/2.99 with unknown field, got: {result:?}"
-        );
-        let manifest = result.unwrap();
-        assert!(
-            matches!(manifest, RegistryManifest::Publication(_)),
-            "expected Publication variant, got {manifest:?}"
-        );
-    }
-
-    #[test]
-    fn test_manifest_major_version_mismatch_fails() {
-        // A manifest with file_format "manifest/99.0" should fail with a major-version error.
-        let result = manifest_from_yaml(
-            r#"
-schema_url: "https://example.com/schemas/1.0.0"
-file_format: "manifest/99.0"
-resolved_registry_uri: "https://example.com/resolved/1.0.0/resolved.yaml"
-"#,
-            &mut vec![],
-        );
-        assert!(result.is_err(), "Expected Err for manifest/99.0, got Ok");
-        let err = result.unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("Incompatible file_format"),
-            "Expected major version error message, got: {msg}"
         );
     }
 

--- a/crates/weaver_semconv/src/unexpected_fields.rs
+++ b/crates/weaver_semconv/src/unexpected_fields.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Detect fields the typed schema didn't recognize by comparing the user's raw
+//! YAML against the typed form after a deserialize/serialize round-trip.
+//!
+//! # How it works
+//!
+//! The caller parses the same YAML document twice:
+//! 1. As `serde_yaml::Value` — keeps every key the user wrote, including typos.
+//! 2. Into the typed schema structs, then re-serializes back to
+//!    `serde_yaml::Value`.
+//!
+//! Because the schema types do not set `#[serde(deny_unknown_fields)]`, serde
+//! silently drops keys it doesn't recognize during step (2). The re-serialized
+//! form therefore contains only known fields, and walking the two trees in
+//! parallel surfaces any key present in (1) but missing from (2) — i.e. a key
+//! the typed schema didn't recognize.
+//!
+//! Tolerating unknown keys at deserialize time is what makes newer-minor
+//! schemas forward-compatible; this diff is how we report them as errors on
+//! known/past-minor schemas, where unknowns indicate a typo or a misdeclared
+//! file_format.
+//!
+//! # False-positive guard
+//!
+//! Many fields use `#[serde(skip_serializing_if = "...")]` to omit defaults from
+//! the re-serialized form. A user who writes those defaults explicitly (e.g.
+//! `note: ""`) would otherwise look like they wrote an unknown key, since the key
+//! is on the raw side but not the normalized side. A default-equivalent guard
+//! suppresses those — null, empty string, empty seq, empty map are all treated as
+//! "would have been skipped anyway".
+
+use crate::Error;
+use serde::Serialize;
+use weaver_common::file_format::FileFormat;
+
+/// Validates `found` against `file_format` (the expected version), then — if the
+/// file's minor is known to this build — diffs `raw` against the re-serialized `typed`
+/// form and returns [`Error::UnexpectedFields`] if any key in `raw` was dropped by the
+/// typed schema. Newer-minor files short-circuit (forward compat — unknowns are tolerated).
+///
+/// `typed` is the deserialized struct; this helper round-trips it to a YAML tree
+/// internally. The round-trip cannot fail in practice — `typed` was just produced
+/// by a successful deserialize, and `serde_yaml::Value` is the most permissive
+/// shape we can serialize into.
+pub fn check<T: Serialize>(
+    raw: &serde_yaml::Value,
+    typed: &T,
+    file_format: &FileFormat,
+    found: &FileFormat,
+    path: &std::path::Path,
+) -> Result<(), Error> {
+    file_format.validate(found, path)?;
+    if !file_format.is_known_minor(found) {
+        return Ok(());
+    }
+    let normalized = serde_yaml::to_value(typed)
+        .expect("re-serializing a deserialized typed struct to serde_yaml::Value cannot fail");
+    let unexpected = collect_paths(raw, &normalized);
+    if unexpected.is_empty() {
+        return Ok(());
+    }
+    Err(Error::UnexpectedFields {
+        path_or_url: path.display().to_string(),
+        file_format: file_format.clone(),
+        fields: unexpected,
+    })
+}
+
+/// Returns dotted paths (e.g. `groups[2].attributes[0].typo`) of every key
+/// present in `raw` but missing or non-default in `normalized`. See module
+/// docs for the algorithm. Most callers should use [`check`]; this lower-level
+/// entry point is exposed for diagnostic use.
+#[must_use]
+pub fn collect_paths(raw: &serde_yaml::Value, normalized: &serde_yaml::Value) -> Vec<String> {
+    let mut out = Vec::new();
+    diff("", raw, normalized, &mut out);
+    out
+}
+
+fn diff(
+    path: &str,
+    raw: &serde_yaml::Value,
+    normalized: &serde_yaml::Value,
+    out: &mut Vec<String>,
+) {
+    match (raw, normalized) {
+        // Walk only `raw_map`'s keys: a key in `norm_map` but not `raw_map`
+        // means a default the user didn't write, which is not a typo.
+        (serde_yaml::Value::Mapping(raw_map), serde_yaml::Value::Mapping(norm_map)) => {
+            for (key, raw_val) in raw_map {
+                // Schema only uses string keys; skip exotic YAML key types.
+                let Some(key_str) = key.as_str() else {
+                    continue;
+                };
+                let sub_path = if path.is_empty() {
+                    key_str.to_owned()
+                } else {
+                    format!("{path}.{key_str}")
+                };
+                match norm_map.get(key) {
+                    // Key survived the round-trip; recurse, unknowns may hide deeper.
+                    Some(norm_val) => diff(&sub_path, raw_val, norm_val, out),
+                    // Key was dropped by serde and the value isn't a default
+                    // that would have been stripped by `skip_serializing_if`.
+                    None if !is_default_equivalent(raw_val) => out.push(sub_path),
+                    None => {}
+                }
+            }
+        }
+        // Pairwise diff. Lengths normally match; if raw is longer, report the
+        // extras so dropped elements don't slip through.
+        (serde_yaml::Value::Sequence(raw_seq), serde_yaml::Value::Sequence(norm_seq)) => {
+            for (i, (raw_val, norm_val)) in raw_seq.iter().zip(norm_seq.iter()).enumerate() {
+                diff(&format!("{path}[{i}]"), raw_val, norm_val, out);
+            }
+            for (i, raw_val) in raw_seq.iter().enumerate().skip(norm_seq.len()) {
+                if !is_default_equivalent(raw_val) {
+                    out.push(format!("{path}[{i}]"));
+                }
+            }
+        }
+        // Leaves and shape mismatches: nothing to recurse into.
+        _ => {}
+    }
+}
+
+fn is_default_equivalent(value: &serde_yaml::Value) -> bool {
+    match value {
+        serde_yaml::Value::Null => true,
+        serde_yaml::Value::Sequence(seq) => seq.is_empty(),
+        serde_yaml::Value::Mapping(map) => map.is_empty(),
+        serde_yaml::Value::String(s) => s.is_empty(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn yaml(s: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(s).expect("test yaml should parse")
+    }
+
+    fn fmt() -> FileFormat {
+        FileFormat::new("resolved", 2, 3)
+    }
+
+    // ---- collect_paths ----
+
+    #[test]
+    fn collect_paths_returns_empty_when_trees_match() {
+        let raw = yaml("name: foo\nvalue: 1");
+        let normalized = yaml("name: foo\nvalue: 1");
+        assert!(collect_paths(&raw, &normalized).is_empty());
+    }
+
+    #[test]
+    fn collect_paths_reports_extra_top_level_key() {
+        let raw = yaml("name: foo\ntyp0: extra");
+        let normalized = yaml("name: foo");
+        assert_eq!(collect_paths(&raw, &normalized), vec!["typ0".to_owned()]);
+    }
+
+    #[test]
+    fn collect_paths_reports_nested_key_with_dotted_path() {
+        let raw = yaml("outer:\n  inner: ok\n  oops: bad");
+        let normalized = yaml("outer:\n  inner: ok");
+        assert_eq!(
+            collect_paths(&raw, &normalized),
+            vec!["outer.oops".to_owned()]
+        );
+    }
+
+    #[test]
+    fn collect_paths_reports_key_inside_sequence_element_with_index() {
+        let raw = yaml("items:\n  - id: a\n    extra: x\n  - id: b");
+        let normalized = yaml("items:\n  - id: a\n  - id: b");
+        assert_eq!(
+            collect_paths(&raw, &normalized),
+            vec!["items[0].extra".to_owned()]
+        );
+    }
+
+    #[test]
+    fn collect_paths_suppresses_default_equivalents() {
+        // Keys whose values would have been stripped by `skip_serializing_if`
+        // are not reported even when absent from `normalized`.
+        let raw = yaml("a: ~\nb: ''\nc: []\nd: {}");
+        let normalized = yaml("{}");
+        assert!(collect_paths(&raw, &normalized).is_empty());
+    }
+
+    #[test]
+    fn collect_paths_ignores_value_only_diffs() {
+        // Same keys, different scalar values — keys present in both, nothing to report.
+        let raw = yaml("name: foo");
+        let normalized = yaml("name: bar");
+        assert!(collect_paths(&raw, &normalized).is_empty());
+    }
+
+    #[test]
+    fn collect_paths_reports_dropped_trailing_sequence_elements() {
+        // Simulates a (de)serializer that drops trailing elements: raw has 3
+        // elements, normalized has 1. Trailing raw elements with non-default
+        // values are reported by index; default-equivalent trailing elements
+        // are suppressed by the same guard used for map values.
+        let raw = yaml("items:\n  - id: a\n  - id: b\n  - {}\n  - id: d");
+        let normalized = yaml("items:\n  - id: a");
+        assert_eq!(
+            collect_paths(&raw, &normalized),
+            vec!["items[1]".to_owned(), "items[3]".to_owned()]
+        );
+    }
+
+    #[test]
+    fn collect_paths_reports_multiple_unexpected_in_order() {
+        let raw = yaml("a: 1\nb: 2\nc: 3");
+        let normalized = yaml("b: 2");
+        assert_eq!(
+            collect_paths(&raw, &normalized),
+            vec!["a".to_owned(), "c".to_owned()]
+        );
+    }
+
+    // ---- check ----
+
+    fn path() -> std::path::PathBuf {
+        std::path::PathBuf::from("/tmp/t.yaml")
+    }
+
+    fn parsed(s: &str) -> FileFormat {
+        s.parse().expect("test file_format should parse")
+    }
+
+    #[test]
+    fn check_returns_ok_when_no_unexpected_on_known_minor() {
+        let raw = yaml("a: 1");
+        let normalized = yaml("a: 1");
+        check(&raw, &normalized, &fmt(), &parsed("resolved/2.3"), &path()).expect("no diff = Ok");
+    }
+
+    #[test]
+    fn check_flags_unexpected_on_current_minor() {
+        let raw = yaml("a: 1\ntyp0: bad");
+        let normalized = yaml("a: 1");
+        match check(&raw, &normalized, &fmt(), &parsed("resolved/2.3"), &path()) {
+            Err(Error::UnexpectedFields { fields, .. }) => {
+                assert_eq!(fields, vec!["typ0".to_owned()]);
+            }
+            other => panic!("expected UnexpectedFields, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_flags_unexpected_on_older_minor() {
+        // Older minors are still "known" to this binary, so unknowns there are
+        // typos, not forward-compat tolerance.
+        let raw = yaml("a: 1\ntyp0: bad");
+        let normalized = yaml("a: 1");
+        match check(&raw, &normalized, &fmt(), &parsed("resolved/2.0"), &path()) {
+            Err(Error::UnexpectedFields { fields, .. }) => {
+                assert_eq!(fields, vec!["typ0".to_owned()]);
+            }
+            other => panic!("expected UnexpectedFields, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_short_circuits_on_newer_minor() {
+        // Forward-compat: newer minor may carry fields this binary doesn't know.
+        let raw = yaml("a: 1\nfuture_field: x");
+        let normalized = yaml("a: 1");
+        check(&raw, &normalized, &fmt(), &parsed("resolved/2.99"), &path())
+            .expect("newer minor tolerates unknowns");
+    }
+
+    #[test]
+    fn check_rejects_different_prefix() {
+        let raw = yaml("a: 1\ntyp0: bad");
+        let normalized = yaml("a: 1");
+        let err = check(&raw, &normalized, &fmt(), &parsed("manifest/2.3"), &path())
+            .expect_err("different prefix should be rejected");
+        assert!(matches!(
+            err,
+            Error::VirtualDirectoryError(weaver_common::Error::UnrecognizedFileFormat { .. })
+        ));
+    }
+
+    #[test]
+    fn check_rejects_incompatible_major() {
+        let raw = yaml("a: 1\ntyp0: bad");
+        let normalized = yaml("a: 1");
+        let err = check(&raw, &normalized, &fmt(), &parsed("resolved/3.0"), &path())
+            .expect_err("incompatible major should be rejected");
+        assert!(matches!(
+            err,
+            Error::VirtualDirectoryError(
+                weaver_common::Error::IncompatibleFileFormatMajorVersion { .. }
+            )
+        ));
+    }
+
+    #[test]
+    fn check_propagates_path_and_file_format_in_error() {
+        let raw = yaml("name: ok\ntyp0: bad\nnested:\n  deeper: bad");
+        let normalized = yaml("name: ok\nnested: {}");
+        let p = std::path::PathBuf::from("/some/where.yaml");
+        match check(&raw, &normalized, &fmt(), &parsed("resolved/2.3"), &p) {
+            Err(Error::UnexpectedFields {
+                path_or_url,
+                file_format,
+                fields,
+            }) => {
+                assert_eq!(path_or_url, "/some/where.yaml");
+                assert_eq!(file_format, fmt());
+                assert_eq!(fields, vec!["typ0".to_owned(), "nested.deeper".to_owned()]);
+            }
+            other => panic!("expected UnexpectedFields, got: {other:?}"),
+        }
+    }
+}

--- a/crates/weaver_semconv/src/unexpected_fields.rs
+++ b/crates/weaver_semconv/src/unexpected_fields.rs
@@ -123,26 +123,77 @@ fn diff(
                 }
             }
         }
-        // Pairwise diff. Lengths normally match; if raw is longer, report the
-        // extras so dropped elements don't slip through.
+        // Pair each raw element with its normalized counterpart, then recurse. An
+        // unmatched raw element was dropped by the round-trip — report it unless it is
+        // a default the serializer would have skipped.
         (serde_yaml::Value::Sequence(raw_seq), serde_yaml::Value::Sequence(norm_seq)) => {
-            for (i, (raw_val, norm_val)) in raw_seq.iter().zip(norm_seq.iter()).enumerate() {
-                diff(
-                    &format!("{path}[{i}]"),
-                    raw_val,
-                    norm_val,
-                    deprecated_keys,
-                    out,
-                );
-            }
-            for (i, raw_val) in raw_seq.iter().enumerate().skip(norm_seq.len()) {
-                if !is_default_equivalent(raw_val) {
-                    out.push(format!("{path}[{i}]"));
+            for (i, (raw_val, matched)) in raw_seq
+                .iter()
+                .zip(align_sequence(raw_seq, norm_seq))
+                .enumerate()
+            {
+                match matched {
+                    Some(j) => {
+                        diff(&format!("{path}[{i}]"), raw_val, &norm_seq[j], deprecated_keys, out)
+                    }
+                    None if !is_default_equivalent(raw_val) => out.push(format!("{path}[{i}]")),
+                    None => {}
                 }
             }
         }
         // Leaves and shape mismatches: nothing to recurse into.
         _ => {}
+    }
+}
+
+/// Matches each raw element to its counterpart in the normalized (round-tripped) tree,
+/// returning the normalized index for each raw element or `None` if it has no match.
+///
+/// An order-preserving collection (`Vec`) keeps the two aligned by position. A reordering
+/// collection (`BTreeSet`/`HashSet`) serializes in a different order, so those are matched
+/// by content instead.
+fn align_sequence(
+    raw_seq: &[serde_yaml::Value],
+    norm_seq: &[serde_yaml::Value],
+) -> Vec<Option<usize>> {
+    // Fast path: already aligned position-for-position.
+    if raw_seq.len() == norm_seq.len()
+        && raw_seq
+            .iter()
+            .zip(norm_seq)
+            .all(|(raw, norm)| same_element(raw, norm))
+    {
+        return (0..raw_seq.len()).map(Some).collect();
+    }
+    let mut used = vec![false; norm_seq.len()];
+    raw_seq
+        .iter()
+        .map(|raw_val| {
+            let matched = norm_seq
+                .iter()
+                .enumerate()
+                .find(|(j, norm_val)| !used[*j] && same_element(raw_val, norm_val))
+                .map(|(j, _)| j);
+            if let Some(j) = matched {
+                used[j] = true;
+            }
+            matched
+        })
+        .collect()
+}
+
+/// Whether `raw` and `norm` are the same logical element.
+///
+/// A round-trip can add keys (synthesized defaults) or drop them (unknowns, skipped
+/// defaults), so only keys present on both sides are compared. Matching on shared content
+/// keeps an unknown key from pairing an element with the wrong counterpart.
+fn same_element(raw: &serde_yaml::Value, norm: &serde_yaml::Value) -> bool {
+    match (raw, norm) {
+        (serde_yaml::Value::Mapping(raw_map), serde_yaml::Value::Mapping(norm_map)) => raw_map
+            .iter()
+            .all(|(k, rv)| norm_map.get(k).map_or(true, |nv| same_element(rv, nv))),
+        (serde_yaml::Value::Sequence(_), serde_yaml::Value::Sequence(_)) => true,
+        _ => raw == norm,
     }
 }
 
@@ -245,6 +296,70 @@ mod tests {
         assert_eq!(
             collect_paths(&raw, &normalized, &[]),
             vec!["a".to_owned(), "c".to_owned()]
+        );
+    }
+
+    // ---- reordering collections (BTreeSet/HashSet of structs) ----
+    // `normalized` is in the collection's sorted order; `raw` is in the user's order.
+
+    #[test]
+    fn collect_paths_ignores_reordered_scalar_set() {
+        // Scalar sets carry no keys, so reordering has nothing to misreport.
+        let raw = yaml("deps: [c, a, b]");
+        let normalized = yaml("deps: [a, b, c]");
+        assert!(collect_paths(&raw, &normalized, &[]).is_empty());
+    }
+
+    #[test]
+    fn collect_paths_realigns_reordered_struct_set_clean() {
+        // Reordered but no unknowns: matching yields no false positives.
+        let raw = yaml("deps:\n  - {id: b, note: hi}\n  - {id: a}");
+        let normalized = yaml("deps:\n  - {id: a}\n  - {id: b, note: hi}");
+        assert!(collect_paths(&raw, &normalized, &[]).is_empty());
+    }
+
+    #[test]
+    fn collect_paths_reports_typo_in_reordered_struct_set() {
+        let raw = yaml("deps:\n  - {id: a, notE: hi}\n  - {id: b}");
+        let normalized = yaml("deps:\n  - {id: a}\n  - {id: b}");
+        assert_eq!(
+            collect_paths(&raw, &normalized, &[]),
+            vec!["deps[0].notE".to_owned()]
+        );
+    }
+
+    #[test]
+    fn collect_paths_unknown_key_does_not_misreport_sibling_field() {
+        // An unknown key (`aaa`) on the reordered element must not flag a sibling's
+        // valid field (`note`).
+        let raw = yaml("deps:\n  - {id: b, aaa: x}\n  - {id: a, note: hi}");
+        let normalized = yaml("deps:\n  - {id: a, note: hi}\n  - {id: b}");
+        assert_eq!(
+            collect_paths(&raw, &normalized, &[]),
+            vec!["deps[0].aaa".to_owned()]
+        );
+    }
+
+    #[test]
+    fn collect_paths_matches_across_a_synthesized_default_field() {
+        // A round-trip may add a known field (`note`); matching on shared keys still
+        // pairs the element with its raw form.
+        let raw = yaml("deps:\n  - {id: b, oops: 1}\n  - {id: a}");
+        let normalized = yaml("deps:\n  - {id: a, note: synthesized}\n  - {id: b}");
+        assert_eq!(
+            collect_paths(&raw, &normalized, &[]),
+            vec!["deps[0].oops".to_owned()]
+        );
+    }
+
+    #[test]
+    fn collect_paths_vec_typo_keeps_positional_index() {
+        // A `Vec` keeps order (fast path); the typo is reported at its true index.
+        let raw = yaml("items:\n  - {id: a}\n  - {id: a, oops: 1}");
+        let normalized = yaml("items:\n  - {id: a}\n  - {id: a}");
+        assert_eq!(
+            collect_paths(&raw, &normalized, &[]),
+            vec!["items[1].oops".to_owned()]
         );
     }
 

--- a/crates/weaver_semconv/src/unexpected_fields.rs
+++ b/crates/weaver_semconv/src/unexpected_fields.rs
@@ -43,12 +43,17 @@ use weaver_common::file_format::FileFormat;
 /// internally. The round-trip cannot fail in practice — `typed` was just produced
 /// by a successful deserialize, and `serde_yaml::Value` is the most permissive
 /// shape we can serialize into.
+///
+/// `deprecated_keys` lists key names the schema still accepts on input but no
+/// longer writes on output (e.g. a field renamed with a deprecation warning).
+/// They would otherwise look like unknowns after the round-trip.
 pub fn check<T: Serialize>(
     raw: &serde_yaml::Value,
     typed: &T,
     file_format: &FileFormat,
     found: &FileFormat,
     path: &std::path::Path,
+    deprecated_keys: &[&str],
 ) -> Result<(), Error> {
     file_format.validate(found, path)?;
     if !file_format.is_known_minor(found) {
@@ -56,7 +61,7 @@ pub fn check<T: Serialize>(
     }
     let normalized = serde_yaml::to_value(typed)
         .expect("re-serializing a deserialized typed struct to serde_yaml::Value cannot fail");
-    let unexpected = collect_paths(raw, &normalized);
+    let unexpected = collect_paths(raw, &normalized, deprecated_keys);
     if unexpected.is_empty() {
         return Ok(());
     }
@@ -70,11 +75,16 @@ pub fn check<T: Serialize>(
 /// Returns dotted paths (e.g. `groups[2].attributes[0].typo`) of every key
 /// present in `raw` but missing or non-default in `normalized`. See module
 /// docs for the algorithm. Most callers should use [`check`]; this lower-level
-/// entry point is exposed for diagnostic use.
+/// entry point is exposed for diagnostic use. `deprecated_keys` names keys that
+/// are accepted on input but not re-serialized; they are never reported.
 #[must_use]
-pub fn collect_paths(raw: &serde_yaml::Value, normalized: &serde_yaml::Value) -> Vec<String> {
+pub fn collect_paths(
+    raw: &serde_yaml::Value,
+    normalized: &serde_yaml::Value,
+    deprecated_keys: &[&str],
+) -> Vec<String> {
     let mut out = Vec::new();
-    diff("", raw, normalized, &mut out);
+    diff("", raw, normalized, deprecated_keys, &mut out);
     out
 }
 
@@ -82,6 +92,7 @@ fn diff(
     path: &str,
     raw: &serde_yaml::Value,
     normalized: &serde_yaml::Value,
+    deprecated_keys: &[&str],
     out: &mut Vec<String>,
 ) {
     match (raw, normalized) {
@@ -100,10 +111,14 @@ fn diff(
                 };
                 match norm_map.get(key) {
                     // Key survived the round-trip; recurse, unknowns may hide deeper.
-                    Some(norm_val) => diff(&sub_path, raw_val, norm_val, out),
+                    Some(norm_val) => diff(&sub_path, raw_val, norm_val, deprecated_keys, out),
                     // Key was dropped by serde and the value isn't a default
                     // that would have been stripped by `skip_serializing_if`.
-                    None if !is_default_equivalent(raw_val) => out.push(sub_path),
+                    None if !is_default_equivalent(raw_val)
+                        && !deprecated_keys.contains(&key_str) =>
+                    {
+                        out.push(sub_path);
+                    }
                     None => {}
                 }
             }
@@ -112,7 +127,13 @@ fn diff(
         // extras so dropped elements don't slip through.
         (serde_yaml::Value::Sequence(raw_seq), serde_yaml::Value::Sequence(norm_seq)) => {
             for (i, (raw_val, norm_val)) in raw_seq.iter().zip(norm_seq.iter()).enumerate() {
-                diff(&format!("{path}[{i}]"), raw_val, norm_val, out);
+                diff(
+                    &format!("{path}[{i}]"),
+                    raw_val,
+                    norm_val,
+                    deprecated_keys,
+                    out,
+                );
             }
             for (i, raw_val) in raw_seq.iter().enumerate().skip(norm_seq.len()) {
                 if !is_default_equivalent(raw_val) {
@@ -153,14 +174,17 @@ mod tests {
     fn collect_paths_returns_empty_when_trees_match() {
         let raw = yaml("name: foo\nvalue: 1");
         let normalized = yaml("name: foo\nvalue: 1");
-        assert!(collect_paths(&raw, &normalized).is_empty());
+        assert!(collect_paths(&raw, &normalized, &[]).is_empty());
     }
 
     #[test]
     fn collect_paths_reports_extra_top_level_key() {
         let raw = yaml("name: foo\ntyp0: extra");
         let normalized = yaml("name: foo");
-        assert_eq!(collect_paths(&raw, &normalized), vec!["typ0".to_owned()]);
+        assert_eq!(
+            collect_paths(&raw, &normalized, &[]),
+            vec!["typ0".to_owned()]
+        );
     }
 
     #[test]
@@ -168,7 +192,7 @@ mod tests {
         let raw = yaml("outer:\n  inner: ok\n  oops: bad");
         let normalized = yaml("outer:\n  inner: ok");
         assert_eq!(
-            collect_paths(&raw, &normalized),
+            collect_paths(&raw, &normalized, &[]),
             vec!["outer.oops".to_owned()]
         );
     }
@@ -178,7 +202,7 @@ mod tests {
         let raw = yaml("items:\n  - id: a\n    extra: x\n  - id: b");
         let normalized = yaml("items:\n  - id: a\n  - id: b");
         assert_eq!(
-            collect_paths(&raw, &normalized),
+            collect_paths(&raw, &normalized, &[]),
             vec!["items[0].extra".to_owned()]
         );
     }
@@ -189,7 +213,7 @@ mod tests {
         // are not reported even when absent from `normalized`.
         let raw = yaml("a: ~\nb: ''\nc: []\nd: {}");
         let normalized = yaml("{}");
-        assert!(collect_paths(&raw, &normalized).is_empty());
+        assert!(collect_paths(&raw, &normalized, &[]).is_empty());
     }
 
     #[test]
@@ -197,7 +221,7 @@ mod tests {
         // Same keys, different scalar values — keys present in both, nothing to report.
         let raw = yaml("name: foo");
         let normalized = yaml("name: bar");
-        assert!(collect_paths(&raw, &normalized).is_empty());
+        assert!(collect_paths(&raw, &normalized, &[]).is_empty());
     }
 
     #[test]
@@ -209,7 +233,7 @@ mod tests {
         let raw = yaml("items:\n  - id: a\n  - id: b\n  - {}\n  - id: d");
         let normalized = yaml("items:\n  - id: a");
         assert_eq!(
-            collect_paths(&raw, &normalized),
+            collect_paths(&raw, &normalized, &[]),
             vec!["items[1]".to_owned(), "items[3]".to_owned()]
         );
     }
@@ -219,7 +243,7 @@ mod tests {
         let raw = yaml("a: 1\nb: 2\nc: 3");
         let normalized = yaml("b: 2");
         assert_eq!(
-            collect_paths(&raw, &normalized),
+            collect_paths(&raw, &normalized, &[]),
             vec!["a".to_owned(), "c".to_owned()]
         );
     }
@@ -238,14 +262,29 @@ mod tests {
     fn check_returns_ok_when_no_unexpected_on_known_minor() {
         let raw = yaml("a: 1");
         let normalized = yaml("a: 1");
-        check(&raw, &normalized, &fmt(), &parsed("resolved/2.3"), &path()).expect("no diff = Ok");
+        check(
+            &raw,
+            &normalized,
+            &fmt(),
+            &parsed("resolved/2.3"),
+            &path(),
+            &[],
+        )
+        .expect("no diff = Ok");
     }
 
     #[test]
     fn check_flags_unexpected_on_current_minor() {
         let raw = yaml("a: 1\ntyp0: bad");
         let normalized = yaml("a: 1");
-        match check(&raw, &normalized, &fmt(), &parsed("resolved/2.3"), &path()) {
+        match check(
+            &raw,
+            &normalized,
+            &fmt(),
+            &parsed("resolved/2.3"),
+            &path(),
+            &[],
+        ) {
             Err(Error::UnexpectedFields { fields, .. }) => {
                 assert_eq!(fields, vec!["typ0".to_owned()]);
             }
@@ -259,7 +298,14 @@ mod tests {
         // typos, not forward-compat tolerance.
         let raw = yaml("a: 1\ntyp0: bad");
         let normalized = yaml("a: 1");
-        match check(&raw, &normalized, &fmt(), &parsed("resolved/2.0"), &path()) {
+        match check(
+            &raw,
+            &normalized,
+            &fmt(),
+            &parsed("resolved/2.0"),
+            &path(),
+            &[],
+        ) {
             Err(Error::UnexpectedFields { fields, .. }) => {
                 assert_eq!(fields, vec!["typ0".to_owned()]);
             }
@@ -272,16 +318,30 @@ mod tests {
         // Forward-compat: newer minor may carry fields this binary doesn't know.
         let raw = yaml("a: 1\nfuture_field: x");
         let normalized = yaml("a: 1");
-        check(&raw, &normalized, &fmt(), &parsed("resolved/2.99"), &path())
-            .expect("newer minor tolerates unknowns");
+        check(
+            &raw,
+            &normalized,
+            &fmt(),
+            &parsed("resolved/2.99"),
+            &path(),
+            &[],
+        )
+        .expect("newer minor tolerates unknowns");
     }
 
     #[test]
     fn check_rejects_different_prefix() {
         let raw = yaml("a: 1\ntyp0: bad");
         let normalized = yaml("a: 1");
-        let err = check(&raw, &normalized, &fmt(), &parsed("manifest/2.3"), &path())
-            .expect_err("different prefix should be rejected");
+        let err = check(
+            &raw,
+            &normalized,
+            &fmt(),
+            &parsed("manifest/2.3"),
+            &path(),
+            &[],
+        )
+        .expect_err("different prefix should be rejected");
         assert!(matches!(
             err,
             Error::VirtualDirectoryError(weaver_common::Error::UnrecognizedFileFormat { .. })
@@ -292,8 +352,15 @@ mod tests {
     fn check_rejects_incompatible_major() {
         let raw = yaml("a: 1\ntyp0: bad");
         let normalized = yaml("a: 1");
-        let err = check(&raw, &normalized, &fmt(), &parsed("resolved/3.0"), &path())
-            .expect_err("incompatible major should be rejected");
+        let err = check(
+            &raw,
+            &normalized,
+            &fmt(),
+            &parsed("resolved/3.0"),
+            &path(),
+            &[],
+        )
+        .expect_err("incompatible major should be rejected");
         assert!(matches!(
             err,
             Error::VirtualDirectoryError(
@@ -307,7 +374,7 @@ mod tests {
         let raw = yaml("name: ok\ntyp0: bad\nnested:\n  deeper: bad");
         let normalized = yaml("name: ok\nnested: {}");
         let p = std::path::PathBuf::from("/some/where.yaml");
-        match check(&raw, &normalized, &fmt(), &parsed("resolved/2.3"), &p) {
+        match check(&raw, &normalized, &fmt(), &parsed("resolved/2.3"), &p, &[]) {
             Err(Error::UnexpectedFields {
                 path_or_url,
                 file_format,

--- a/crates/weaver_semconv/src/unexpected_fields.rs
+++ b/crates/weaver_semconv/src/unexpected_fields.rs
@@ -133,9 +133,13 @@ fn diff(
                 .enumerate()
             {
                 match matched {
-                    Some(j) => {
-                        diff(&format!("{path}[{i}]"), raw_val, &norm_seq[j], deprecated_keys, out)
-                    }
+                    Some(j) => diff(
+                        &format!("{path}[{i}]"),
+                        raw_val,
+                        &norm_seq[j],
+                        deprecated_keys,
+                        out,
+                    ),
                     None if !is_default_equivalent(raw_val) => out.push(format!("{path}[{i}]")),
                     None => {}
                 }

--- a/crates/weaver_semconv/src/v2/mod.rs
+++ b/crates/weaver_semconv/src/v2/mod.rs
@@ -46,7 +46,11 @@ pub struct CommonFields {
     /// Specifies if the semantic convention is deprecated. The string
     /// provided as description MUST specify why it's deprecated and/or what
     /// to use instead. See also stability.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::deprecated::deserialize_option_deprecated",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub deprecated: Option<Deprecated>,
     /// Annotations for the attribute or signal.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/crates/weaver_semconv/src/v2/span.rs
+++ b/crates/weaver_semconv/src/v2/span.rs
@@ -218,8 +218,8 @@ impl SpanRefinement {
 /// Specification of the span name.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
+#[schemars(deny_unknown_fields)]
 pub struct SpanName {
     /// Required description of how a span name should be created.
     pub note: String,

--- a/crates/weaver_semconv/tests/published_repository/3.0.0/registry_manifest.yaml
+++ b/crates/weaver_semconv/tests/published_repository/3.0.0/registry_manifest.yaml
@@ -1,6 +1,5 @@
 file_format: manifest/2.0
 description: Test repository that has been resolved.
 schema_url: http://resolved/3.0.0
-repository_url: https://github.com/open-telemetry/weaver.git
 stability: stable
 resolved_registry_uri: resolved_schema.yaml

--- a/crates/weaver_semconv/tests/published_repository/resolved/1.0.0
+++ b/crates/weaver_semconv/tests/published_repository/resolved/1.0.0
@@ -1,6 +1,5 @@
 file_format: manifest/2.0
 description: Test repository that has been resolved.
 schema_url: http://resolved/1.0.0
-repository_url: https://github.com/open-telemetry/weaver.git
 stability: stable
 resolved_registry_uri: resolved_1.0.0.yaml

--- a/crates/weaver_semconv/tests/published_repository/resolved/2.0.0
+++ b/crates/weaver_semconv/tests/published_repository/resolved/2.0.0
@@ -1,6 +1,5 @@
 file_format: manifest/2.0
 description: Test repository that has been resolved.
 schema_url: http://resolved/2.0.0
-repository_url: https://github.com/open-telemetry/weaver.git
 stability: stable
 resolved_registry_uri: https://github.com/open-telemetry/weaver.git\creates/weaver_semconv/tests/published_respository/resolved/resolved_2.0.0

--- a/crates/weaver_semconv_gen/src/v2.rs
+++ b/crates/weaver_semconv_gen/src/v2.rs
@@ -469,7 +469,7 @@ mod tests {
 
     fn test_registry() -> ResolvedTelemetrySchema {
         ResolvedTelemetrySchema {
-            file_format: "resolved/2.0".to_owned(),
+            file_format: "resolved/2.0".parse().unwrap(),
             schema_url: "https://todo/1.0.0".try_into().unwrap(),
             attribute_catalog: vec![Attribute {
                 key: "attr1".to_owned(),

--- a/schemas/publication-manifest.v2.json
+++ b/schemas/publication-manifest.v2.json
@@ -19,7 +19,7 @@
       ]
     },
     "file_format": {
-      "description": "The file format version of this publication manifest.\nAlways `\"manifest/2.0\"`in this version.",
+      "description": "File-format version of the form `prefix/MAJOR.MINOR`. Always `manifest/2.0`\nfor this schema. A different prefix or a different major version (in either\ndirection) is rejected; newer minor versions are tolerated for forward\ncompatibility (unknown fields are ignored, with a warning).",
       "type": "string",
       "const": "manifest/2.0"
     },

--- a/schemas/semconv.resolved.v2.json
+++ b/schemas/semconv.resolved.v2.json
@@ -20,7 +20,7 @@
       "uniqueItems": true
     },
     "file_format": {
-      "description": "Version of the file structure.\nAlways `\"resolved/2.0\"` in this version.",
+      "description": "File-format version of the form `prefix/MAJOR.MINOR`. Always `resolved/2.0`\nfor this schema. A different prefix or a different major version (in either\ndirection) is rejected; newer minor versions are tolerated for forward\ncompatibility (unknown fields are ignored, with a warning).",
       "type": "string",
       "const": "resolved/2.0"
     },

--- a/src/registry/package.rs
+++ b/src/registry/package.rs
@@ -221,10 +221,14 @@ mod tests {
         // manifest.yaml must exist and contain the correct fields
         let manifest_path = output.path().join("manifest.yaml");
         assert!(manifest_path.exists(), "manifest.yaml not written");
-        let manifest_content =
-            fs::read_to_string(&manifest_path).expect("failed to read manifest.yaml");
-        let manifest: PublicationRegistryManifest =
-            serde_yaml::from_str(&manifest_content).expect("manifest.yaml is not valid YAML");
+        let manifest = match RegistryManifest::try_from_file(&manifest_path, &mut vec![])
+            .expect("manifest.yaml failed to load")
+        {
+            RegistryManifest::Publication(m) => m,
+            other @ RegistryManifest::Definition(_) => {
+                panic!("expected publication manifest, got {other:?}")
+            }
+        };
 
         assert_eq!(manifest.file_format, PUBLICATION_MANIFEST_FILE_FORMAT);
         assert_eq!(manifest.schema_url.as_str(), "https://test/schemas/1.0.0");


### PR DESCRIPTION
Older weaver can now read files written by a newer minor version. 
                                                                                                                                                                                                                                                               
- Newer minor (resolved/2.X on a 2.0 build): loads, unknowns ignored, warning that newer version is available is logged.                                                                                                                                                                       
- Major mismatch (e.g. resolved/3.0): not supported, fatal error at start
- Same/older minor with unknown field: fatal error listing unexpected fields (path). e.g. registry.spans[0].unknown_field

> [!WARNING]
> 
> It introduces regression for definition side (we reuse quite a few types between definition and resolved).
> Since deny_unknown_fields is relaxed, we'll tolerate errors in definitions that we failed on before.
> 
> Definitions PR: https://github.com/open-telemetry/weaver/pull/1422