### PR TITLE
Reimplement test http server to fix vulns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,21 +49,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -172,12 +151,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "assert_cmd"
@@ -326,12 +299,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -397,27 +364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
-name = "brotli"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,16 +372,6 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
-]
-
-[[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
 ]
 
 [[package]]
@@ -550,12 +486,6 @@ dependencies = [
  "chrono",
  "phf 0.12.1",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cipher"
@@ -908,16 +838,6 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
-name = "deflate"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
-dependencies = [
- "adler32",
- "gzip-header",
-]
 
 [[package]]
 name = "deflate64"
@@ -2230,7 +2150,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bstr",
  "gix-command",
  "gix-credentials",
@@ -2367,15 +2287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gzip-header"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86848f4fd157d91041a62c78046fb7b248bcc2dce78376d436a1756e9a038577"
-dependencies = [
- "crc32fast",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,12 +2372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,6 +2424,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -2610,7 +2521,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2903,7 +2814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c264fe397c981705976c71f1bfe020382b9eda52ae950e57fe885e147bdd67d"
 dependencies = [
  "aho-corasick",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "jaq-core",
  "libm",
@@ -3413,24 +3324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "multipart"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
-dependencies = [
- "buf_redux",
- "httparse",
- "log",
- "mime",
- "mime_guess",
- "quick-error",
- "rand 0.8.6",
- "safemem",
- "tempfile",
- "twoway",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,16 +3472,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -4202,12 +4085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4646,7 +4523,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -4706,7 +4583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "futures",
  "pastey",
@@ -4732,30 +4609,6 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "rouille"
-version = "3.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3716fbf57fc1084d7a706adf4e445298d123e4a44294c4e8213caf1b85fcc921"
-dependencies = [
- "base64 0.13.1",
- "brotli",
- "chrono",
- "deflate",
- "filetime",
- "multipart",
- "percent-encoding",
- "rand 0.8.6",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1_smol",
- "threadpool",
- "time",
- "tiny_http",
- "url",
 ]
 
 [[package]]
@@ -4893,12 +4746,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -5167,12 +5014,6 @@ dependencies = [
  "digest",
  "sha1",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -5483,7 +5324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.1",
  "fancy-regex 0.11.0",
  "filedescriptor",
@@ -5571,15 +5412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5599,18 +5431,6 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "tiny_http"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
-dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
-]
 
 [[package]]
 name = "tinystr"
@@ -5756,7 +5576,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "h2",
  "http",
@@ -5871,10 +5691,19 @@ checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5930,15 +5759,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "twoway"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "typed-arena"
@@ -6065,7 +5885,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "flate2",
  "log",
  "percent-encoding",
@@ -6082,7 +5902,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "http",
  "httparse",
  "log",
@@ -6431,6 +6251,7 @@ dependencies = [
 name = "weaver_common"
 version = "0.23.0"
 dependencies = [
+ "axum",
  "dirs",
  "flate2",
  "gix",
@@ -6440,13 +6261,14 @@ dependencies = [
  "openssl",
  "paris",
  "regex",
- "rouille",
  "schemars",
  "serde",
  "serde_json",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
+ "tower-http 0.6.10",
  "ureq",
  "url",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ opentelemetry-stdout = { version = "0.32.0", features = [
     "logs",
 ] }
 tokio = { version = "1.47.1", features = ["full"] }
-rouille = "3.6.2"
+axum = "0.8"
 convert_case = "0.11"
 log = { version = "0.4.28", features = ["std"] }
 utoipa = "5.3"
@@ -120,7 +120,7 @@ tonic = { version = "0.14.1", default-features = false, features = [
 tonic-prost = "0.14.1"
 env_logger = "0.11.8"
 chrono = "0.4.41"
-axum = "0.8"
+axum.workspace = true
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 mime_guess = "2.0"
 utoipa = { workspace = true, features = ["axum_extras"] }

--- a/crates/weaver_common/Cargo.toml
+++ b/crates/weaver_common/Cargo.toml
@@ -17,7 +17,6 @@ serde.workspace = true
 serde_json.workspace = true
 miette.workspace = true
 thiserror.workspace = true
-rouille.workspace = true
 regex.workspace = true
 once_cell.workspace = true
 schemars.workspace = true
@@ -45,5 +44,8 @@ zip.workspace = true
 openssl.workspace = true
 
 [dev-dependencies]
+axum.workspace = true
+tokio.workspace = true
+tower-http = { version = "0.6", features = ["fs"] }
 ureq.workspace = true
 walkdir.workspace = true

--- a/crates/weaver_common/src/test.rs
+++ b/crates/weaver_common/src/test.rs
@@ -2,12 +2,24 @@
 
 //! HTTP server for testing purposes.
 
+use axum::{
+    extract::{Request, State},
+    http::{HeaderMap, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    Router,
+};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
+use tokio::net::TcpListener;
+use tokio::runtime::Runtime;
+use tokio::task::AbortHandle;
+use tower_http::services::ServeDir;
 
-use rouille::{match_assets, Server};
-use std::sync::mpsc::Sender;
+/// Shared tokio runtime for all test HTTP servers.
+static RUNTIME: LazyLock<Runtime> =
+    LazyLock::new(|| Runtime::new().expect("failed to create test runtime"));
 
 /// An error that can occur while starting the HTTP server.
 #[derive(thiserror::Error, Debug, Clone)]
@@ -16,33 +28,50 @@ pub struct HttpServerError {
     error: String,
 }
 
-/// Internal test HTTP server holding the kill switch and port.
+/// Internal test HTTP server. Aborts its task on drop.
 struct TestHttpServer {
-    kill_switch: Sender<()>,
+    abort: AbortHandle,
     port: u16,
 }
 
 impl Drop for TestHttpServer {
     fn drop(&mut self) {
-        let _ = self.kill_switch.send(());
+        self.abort.abort();
     }
 }
 
 impl TestHttpServer {
-    fn new(
-        server: Server<impl Fn(&rouille::Request) -> rouille::Response + Send + Sync + 'static>,
-    ) -> Self {
-        let port = server.server_addr().port();
-        let (_, kill_switch) = server.stoppable();
-        Self { kill_switch, port }
+    fn new(router: Router) -> Result<Self, HttpServerError> {
+        let (port_tx, port_rx) = std::sync::mpsc::sync_channel(1);
+        let handle = RUNTIME.spawn(async move {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("failed to bind");
+            port_tx
+                .send(
+                    listener
+                        .local_addr()
+                        .expect("failed to get local addr")
+                        .port(),
+                )
+                .expect("failed to send port");
+            axum::serve(listener, router).await.expect("server error");
+        });
+        let port = port_rx.recv().map_err(|e| HttpServerError {
+            error: e.to_string(),
+        })?;
+        Ok(Self {
+            abort: handle.abort_handle(),
+            port,
+        })
     }
 
     fn port(&self) -> u16 {
         self.port
     }
 
-    fn relative_path_to_url(&self, file: &str) -> String {
-        format!("http://127.0.0.1:{}/{}", self.port, file)
+    fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}/{}", self.port, path)
     }
 }
 
@@ -53,14 +82,8 @@ impl ServeStaticFiles {
     /// Creates a new HTTP server that serves static files from a directory.
     /// Note: This server is only available for testing purposes.
     pub fn from(static_path: impl Into<PathBuf>) -> Result<Self, HttpServerError> {
-        let static_path = static_path.into();
-        let server = Server::new("127.0.0.1:0", move |request| {
-            match_assets(request, &static_path)
-        })
-        .map_err(|e| HttpServerError {
-            error: e.to_string(),
-        })?;
-        Ok(Self(TestHttpServer::new(server)))
+        let router = Router::new().fallback_service(ServeDir::new(static_path.into()));
+        Ok(Self(TestHttpServer::new(router)?))
     }
 
     /// Returns the port of the server.
@@ -69,12 +92,27 @@ impl ServeStaticFiles {
         self.0.port()
     }
 
-    /// Returns the URL of a file.
-    /// The file path should be relative to the static path.
+    /// Returns the URL for a relative path on this server.
     #[must_use]
-    pub fn relative_path_to_url(&self, file: &str) -> String {
-        self.0.relative_path_to_url(file)
+    pub fn relative_path_to_url(&self, path: &str) -> String {
+        self.0.url(path)
     }
+}
+
+async fn check_auth(
+    State(expected_token): State<Arc<str>>,
+    headers: HeaderMap,
+    request: Request,
+    next: Next,
+) -> Response {
+    let auth = headers
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    if auth != format!("Bearer {expected_token}") {
+        return (StatusCode::UNAUTHORIZED, "Unauthorized").into_response();
+    }
+    next.run(request).await
 }
 
 /// An HTTP server that requires Bearer token authentication to serve static files.
@@ -88,20 +126,11 @@ impl ServeStaticFilesWithAuth {
         static_path: impl Into<PathBuf>,
         expected_token: impl Into<String>,
     ) -> Result<Self, HttpServerError> {
-        let static_path = static_path.into();
-        let expected_token = expected_token.into();
-        let server = Server::new("127.0.0.1:0", move |request| {
-            let auth = request.header("Authorization").unwrap_or_default();
-            let expected = format!("Bearer {expected_token}");
-            if auth != expected {
-                return rouille::Response::text("Unauthorized").with_status_code(401);
-            }
-            match_assets(request, &static_path)
-        })
-        .map_err(|e| HttpServerError {
-            error: e.to_string(),
-        })?;
-        Ok(Self(TestHttpServer::new(server)))
+        let token: Arc<str> = expected_token.into().into();
+        let router = Router::new()
+            .fallback_service(ServeDir::new(static_path.into()))
+            .layer(middleware::from_fn_with_state(token, check_auth));
+        Ok(Self(TestHttpServer::new(router)?))
     }
 
     /// Returns the port of the server.
@@ -116,36 +145,95 @@ impl ServeStaticFilesWithAuth {
         format!("http://127.0.0.1:{}/", self.0.port())
     }
 
-    /// Returns the URL of a file.
+    /// Returns the URL for a relative path on this server.
     #[must_use]
-    pub fn relative_path_to_url(&self, file: &str) -> String {
-        self.0.relative_path_to_url(file)
+    pub fn relative_path_to_url(&self, path: &str) -> String {
+        self.0.url(path)
     }
 }
 
 /// A mock GitHub REST API server.
 ///
 /// Serves `GET /repos/{owner}/{repo}/releases/tags/{tag}` with a caller-provided
-/// JSON body, and `GET /<asset-path>` with caller-provided binary content. Any
-/// other path returns 404.
+/// JSON body, and `GET /assets/{filename}` with caller-provided binary content.
+/// Any other path returns 404.
 ///
-/// Counts the number of requests it received so tests can assert caching behavior.
+/// Counts every request so tests can assert caching behaviour.
 pub struct MockGitHubApi {
     server: TestHttpServer,
     request_count: Arc<AtomicUsize>,
 }
+
 /// Description of a single release served by [`MockGitHubApi`].
 pub struct MockRelease {
-    /// `{owner}/{repo}/{tag}` path components.
+    /// The repository owner.
     pub owner: String,
     /// The repository name.
     pub repo: String,
     /// The release tag.
     pub tag: String,
-    /// The assets in the release: `(filename, content)` pairs. Each asset is
-    /// served at `/assets/{filename}` and the release JSON's `url` points to
-    /// that same path on this server.
+    /// Assets in the release: `(filename, content)` pairs. Each asset is
+    /// served at `/assets/{filename}` and the release JSON's `url` points there.
     pub assets: Vec<(String, Vec<u8>)>,
+}
+
+struct MockApiState {
+    releases: Vec<MockRelease>,
+}
+
+async fn mock_github_handler(
+    State(state): State<Arc<MockApiState>>,
+    headers: HeaderMap,
+    request: Request,
+) -> Response {
+    let path = request.uri().path().to_owned();
+    for release in &state.releases {
+        let tags_path = format!(
+            "/repos/{}/{}/releases/tags/{}",
+            release.owner, release.repo, release.tag
+        );
+        if path == tags_path {
+            let host = headers
+                .get("Host")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("127.0.0.1");
+            let assets: Vec<serde_json::Value> = release
+                .assets
+                .iter()
+                .map(|(name, _)| {
+                    serde_json::json!({
+                        "name": name,
+                        "url": format!("http://{host}/assets/{name}"),
+                    })
+                })
+                .collect();
+            return (
+                StatusCode::OK,
+                axum::Json(serde_json::json!({ "assets": assets })),
+            )
+                .into_response();
+        }
+        for (name, content) in &release.assets {
+            if path == format!("/assets/{name}") {
+                return (
+                    StatusCode::OK,
+                    [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
+                    content.clone(),
+                )
+                    .into_response();
+            }
+        }
+    }
+    StatusCode::NOT_FOUND.into_response()
+}
+
+async fn count_requests(
+    State(counter): State<Arc<AtomicUsize>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let _ = counter.fetch_add(1, Ordering::SeqCst);
+    next.run(request).await
 }
 
 impl MockGitHubApi {
@@ -153,54 +241,21 @@ impl MockGitHubApi {
     /// server fails to bind to a local port.
     pub fn start(releases: Vec<MockRelease>) -> Result<Self, HttpServerError> {
         let request_count = Arc::new(AtomicUsize::new(0));
-        let counter = Arc::clone(&request_count);
-        let server = Server::new("127.0.0.1:0", move |request| {
-            _ = counter.fetch_add(1, Ordering::SeqCst);
-            let url = request.url();
-            for release in &releases {
-                let tags_path = format!(
-                    "/repos/{}/{}/releases/tags/{}",
-                    release.owner, release.repo, release.tag
-                );
-                if url == tags_path {
-                    // Build a release JSON where each asset's `url` points at
-                    // `/assets/{filename}` on this same server.
-                    let host = request.header("Host").unwrap_or("127.0.0.1");
-                    let assets_json: Vec<serde_json::Value> = release
-                        .assets
-                        .iter()
-                        .map(|(name, _)| {
-                            serde_json::json!({
-                                "name": name,
-                                "url": format!("http://{host}/assets/{name}"),
-                            })
-                        })
-                        .collect();
-                    let body = serde_json::json!({ "assets": assets_json });
-                    return rouille::Response::from_data("application/json", body.to_string());
-                }
-                for (name, content) in &release.assets {
-                    if url == format!("/assets/{name}") {
-                        return rouille::Response::from_data(
-                            "application/octet-stream",
-                            content.clone(),
-                        );
-                    }
-                }
-            }
-            rouille::Response::empty_404()
-        })
-        .map_err(|e| HttpServerError {
-            error: e.to_string(),
-        })?;
+        let state = Arc::new(MockApiState { releases });
+        let router = Router::new()
+            .fallback(mock_github_handler)
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&request_count),
+                count_requests,
+            ))
+            .with_state(state);
         Ok(Self {
-            server: TestHttpServer::new(server),
+            server: TestHttpServer::new(router)?,
             request_count,
         })
     }
 
-    /// Base URL of the mock API (e.g. `http://127.0.0.1:12345`). Pass this to
-    /// `normalize_github_url_with_api_base` in tests.
+    /// Base URL of the mock API (e.g. `http://127.0.0.1:12345`).
     #[must_use]
     pub fn base_url(&self) -> String {
         format!("http://127.0.0.1:{}", self.server.port())
@@ -230,7 +285,7 @@ mod tests {
         assert_eq!(content.status(), 200);
         assert_eq!(
             content.headers().get("Content-Type").unwrap(),
-            "application/octet-stream"
+            "text/x-yaml"
         );
         let mut body = String::new();
         _ = content
@@ -246,7 +301,7 @@ mod tests {
         assert_eq!(content.status(), 200);
         assert_eq!(
             content.headers().get("Content-Type").unwrap(),
-            "application/octet-stream"
+            "text/x-yaml"
         );
         let mut body = String::new();
         _ = content
@@ -259,7 +314,6 @@ mod tests {
         let result = ureq::get(&server.relative_path_to_url("unknown_file.yaml")).call();
         assert!(result.is_err());
         let err = result.unwrap_err();
-        // In ureq v3, check if it's a status error with code 404
         if let ureq::Error::StatusCode(code) = err {
             assert_eq!(code, 404);
         } else {

--- a/crates/weaver_common/src/vdir.rs
+++ b/crates/weaver_common/src/vdir.rs
@@ -73,7 +73,6 @@ use gix::remote::fetch::Shallow;
 use gix::{create, open, progress};
 use once_cell::sync::Lazy;
 use regex::Regex;
-use rouille::url::Url;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -88,6 +87,7 @@ use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 use ureq::config::{Config, RedirectAuthHeaders};
 use ureq::Agent;
+use url::Url;
 
 /// When true, git clone operations use `open::Options::default()` which reads
 /// global/system git config and enables credential helpers for private repos.


### PR DESCRIPTION
Scorecard is reporting these:

```
Warn: Project is vulnerable to: RUSTSEC-2023-0028
Warn: Project is vulnerable to: RUSTSEC-2023-0050
Warn: Project is vulnerable to: RUSTSEC-2023-0081
Warn: Project is vulnerable to: RUSTSEC-2021-0146
```

These are all because of the unmaintained crate: rouille which is used for a test http server. This PR reimplements that using axum which is already a dependency anyway.