### PR TITLE
Remove vendored openssl dependency

### DIFF
--- a/crates/weaver_common/Cargo.toml
+++ b/crates/weaver_common/Cargo.toml
@@ -34,10 +34,15 @@ gix = { version = "0.81.0", default-features = false, features = [
     "worktree-mutation",
     "sha1",
 ] }
-openssl.workspace = true
 flate2 = "1.1.4"
 tar = "0.4.43"
 zip.workspace = true
+
+# Use vendored OpenSSL on non-Windows platforms to avoid system OpenSSL deps
+# This enables the "vendored" feature for the openssl crate when building on
+# non-Windows targets.
+[target.'cfg(not(windows))'.dependencies]
+openssl.workspace = true
 
 [dev-dependencies]
 ureq.workspace = true


### PR DESCRIPTION
The OTel Dataflow Engine (aka otel-arrow) has been using Weaver. In weaver due to dependency on openssl vendored feature it causes openssl build everytime. This change is made to avoid such overhead. With this change weaver will rely on windoows native tls implementation. 

Part of #1382.

Part of https://github.com/open-telemetry/otel-arrow/issues/2697.