### PR TITLE
Remediate Curl/libcurl CVEs (CVE-2026-5773, CVE-2026-6276)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,8 @@ RUN cd /build/ui && pnpm build
 RUN ./cross-arch-build.sh
 
 # The runtime image
-FROM docker.io/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+FROM docker.io/alpine:3.23.4@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
 LABEL maintainer="The OpenTelemetry Authors"
-RUN apk add --no-cache \
-  'curl>=8.20.0-r0' \
-  'libcurl>=8.20.0-r0'
 RUN addgroup weaver \
   && adduser \
   --ingroup weaver \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN ./cross-arch-build.sh
 # The runtime image
 FROM docker.io/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 LABEL maintainer="The OpenTelemetry Authors"
+RUN apk add --no-cache \
+  'curl>=8.20.0-r0' \
+  'libcurl>=8.20.0-r0'
 RUN addgroup weaver \
   && adduser \
   --ingroup weaver \


### PR DESCRIPTION
# Why this change
The current runtime image is pinned to Alpine 3.23.4, where scanner results flagged curl/libcurl CVEs affecting 8.19.0-r0 (CVE-2026-5773, CVE-2026-6276).

For this PR, bumped pinned Alpine runtime digest to pick up patched curl/libcurl; verified with local JFrog scan (no security violations)


