### PR TITLE
Consolidate deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ itertools = "0.14.0"
 globset = { version = "0.4.16", features = ["serde1"] }
 miette = { version = "7.6.0", features = ["fancy", "serde"] }
 include_dir = "0.7.4"
-tempfile = "3.23.0"
+tempfile = "3.27.0"
 schemars = { version = "1", features = ["semver1"] }
 dirs = "6.0.0"
 once_cell = "1.21.3"
@@ -70,6 +70,8 @@ utoipa = "5.3"
 rand = "0.10.0"
 toml = "0.9.8"
 zip = "5.1.1"
+assert_cmd = "2.2.1"
+semver = { version = "1.0.27", features = ["serde"] }
 
 # Features definition =========================================================
 [features]
@@ -141,7 +143,7 @@ weaver_diff = { path = "crates/weaver_diff" }
 weaver_version = { path = "crates/weaver_version" }
 tempfile.workspace = true
 ureq.workspace = true
-assert_cmd = "=2.2.1"
+assert_cmd.workspace = true
 portpicker = "=0.1.1"
 zip.workspace = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,8 @@ toml = "0.9.8"
 zip = "5.1.1"
 assert_cmd = "2.2.1"
 semver = { version = "1.0.27", features = ["serde"] }
+portpicker = "0.1.1"
+glob = "0.3.3"
 
 # Features definition =========================================================
 [features]
@@ -144,7 +146,7 @@ weaver_version = { path = "crates/weaver_version" }
 tempfile.workspace = true
 ureq.workspace = true
 assert_cmd.workspace = true
-portpicker = "=0.1.1"
+portpicker.workspace = true
 zip.workspace = true
 
 [build-dependencies]
@@ -164,7 +166,10 @@ lto = "thin"
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
 unused_lifetimes = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)', 'cfg(tarpaulin_include)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(tarpaulin)',
+    'cfg(tarpaulin_include)',
+] }
 # unreachable_pub = "warn"
 semicolon_in_expressions_from_macros = "warn"
 missing_docs = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ weaver_version = { path = "crates/weaver_version" }
 clap = { version = "4.6.1", features = ["derive"] }
 clap_complete = "4.6.2"
 clap-markdown = "0.1"
-rayon = "1.10.0"
+rayon.workspace = true
 ratatui = { version = "0.30.0", features = ["serde"] }
 ratatui-textarea = "0.9.1"
 prost = "0.14.1"

--- a/crates/weaver_common/Cargo.toml
+++ b/crates/weaver_common/Cargo.toml
@@ -26,7 +26,7 @@ log.workspace = true
 url.workspace = true
 
 tempfile.workspace = true
-dirs = "6.0.0"
+dirs.workspace = true
 gix = { version = "0.83.0", default-features = false, features = [
     "comfort",
     "blocking-http-transport-reqwest-native-tls",

--- a/crates/weaver_emit/Cargo.toml
+++ b/crates/weaver_emit/Cargo.toml
@@ -23,7 +23,7 @@ serde.workspace = true
 miette.workspace = true
 
 [dev-dependencies]
-futures-util = { version = "=0.3.32", default-features = false }
+futures-util = { version = "0.3.32", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/weaver_forge/Cargo.toml
+++ b/crates/weaver_forge/Cargo.toml
@@ -32,8 +32,8 @@ jaq-core = "2.2.1"
 jaq-std = "2.1.2"
 jaq-json = { version = "1.1.3", features = ["serde_json"] }
 indexmap = "2.11.4"
-regex = "1.11.3"
-markdown = "=1.0.0"
+regex.workspace = true
+markdown = "1.0.0"
 textwrap = "0.16.2"
 
 convert_case.workspace = true

--- a/crates/weaver_live_check/Cargo.toml
+++ b/crates/weaver_live_check/Cargo.toml
@@ -31,7 +31,7 @@ strum = { version = "0.27.2", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd.workspace = true
-portpicker = "0.1.1"
+portpicker.workspace = true
 tempfile.workspace = true
 serde_yaml.workspace = true
 serial_test = "3.4.0"

--- a/crates/weaver_live_check/Cargo.toml
+++ b/crates/weaver_live_check/Cargo.toml
@@ -30,9 +30,9 @@ tokio.workspace = true
 strum = { version = "0.27.2", features = ["derive"] }
 
 [dev-dependencies]
-assert_cmd = "2.2.0"
+assert_cmd.workspace = true
 portpicker = "0.1.1"
-tempfile = "3.27.0"
+tempfile.workspace = true
 serde_yaml.workspace = true
 serial_test = "3.4.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/weaver_resolver/Cargo.toml
+++ b/crates/weaver_resolver/Cargo.toml
@@ -30,5 +30,5 @@ log.workspace = true
 rand.workspace = true
 
 [dev-dependencies]
-glob = "=0.3.3"
+glob.workspace = true
 tempfile.workspace = true

--- a/crates/weaver_semconv/Cargo.toml
+++ b/crates/weaver_semconv/Cargo.toml
@@ -32,7 +32,7 @@ itertools.workspace = true
 log.workspace = true
 url.workspace = true
 
-glob = "0.3.3"
+glob.workspace = true
 jsonschema = "0.46.4"        # JSON Schema validation used to enhance error messages
 saphyr = "0.0.6"             # YAML parser preserving span information (location in file)
 utoipa = { workspace = true, optional = true }

--- a/crates/weaver_version/Cargo.toml
+++ b/crates/weaver_version/Cargo.toml
@@ -17,5 +17,5 @@ serde_yaml.workspace = true
 thiserror.workspace = true
 schemars.workspace = true
 
-semver = {version =  "1.0.27", features = ["serde"]}
+semver.workspace = true
 weaver_semconv = { path = "../weaver_semconv" }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-assert_cmd = "2.0.17"
+assert_cmd.workspace = true
 serde_json.workspace = true
 gix = { version = "0.83.0", default-features = false, features = [
     "comfort",
@@ -20,8 +20,8 @@ gix = { version = "0.83.0", default-features = false, features = [
     "blocking-http-transport-reqwest-rust-tls",
     "sha1",
 ] }
-semver = "1.0.27"
-toml = "0.9.7"
+semver.workspace = true
+toml.workspace = true
 
 #[lints]
 #workspace = true


### PR DESCRIPTION
We had a few places where we were redeclaring crate versions across the Cargo.toml files. Renovate in #1420 is trying to pin to specific versions which then breaks.

This PR consolidates a bunch of dependencies into the workspace and removes unnecessary pins.