### PR TITLE
feat(docker): allow runtime base override via RUNTIME_BASE arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,10 @@ RUN cd /build/ui && pnpm build
 RUN ./cross-arch-build.sh
 
 # The runtime image
-FROM docker.io/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+# Keep the default pinned Alpine runtime for backward compatibility, but allow
+# downstream builds to override the runtime base image/distro when needed.
+ARG RUNTIME_BASE=docker.io/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+FROM ${RUNTIME_BASE}
 LABEL maintainer="The OpenTelemetry Authors"
 RUN addgroup weaver \
   && adduser \


### PR DESCRIPTION
## Summary

- Introduce `ARG RUNTIME_BASE` for the runtime stage in `Dockerfile`.
- Keep the existing pinned Alpine image as the default value.
- Switch runtime `FROM` to `FROM ${RUNTIME_BASE}`.

## Why

This keeps current behavior unchanged while allowing downstream/CI builds to override the runtime base image or distro when security/compliance requirements need a faster patch path than the default runtime base cadence.

This is proposed as a follow-up to issue #1453.

## Backward compatibility

- Default build output remains the same (`alpine:3.23.4@sha256:...`).
- No workflow changes are required for existing users.

## Example

```bash
docker build --build-arg RUNTIME_BASE=docker.io/alpine:3.24.2 .
```