### PR TITLE
Fix Flaky test port reservation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
     permissions:
       contents: none
     name: CI
-    needs: [test, msrv, docs, rustfmt, clippy, check-usage-docs, check-generated]
+    needs:
+      [test, msrv, docs, rustfmt, clippy, check-usage-docs, check-generated]
     runs-on: ubuntu-latest
     steps:
       - name: Done
@@ -39,8 +40,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
           cache-dependency-path: ui/pnpm-lock.yaml
       - name: Verify pnpm is available
         run: pnpm --version
@@ -85,8 +86,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
           cache-dependency-path: ui/pnpm-lock.yaml
       - name: Verify pnpm is available
         run: pnpm --version
@@ -146,8 +147,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
           cache-dependency-path: ui/pnpm-lock.yaml
       - name: Verify pnpm is available
         run: pnpm --version
@@ -228,8 +229,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
           cache-dependency-path: ui/pnpm-lock.yaml
       - name: Verify pnpm is available
         run: pnpm --version
@@ -280,8 +281,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
           cache-dependency-path: ui/pnpm-lock.yaml
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -401,7 +402,7 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Gather coverage
-        run: cargo tarpaulin --workspace --output-dir coverage --out lcov --ignore-tests -e xtask -e weaver -e weaver_macros --exclude-files 'crates/weaver_forge/codegen_examples/expected_codegen/*' 'crates/weaver_live_check/tests/*'
+        run: cargo tarpaulin --workspace --output-dir coverage --out lcov --ignore-tests -e xtask -e weaver -e weaver_macros -e weaver_test_support --exclude-files 'crates/weaver_forge/codegen_examples/expected_codegen/*' 'crates/weaver_live_check/tests/*'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6530,6 +6530,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "weaver_test_support"
+version = "0.23.0"
+
+[[package]]
 name = "weaver_version"
 version = "0.23.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2835,7 +2835,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3916,15 +3916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portpicker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
