### PR TITLE
Fix fuzz job

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -2,15 +2,9 @@
 
 cd "$SRC/weaver"
 
-cargo +nightly fuzz build
+cargo +nightly fuzz build -O --debug-assertions
 
 FUZZ_OUT="fuzz/target/x86_64-unknown-linux-gnu/release"
-cp "$FUZZ_OUT/live_check_json"       "$OUT/"
-cp "$FUZZ_OUT/live_check_text"       "$OUT/"
-cp "$FUZZ_OUT/semconv_yaml"          "$OUT/"
-cp "$FUZZ_OUT/semconv_manifest_yaml" "$OUT/"
-cp "$FUZZ_OUT/forge_config_yaml"     "$OUT/"
-cp "$FUZZ_OUT/weaver_config_toml"    "$OUT/"
-cp "$FUZZ_OUT/policy_rego"           "$OUT/"
-cp "$FUZZ_OUT/forge_jq"              "$OUT/"
-cp "$FUZZ_OUT/forge_jinja"           "$OUT/"
+for f in fuzz/fuzz_targets/*.rs; do
+    cp "$FUZZ_OUT/$(basename "${f%.*}")" "$OUT/"
+done

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -2,7 +2,7 @@
 
 cd "$SRC/weaver"
 
-cargo +nightly fuzz build --manifest-path fuzz/Cargo.toml
+cargo +nightly fuzz build
 
 FUZZ_OUT="fuzz/target/x86_64-unknown-linux-gnu/release"
 cp "$FUZZ_OUT/live_check_json"       "$OUT/"

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -10,6 +10,9 @@ permissions: read-all
 jobs:
   BatchFuzzing:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -17,6 +20,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@main
+        with:
+          language: rust
+          sanitizer: ${{ matrix.sanitizer }}
       - name: Run ClusterFuzzLite batch fuzzing
         uses: google/clusterfuzzlite/actions/run_fuzzers@main
         with:

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -18,16 +18,15 @@ jobs:
       matrix:
         sanitizer: [address]
     steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build Fuzzers (${{ matrix.sanitizer }})
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@52ecc61cb587ee99c26825a112a21abf19c7448c # main
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: rust
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           sanitizer: ${{ matrix.sanitizer }}
       - name: Run ClusterFuzzLite batch fuzzing
-        uses: google/clusterfuzzlite/actions/run_fuzzers@52ecc61cb587ee99c26825a112a21abf19c7448c # main
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 600

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build Fuzzers (${{ matrix.sanitizer }})
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@main
+        uses: google/clusterfuzzlite/actions/build_fuzzers@52ecc61cb587ee99c26825a112a21abf19c7448c # main
         with:
           language: rust
           sanitizer: ${{ matrix.sanitizer }}
       - name: Run ClusterFuzzLite batch fuzzing
-        uses: google/clusterfuzzlite/actions/run_fuzzers@main
+        uses: google/clusterfuzzlite/actions/run_fuzzers@52ecc61cb587ee99c26825a112a21abf19c7448c # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 600
@@ -36,7 +36,7 @@ jobs:
           output-sarif: true
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: cifuzz-sarif/results.sarif
           category: clusterfuzzlite-${{ matrix.sanitizer }}

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,20 +1,20 @@
-name: ClusterFuzzLite batch fuzzing
+name: ClusterFuzzLite PR fuzzing
 
-# Nightly extended fuzzing across all targets. Companion to cflite_pr.yml
-# (per-PR fuzzing of changed code). NOTE: ClusterFuzzLite's `mode: batch`
-# does not currently populate SARIF results, so crashes found here will
-# appear in the run's `crashes` artifact but NOT in the Security tab.
-# PR-mode (code-change) is the path that reliably surfaces findings.
+# Per-PR fuzzing of changed code. Companion to cflite_batch.yml (nightly
+# scheduled batch runs). This workflow uses `mode: code-change`, which is the
+# only ClusterFuzzLite mode that reliably emits SARIF for the Security tab.
 
 on:
-  schedule:
-    - cron: '0 2 * * *'  # nightly at 02:00 UTC
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**'
+      - '!**/*.md'
+      - '!docs/**'
 
 permissions: read-all
 
 jobs:
-  BatchFuzzing:
+  PRFuzzing:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,14 +29,15 @@ jobs:
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: rust
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           sanitizer: ${{ matrix.sanitizer }}
-      - name: Run ClusterFuzzLite batch fuzzing
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Fuzzers (${{ matrix.sanitizer }})
+        id: run
         uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          fuzz-seconds: 600
-          mode: batch
+          fuzz-seconds: 300
+          mode: code-change
           sanitizer: ${{ matrix.sanitizer }}
           output-sarif: true
       - name: Upload SARIF

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -13,6 +13,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   PRFuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Attempt to fix the fuzzer.

This should get the fuzzer running (I've proved this in my fork) - the results are still somewhat buried but there seems to be an issue upstream with the reporting aspect.

There is a different way to do this where you register with OSS-Fuzz - OpenTelemetry is registered and otel go and go-contrib are using it.