### PR TITLE
Don't check template-type key format

### DIFF
--- a/defaults/policies/live_check_advice/otel.rego
+++ b/defaults/policies/live_check_advice/otel.rego
@@ -35,6 +35,7 @@ deny contains make_advice(advice_type, advice_level, advice_context, message) if
 # checks attribute name format
 deny contains make_advice(advice_type, advice_level, advice_context, message) if {
 	input.sample.attribute
+	not is_template_type(input.sample.attribute.name)
 	not regex.match(name_regex, input.sample.attribute.name)
 	advice_type := "invalid_format"
 	advice_level := "violation"


### PR DESCRIPTION
Fixes #1443 

This PR goes with the assumption that the `<key>` part of a template type can be any format and does not need to comply with the regex rule covering the rest of the attribute key. @lmolkova - is this the correct assumption?

This is achieved by simply checking if we've already matched a template type (which we can assume has correct formatting) and therefore skip the `invalid_format` check.