### PR TITLE
Use pinned weaver version versus latest in dog-fooding

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -157,7 +157,7 @@
       customType: "regex",
       description: "Update Rust toolchain version",
       managerFilePatterns: [
-        "rust-toolchain.toml", 
+        "rust-toolchain.toml",
         "justfile",
       ],
       matchStrings: [
@@ -172,6 +172,20 @@
       currentValueTemplate: "{{depVersion}}",
       packageNameTemplate: "rust-lang/rust",
       depTypeTemplate: "SDK",
+    },
+    {
+      customType: "regex",
+      description: "Update otel/weaver Docker image references (justfile, CI, docs)",
+      managerFilePatterns: [
+        "justfile",
+        ".github/workflows/ci.yml",
+        "crates/weaver_live_check/docs/dog-fooding.md",
+      ],
+      matchStrings: [
+        "otel\\/weaver:(?<currentValue>v[\\d.]+)",
+      ],
+      depNameTemplate: "otel/weaver",
+      datasourceTemplate: "docker",
     },
   ],
   labels: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
           -u "$(id -u):$(id -g)"
           -e HOME=/tmp
           -v "${{ github.workspace }}":/home/weaver/source
-          otel/weaver:latest
+          otel/weaver:v0.23.0
           registry generate
           --registry /home/weaver/source/crates/weaver_live_check/model/
           --templates /home/weaver/source/crates/weaver_live_check/templates/
@@ -370,7 +370,7 @@ jobs:
           -u "$(id -u):$(id -g)"
           -e HOME=/tmp
           -v "${{ github.workspace }}":/home/weaver/source
-          otel/weaver:latest
+          otel/weaver:v0.23.0
           registry generate
           --registry /home/weaver/source/crates/weaver_live_check/model/
           --templates /home/weaver/source/crates/weaver_live_check/templates/

--- a/crates/weaver_live_check/docs/dog-fooding.md
+++ b/crates/weaver_live_check/docs/dog-fooding.md
@@ -75,7 +75,7 @@ docker run --rm \
   -u "$(id -u):$(id -g)" \
   -e HOME=/tmp \
   -v "$(pwd)":/home/weaver/source \
-  otel/weaver:latest \
+  otel/weaver:v0.23.0 \
   registry generate \
   --registry /home/weaver/source/crates/weaver_live_check/model/ \
   --templates /home/weaver/source/crates/weaver_live_check/templates/ \
@@ -93,7 +93,7 @@ docker run --rm \
   -u "$(id -u):$(id -g)" \
   -e HOME=/tmp \
   -v "$(pwd)":/home/weaver/source \
-  otel/weaver:latest \
+  otel/weaver:v0.23.0 \
   registry generate \
   --registry /home/weaver/source/crates/weaver_live_check/model/ \
   --templates /home/weaver/source/crates/weaver_live_check/templates/ \

--- a/justfile
+++ b/justfile
@@ -35,8 +35,8 @@ upgrade:
     cargo upgrade
 
 generate:
-    docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -v "$(pwd)":/home/weaver/source otel/weaver:latest registry generate --registry /home/weaver/source/crates/weaver_live_check/model/ --templates /home/weaver/source/crates/weaver_live_check/templates/ --v2 rust /home/weaver/source/crates/weaver_live_check/src/
-    docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -v "$(pwd)":/home/weaver/source otel/weaver:latest registry generate --registry /home/weaver/source/crates/weaver_live_check/model/ --templates /home/weaver/source/crates/weaver_live_check/templates/ --v2 markdown /home/weaver/source/crates/weaver_live_check/docs/
+    docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -v "$(pwd)":/home/weaver/source otel/weaver:v0.23.0 registry generate --registry /home/weaver/source/crates/weaver_live_check/model/ --templates /home/weaver/source/crates/weaver_live_check/templates/ --v2 rust /home/weaver/source/crates/weaver_live_check/src/
+    docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -v "$(pwd)":/home/weaver/source otel/weaver:v0.23.0 registry generate --registry /home/weaver/source/crates/weaver_live_check/model/ --templates /home/weaver/source/crates/weaver_live_check/templates/ --v2 markdown /home/weaver/source/crates/weaver_live_check/docs/
     cargo fmt -p weaver_live_check
 
 validate-workspace:


### PR DESCRIPTION
Turns out `latest` gets cached in tools like docker desktop and rancher to whatever was latest at that time. So as a user you'd have to manually get the latest. So there's a footgun.

It's cleaner/better practice to use a pinned version and then have renovate track this anyway.