### PR TITLE
Fix Scorecard pin dependencies issues

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -141,6 +141,19 @@
     },
     {
       customType: "regex",
+      description: "Update pnpm version in Dockerfile",
+      managerFilePatterns: [
+        "Dockerfile",
+      ],
+      matchStrings: [
+        "npm install -g pnpm@(?<currentValue>[0-9.]+)",
+      ],
+      depNameTemplate: "pnpm",
+      datasourceTemplate: "npm",
+      versioningTemplate: "semver",
+    },
+    {
+      customType: "regex",
       description: "Update Just file",
       managerFilePatterns: [
         "justfile",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           components: rustfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,11 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install dist
-        # we specify bash to get pipefail; it guards against the `curl` command
-        # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh -o /tmp/cargo-dist-installer.sh
+          echo "e79d87e418b9d2cbe992d014985457c28a5a7c553add3da4ed1047e161c928f4  /tmp/cargo-dist-installer.sh" | sha256sum -c
+          sh /tmp/cargo-dist-installer.sh
       - name: Cache dist
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
@@ -130,7 +131,9 @@ jobs:
         if: ${{ matrix.container }}
         run: |
           if ! command -v cargo > /dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh
+            echo "6c30b75a75b28a96fd913a037c8581b580080b6ee9b8169a3c0feb1af7fe8caf  /tmp/rustup-init.sh" | sha256sum -c
+            sh /tmp/rustup-init.sh -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
       - name: "Setup pnpm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@ WORKDIR /build
 # Install Node.js and musl build dependencies
 # renovate: datasource=node-version depName=node
 ARG NODE_VERSION=24
-RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x -o /tmp/nodesource-setup.sh && \
+  echo "6e3d580f5bd7ccf2aa1e8df8d35c60d78e873c3ff8beb282c9bebd914904ad72  /tmp/nodesource-setup.sh" | sha256sum -c && \
+  bash /tmp/nodesource-setup.sh && \
   apt-get install -y nodejs musl-tools musl-dev perl
 
 # Copy UI package files first for better layer caching
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10.33.4
 COPY ui/package.json ui/pnpm-lock.yaml /build/ui/
 RUN cd /build/ui && pnpm install --frozen-lockfile
 

--- a/crates/xtask/src/fix_release_permissions.rs
+++ b/crates/xtask/src/fix_release_permissions.rs
@@ -2,11 +2,12 @@ use anyhow::{bail, Context};
 
 const PATH: &str = ".github/workflows/release.yml";
 
-/// Patch release.yml after `dist generate` to restore scoped GitHub workflow permissions.
+/// Patch release.yml after `dist generate` to fix Scorecard findings.
 ///
-/// dist generates `permissions: contents: write` at the top level; Scorecard flags this.
-/// This patches it to `contents: read` and grants `contents: write` only to the two jobs
-/// that actually create GitHub Releases (plan and host).
+/// 1. Permissions: dist generates `permissions: contents: write` at the top level; this patches
+///    it to `contents: read` and grants `contents: write` only to plan and host jobs.
+/// 2. Pinned-Dependencies: replaces `curl | sh` patterns with download-verify-execute so
+///    Scorecard recognises the scripts as hash-pinned.
 pub fn run() -> anyhow::Result<()> {
     let content =
         std::fs::read_to_string(PATH).with_context(|| format!("failed to read {PATH}"))?;
@@ -15,7 +16,7 @@ pub fn run() -> anyhow::Result<()> {
 
     std::fs::write(PATH, patched).with_context(|| format!("failed to write {PATH}"))?;
 
-    println!("Patched {PATH}: scoped contents:write to plan and host jobs only");
+    println!("Patched {PATH}: scoped permissions and pinned curl downloads");
     Ok(())
 }
 
@@ -34,6 +35,37 @@ fn apply_patches(content: &str) -> anyhow::Result<String> {
         (
             "  host:\n    needs:",
             "  host:\n    permissions:\n      \"contents\": \"write\"\n    needs:",
+        ),
+        // Scorecard Pinned-Dependencies: replace curl|sh with download-verify-execute
+        (
+            concat!(
+                "      - name: Install dist\n",
+                "        # we specify bash to get pipefail; it guards against the `curl` command\n",
+                "        # failing. otherwise `sh` won't catch that `curl` returned non-0\n",
+                "        shell: bash\n",
+                "        run: \"curl --proto '=https' --tlsv1.2 -LsSf",
+                " https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh\"",
+            ),
+            concat!(
+                "      - name: Install dist\n",
+                "        shell: bash\n",
+                "        run: |\n",
+                "          curl --proto '=https' --tlsv1.2 -LsSf",
+                " https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh",
+                " -o /tmp/cargo-dist-installer.sh\n",
+                "          echo \"e79d87e418b9d2cbe992d014985457c28a5a7c553add3da4ed1047e161c928f4",
+                "  /tmp/cargo-dist-installer.sh\" | sha256sum -c\n",
+                "          sh /tmp/cargo-dist-installer.sh",
+            ),
+        ),
+        (
+            "            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
+            concat!(
+                "            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh\n",
+                "            echo \"6c30b75a75b28a96fd913a037c8581b580080b6ee9b8169a3c0feb1af7fe8caf",
+                "  /tmp/rustup-init.sh\" | sha256sum -c\n",
+                "            sh /tmp/rustup-init.sh -y",
+            ),
         ),
     ];
 


### PR DESCRIPTION
There are 5 pin dep issues that this should clear. A couple of them are download-then-run issues so a verify step against the sha is added.

This does add more maintenance on our plates - renovate can't cover the custom sha verification steps.