### PR TITLE
fix: default enum member value to id

### DIFF
--- a/crates/weaver_semconv/src/attribute.rs
+++ b/crates/weaver_semconv/src/attribute.rs
@@ -418,19 +418,34 @@ pub struct EnumEntriesSpec {
     pub annotations: Option<BTreeMap<String, YamlValue>>,
 }
 
+/// Deserialization helper for [`EnumEntriesSpec`] that allows `value` to be
+/// omitted and defaulted from `id`. The fields mirror [`EnumEntriesSpec`]
+/// (including doc comments) so the generated JSON schema retains field
+/// descriptions when `#[serde(from = "...")]` redirects schema derivation here.
 #[derive(Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct EnumEntriesSpecDeserialize {
+    /// String that uniquely identifies the enum entry.
     id: String,
+    /// String, int, or boolean; value of the enum entry.
+    /// If omitted, defaults to the value of `id`.
     value: Option<ValueSpec>,
+    /// Brief description of the enum entry value.
+    /// It defaults to the value of id.
     brief: Option<String>,
+    /// Longer description.
+    /// It defaults to an empty string.
     note: Option<String>,
+    /// Stability of this enum value.
     stability: Option<Stability>,
+    /// Deprecation note.
     #[serde(
         deserialize_with = "crate::deprecated::deserialize_option_deprecated",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     deprecated: Option<Deprecated>,
+    /// Annotations for the member.
     annotations: Option<BTreeMap<String, YamlValue>>,
 }
 

--- a/crates/weaver_semconv/src/attribute.rs
+++ b/crates/weaver_semconv/src/attribute.rs
@@ -389,6 +389,7 @@ impl Display for TemplateTypeSpec {
 )]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
+#[serde(from = "EnumEntriesSpecDeserialize")]
 pub struct EnumEntriesSpec {
     /// String that uniquely identifies the enum entry.
     pub id: String,
@@ -415,6 +416,38 @@ pub struct EnumEntriesSpec {
     /// Annotations for the member.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<BTreeMap<String, YamlValue>>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct EnumEntriesSpecDeserialize {
+    id: String,
+    value: Option<ValueSpec>,
+    brief: Option<String>,
+    note: Option<String>,
+    stability: Option<Stability>,
+    #[serde(
+        deserialize_with = "crate::deprecated::deserialize_option_deprecated",
+        default
+    )]
+    deprecated: Option<Deprecated>,
+    annotations: Option<BTreeMap<String, YamlValue>>,
+}
+
+impl From<EnumEntriesSpecDeserialize> for EnumEntriesSpec {
+    fn from(entry: EnumEntriesSpecDeserialize) -> Self {
+        Self {
+            value: entry
+                .value
+                .unwrap_or_else(|| ValueSpec::String(entry.id.clone())),
+            id: entry.id,
+            brief: entry.brief,
+            note: entry.note,
+            stability: entry.stability,
+            deprecated: entry.deprecated,
+            annotations: entry.annotations,
+        }
+    }
 }
 
 /// Implements a human readable display for EnumEntries.

--- a/crates/weaver_semconv/src/semconv.rs
+++ b/crates/weaver_semconv/src/semconv.rs
@@ -725,6 +725,52 @@ mod tests {
         assert_eq!(semconv_spec.spec.into_v1("test").groups.len(), 2);
     }
 
+    #[test]
+    fn test_enum_member_value_defaults_to_id() {
+        let spec = r#"
+        groups:
+          - id: registry.test
+            type: attribute_group
+            brief: Test attributes
+            attributes:
+              - id: test.environment
+                brief: Test environment.
+                stability: stable
+                type:
+                  members:
+                    - id: production
+                      brief: Production environment.
+                      stability: stable
+                    - id: staging
+                      value: stage
+                      brief: Staging environment.
+                      stability: stable
+        "#;
+
+        let semconv_spec = semconv_from_file(spec)
+            .into_result_failing_non_fatal()
+            .unwrap()
+            .spec
+            .into_v1("test");
+        let crate::attribute::AttributeSpec::Id { r#type, .. } =
+            &semconv_spec.groups[0].attributes[0]
+        else {
+            panic!("expected local attribute definition");
+        };
+        let crate::attribute::AttributeType::Enum { members } = r#type else {
+            panic!("expected enum attribute type");
+        };
+
+        assert_eq!(
+            members[0].value,
+            crate::attribute::ValueSpec::String("production".to_owned())
+        );
+        assert_eq!(
+            members[1].value,
+            crate::attribute::ValueSpec::String("stage".to_owned())
+        );
+    }
+
     fn parse_versioned(spec: &str) -> Versioned {
         let temp_file = make_temp_file(spec);
         SemConvSpecWithProvenance::from_file(

--- a/schemas/semconv.materialized.v2.json
+++ b/schemas/semconv.materialized.v2.json
@@ -469,14 +469,20 @@
           ]
         },
         "value": {
-          "description": "String, int, or boolean; value of the enum entry.",
-          "$ref": "#/$defs/ValueSpec"
+          "description": "String, int, or boolean; value of the enum entry.\nIf omitted, defaults to the value of `id`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ValueSpec"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
       "required": [
-        "id",
-        "value"
+        "id"
       ]
     },
     "Event": {

--- a/schemas/semconv.resolved.v2.json
+++ b/schemas/semconv.resolved.v2.json
@@ -452,14 +452,20 @@
           ]
         },
         "value": {
-          "description": "String, int, or boolean; value of the enum entry.",
-          "$ref": "#/$defs/ValueSpec"
+          "description": "String, int, or boolean; value of the enum entry.\nIf omitted, defaults to the value of `id`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ValueSpec"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
       "required": [
-        "id",
-        "value"
+        "id"
       ]
     },
     "Event": {

--- a/schemas/semconv.schema.v2.json
+++ b/schemas/semconv.schema.v2.json
@@ -652,14 +652,20 @@
           ]
         },
         "value": {
-          "description": "String, int, or boolean; value of the enum entry.",
-          "$ref": "#/$defs/ValueSpec"
+          "description": "String, int, or boolean; value of the enum entry.\nIf omitted, defaults to the value of `id`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ValueSpec"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
       "required": [
-        "id",
-        "value"
+        "id"
       ]
     },
     "Event": {


### PR DESCRIPTION
## What changed

Enum member deserialization now accepts entries without an explicit `value` field and fills the public `EnumEntriesSpec.value` with the member `id`. Explicit `value` fields are still preserved.

This keeps downstream code working with a concrete `ValueSpec` while matching the semantic convention schema behavior described in #733.

Closes #733.

## Verification

- `cargo test -p weaver_semconv test_enum_member_value_defaults_to_id`
- `cargo test -p weaver_semconv`