-dependencies = [
- "rand 0.8.6",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4167,8 +4158,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -4178,7 +4167,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -4191,16 +4180,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4218,9 +4197,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -4655,7 +4631,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4714,7 +4690,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5266,7 +5242,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6178,7 +6154,6 @@ dependencies = [
  "miette",
  "mime_guess",
  "opentelemetry",
- "portpicker",
  "prost",
  "ratatui",
  "ratatui-textarea",
@@ -6212,6 +6187,7 @@ dependencies = [
  "weaver_search",
  "weaver_semconv",
  "weaver_semconv_gen",
+ "weaver_test_support",
  "weaver_version",
  "zip",
 ]
@@ -6381,7 +6357,6 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
- "portpicker",
  "schemars",
  "serde",
  "serde_json",
@@ -6398,6 +6373,7 @@ dependencies = [
  "weaver_forge",
  "weaver_resolved_schema",
  "weaver_semconv",
+ "weaver_test_support",
 ]
 
 [[package]]
@@ -6679,7 +6655,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ toml = "0.9.8"
 zip = "5.1.1"
 assert_cmd = "2.2.1"
 semver = { version = "1.0.27", features = ["serde"] }
-portpicker = "0.1.1"
 glob = "0.3.3"
 
 # Features definition =========================================================
@@ -144,10 +143,10 @@ tokio.workspace = true
 [dev-dependencies]
 weaver_diff = { path = "crates/weaver_diff" }
 weaver_version = { path = "crates/weaver_version" }
+weaver_test_support = { path = "crates/weaver_test_support" }
 tempfile.workspace = true
 ureq.workspace = true
 assert_cmd.workspace = true
-portpicker.workspace = true
 zip.workspace = true
 
 [build-dependencies]

--- a/crates/weaver_live_check/Cargo.toml
+++ b/crates/weaver_live_check/Cargo.toml
@@ -30,8 +30,8 @@ tokio.workspace = true
 strum = { version = "0.27.2", features = ["derive"] }
 
 [dev-dependencies]
+weaver_test_support = { path = "../weaver_test_support" }
 assert_cmd.workspace = true
-portpicker.workspace = true
 tempfile.workspace = true
 serde_yaml.workspace = true
 serial_test = "3.4.0"

--- a/crates/weaver_live_check/tests/livecheck_emit.rs
+++ b/crates/weaver_live_check/tests/livecheck_emit.rs
@@ -8,6 +8,7 @@ use std::process::{Child, Command as StdCommand};
 use std::rc::Rc;
 use std::thread::sleep;
 use std::time::Duration;
+use weaver_test_support::reserve_test_port;
 
 /// Guard that kills the child process on drop (e.g., on panic) to prevent orphaned processes.
 struct ChildGuard(Option<Child>);
@@ -124,14 +125,15 @@ fn collect_violation_messages(value: &serde_json::Value, messages: &mut Vec<Stri
 #[cfg_attr(tarpaulin, ignore)]
 async fn test_livecheck_emit_roundtrip() {
     // 1. Allocate dynamic ports
-    let grpc_port = portpicker::pick_unused_port().expect("no free port for gRPC");
-    let admin_port = portpicker::pick_unused_port().expect("no free port for admin");
+    let grpc_port = reserve_test_port();
+    let admin_port = reserve_test_port();
 
     // 2. Start weaver live-check as a child process using the live_check model as registry
     //    The model dir is relative to this crate's manifest, so build an absolute path.
     let model_dir = format!("{}/model", env!("CARGO_MANIFEST_DIR"));
     #[allow(deprecated)] // cargo_bin() is the only cross-crate way to find the binary
     let weaver_bin = assert_cmd::cargo::cargo_bin("weaver");
+
     let mut guard = ChildGuard(Some(
         StdCommand::new(weaver_bin)
             .args([

--- a/crates/weaver_test_support/Cargo.toml
+++ b/crates/weaver_test_support/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "weaver_test_support"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Internal test utilities shared across weaver crates."
+
+[dependencies]
+
+[lints]
+workspace = true
+
+[package.metadata.cargo-machete]
+ignored = []

--- a/crates/weaver_test_support/README.md
+++ b/crates/weaver_test_support/README.md
@@ -1,0 +1,12 @@
+# Weaver test support
+
+Status: **Internal**
+
+This crate provides small test-only utilities shared across weaver crates. It
+is intended for use as a `[dev-dependencies]` entry only and is not published.
+
+Currently exports:
+
+- `reserve_test_port()` — returns a free local TCP port from a PID-derived
+  lane (30000–40000), avoiding cross-binary collisions when test suites run
+  in parallel.

--- a/crates/weaver_test_support/allowed-external-types.toml
+++ b/crates/weaver_test_support/allowed-external-types.toml
@@ -1,0 +1,5 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# This is used with cargo-check-external-types to reduce the surface area of downstream crates from
+# the public API. Ideally this can have a few exceptions as possible.
+allowed_external_types = []

--- a/crates/weaver_test_support/src/lib.rs
+++ b/crates/weaver_test_support/src/lib.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Test utilities shared across weaver crates.
+//!
+//! This crate is intended for use as a `[dev-dependencies]` entry only.
+
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::OnceLock;
+
+const LANE_BASE: u16 = 30000;
+const LANE_SIZE: u16 = 50;
+const NUM_LANES: u16 = 200;
+
+static NEXT_PORT: OnceLock<AtomicU16> = OnceLock::new();
+
+fn next_port_counter() -> &'static AtomicU16 {
+    NEXT_PORT.get_or_init(|| {
+        let lane_idx = u16::try_from(std::process::id() % u32::from(NUM_LANES))
+            .expect("lane index is bounded by NUM_LANES, which fits in u16");
+        AtomicU16::new(LANE_BASE + lane_idx * LANE_SIZE)
+    })
+}
+
+/// Reserve a free port for use in a test. Each test binary picks a 50-port
+/// lane from a PID-derived offset (30000–40000); within the binary an
+/// atomic counter walks through the lane and the candidate is verified
+/// free with a probe-bind. Cross-binary collisions are vanishingly rare
+/// because lanes don't overlap.
+#[must_use]
+pub fn reserve_test_port() -> u16 {
+    let counter = next_port_counter();
+    for _ in 0..(LANE_SIZE as usize * 4) {
+        let port = counter.fetch_add(1, Ordering::SeqCst);
+        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return port;
+        }
+    }
+    panic!("could not reserve a free port in this test binary's port lane")
+}

--- a/src/registry/otlp/mod.rs
+++ b/src/registry/otlp/mod.rs
@@ -612,11 +612,12 @@ mod tests {
     use crate::registry::otlp::grpc_stubs::proto::collector::metrics::v1::metrics_service_client::MetricsServiceClient;
     use crate::registry::otlp::grpc_stubs::proto::collector::trace::v1::trace_service_client::TraceServiceClient;
     use std::thread;
+    use weaver_test_support::reserve_test_port;
 
     #[test]
     fn test_inactivity_stop_after_1_second() {
-        let grpc_port = portpicker::pick_unused_port().expect("No free ports");
-        let admin_port = portpicker::pick_unused_port().expect("No free ports");
+        let grpc_port = reserve_test_port();
+        let admin_port = reserve_test_port();
         let inactivity_timeout = Duration::from_secs(1);
 
         let (mut receiver, _report_sender) =
@@ -708,8 +709,8 @@ mod tests {
 
     #[test]
     fn test_http_stop_endpoint_with_report() {
-        let grpc_port = portpicker::pick_unused_port().expect("No free ports");
-        let admin_port = portpicker::pick_unused_port().expect("No free ports");
+        let grpc_port = reserve_test_port();
+        let admin_port = reserve_test_port();
         let inactivity_timeout = Duration::from_secs(5);
 
         let (mut receiver, report_sender) =
@@ -755,8 +756,8 @@ mod tests {
 
     #[test]
     fn test_http_stop_endpoint_immediate() {
-        let grpc_port = portpicker::pick_unused_port().expect("No free ports");
-        let admin_port = portpicker::pick_unused_port().expect("No free ports");
+        let grpc_port = reserve_test_port();
+        let admin_port = reserve_test_port();
         let inactivity_timeout = Duration::from_secs(5);
 
         let (mut receiver, _report_sender) =
@@ -790,8 +791,8 @@ mod tests {
 
     #[test]
     fn test_health_endpoint() {
-        let grpc_port = portpicker::pick_unused_port().expect("No free ports");
-        let admin_port = portpicker::pick_unused_port().expect("No free ports");
+        let grpc_port = reserve_test_port();
+        let admin_port = reserve_test_port();
         let inactivity_timeout = Duration::from_secs(5);
 
         let (_receiver, _report_sender) =

--- a/tests/registry_emit.rs
+++ b/tests/registry_emit.rs
@@ -7,8 +7,7 @@ use std::process::Command as StdCommand;
 use std::thread::sleep;
 use std::time::Duration;
 use tempfile::tempdir;
-
-use portpicker::pick_unused_port;
+use weaver_test_support::reserve_test_port;
 
 /// This test verifies the roundtrip functionality of registry live check and emit commands.
 /// This test doesn't count for the coverage report as it runs separate processes.
@@ -30,8 +29,8 @@ fn run_emit_with_live_check_test(use_v2: bool) {
         .to_str()
         .expect("Failed to convert temp directory path to string");
 
-    let otlp_grpc_port = pick_unused_port().expect("no free OTLP gRPC port");
-    let admin_port = pick_unused_port().expect("no free admin port");
+    let otlp_grpc_port = reserve_test_port();
+    let admin_port = reserve_test_port();
 
     // Build the arguments for live check command
     // Note: --input-source otlp and --skip-policies false are explicitly set
@@ -150,11 +149,11 @@ fn run_emit_with_live_check_test(use_v2: bool) {
 #[test]
 fn test_emit_with_resource_attributes() {
     // Ports for weaver3 (final collector)
-    let w3_grpc_port = pick_unused_port().expect("no free weaver3 OTLP gRPC port");
-    let w3_admin_port = pick_unused_port().expect("no free weaver3 admin port");
+    let w3_grpc_port = reserve_test_port();
+    let w3_admin_port = reserve_test_port();
     // Ports for weaver2 (middle live-check with emit)
-    let w2_grpc_port = pick_unused_port().expect("no free weaver2 OTLP gRPC port");
-    let w2_admin_port = pick_unused_port().expect("no free weaver2 admin port");
+    let w2_grpc_port = reserve_test_port();
+    let w2_admin_port = reserve_test_port();
 
     // Temp dir for weaver3's JSON output
     let temp_dir = tempdir().expect("Failed to create temporary directory");

--- a/tests/serve_ui.rs
+++ b/tests/serve_ui.rs
@@ -6,13 +6,12 @@ use std::io::Read;
 use std::process::Command as StdCommand;
 use std::thread::sleep;
 use std::time::Duration;
-
-use portpicker::pick_unused_port;
+use weaver_test_support::reserve_test_port;
 
 /// Test that weaver serve starts and serves the UI correctly.
 #[test]
 fn test_ui_served() {
-    let port = pick_unused_port().expect("no free port for weaver serve");
+    let port = reserve_test_port();
     let bind_address = format!("127.0.0.1:{port}");
 
     // Start weaver serve command as a background process on a non-standard port


### PR DESCRIPTION
We have flaky tests due to port collisions despite using port picker. There are race hazards due to parallel runs.

Solved with our own implementation of port reservation which also separates port selection for multiple binaries running at the same time.