### PR TITLE
Add one_of and all_of to entity associations

### DIFF
--- a/crates/weaver_forge/src/registry.rs
+++ b/crates/weaver_forge/src/registry.rs
@@ -16,6 +16,7 @@ use weaver_resolved_schema::registry::{Group, Registry};
 use weaver_semconv::any_value::AnyValueSpec;
 use weaver_semconv::attribute::BasicRequirementLevelSpec;
 use weaver_semconv::deprecated::Deprecated;
+use weaver_semconv::entity_association::EntityAssociation;
 use weaver_semconv::group::{GroupType, InstrumentSpec, SpanKindSpec};
 use weaver_semconv::stability::Stability;
 use weaver_semconv::YamlValue;
@@ -120,9 +121,12 @@ pub struct ResolvedGroup {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<AnyValueSpec>,
     /// The associated entities of this group.
+    ///
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
     /// Annotations for the group.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/weaver_forge/src/v2/event.rs
+++ b/crates/weaver_forge/src/v2/event.rs
@@ -5,6 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_semconv::{
     attribute::RequirementLevel,
+    entity_association::EntityAssociation,
     v2::{signal_id::SignalId, CommonFields},
 };
 
@@ -25,11 +26,11 @@ pub struct Event {
 
     /// Which resources this event should be associated with.
     ///
-    /// This list is an "any of" list, where a event may be associated with one or more entities, but should
-    /// be associated with at least one in this list.
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
 
     /// Common fields (like brief, note, annotations).
     #[serde(flatten)]

--- a/crates/weaver_forge/src/v2/metric.rs
+++ b/crates/weaver_forge/src/v2/metric.rs
@@ -6,6 +6,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_semconv::{
     attribute::{BasicRequirementLevelSpec, RequirementLevel},
+    entity_association::EntityAssociation,
     group::InstrumentSpec,
     v2::{signal_id::SignalId, CommonFields},
 };
@@ -33,11 +34,11 @@ pub struct Metric {
     // TODO - Should Entity Associations be "strong" links?
     /// Which resources this metric should be associated with.
     ///
-    /// This list is an "any of" list, where a metric may be associated with one or more entities, but should
-    /// be associated with at least one in this list.
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
 
     /// The requirement level of the metric. Defaults to 'recommended' when omitted.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/weaver_forge/src/v2/span.rs
+++ b/crates/weaver_forge/src/v2/span.rs
@@ -6,6 +6,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_semconv::{
     attribute::RequirementLevel,
+    entity_association::EntityAssociation,
     group::SpanKindSpec,
     v2::{signal_id::SignalId, span::SpanName, CommonFields},
 };
@@ -28,11 +29,11 @@ pub struct Span {
     pub attributes: Vec<SpanAttribute>,
     /// Which resources this span should be associated with.
     ///
-    /// This list is an "any of" list, where a span may be associated with one or more entities, but should
-    /// be associated with at least one in this list.
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
 
     /// Common fields (like brief, note, annotations).
     #[serde(flatten)]

--- a/crates/weaver_live_check/data/entity_associations.json
+++ b/crates/weaver_live_check/data/entity_associations.json
@@ -1,0 +1,51 @@
+[
+  {
+    "resource": {
+      "attributes": [
+        { "name": "service.name", "value": "my-service", "type": "string" }
+      ]
+    }
+  },
+  {
+    "log": {
+      "attributes": [],
+      "body": "",
+      "event_name": "thing.happened",
+      "severity_number": 9,
+      "severity_text": "INFO"
+    }
+  },
+  {
+    "resource": {
+      "attributes": [
+        { "name": "host.name", "value": "host-1", "type": "string" }
+      ]
+    }
+  },
+  {
+    "log": {
+      "attributes": [],
+      "body": "",
+      "event_name": "thing.happened",
+      "severity_number": 9,
+      "severity_text": "INFO"
+    }
+  },
+  {
+    "resource": {
+      "attributes": [
+        { "name": "tenant.id", "value": "t-1", "type": "string" },
+        { "name": "container.id", "value": "c-1", "type": "string" }
+      ]
+    }
+  },
+  {
+    "log": {
+      "attributes": [],
+      "body": "",
+      "event_name": "thing.happened",
+      "severity_number": 9,
+      "severity_text": "INFO"
+    }
+  }
+]

--- a/crates/weaver_live_check/data/model/entity_associations/registry.yaml
+++ b/crates/weaver_live_check/data/model/entity_associations/registry.yaml
@@ -1,0 +1,76 @@
+# Demonstrates nested one_of / all_of entity associations for `weaver registry live-check`.
+#
+# Run against data/entity_associations.json, whose three resource+log pairs show:
+#   1. empty resource    -> tenant.id violation AND inner one_of(host, container) unsatisfied
+#   2. host.name present  -> inner one_of satisfied via host, but tenant.id still missing
+#   3. tenant.id + container.id present -> required levels satisfied; recommended container.name
+#      missing -> improvement
+groups:
+  # --- Attributes ---
+  - id: registry.service
+    type: attribute_group
+    stability: stable
+    brief: "Service attributes"
+    attributes:
+      - id: service.name
+        type: string
+        stability: stable
+        brief: "Service name"
+        examples: ["my-service"]
+
+  # --- Entities ---
+  - id: entity.host
+    type: entity
+    name: host
+    stability: stable
+    brief: "A host"
+    attributes:
+      - id: host.name
+        type: string
+        stability: stable
+        brief: "Host name"
+        requirement_level: required
+
+  - id: entity.container
+    type: entity
+    name: container
+    stability: stable
+    brief: "A container"
+    attributes:
+      - id: container.id
+        type: string
+        stability: stable
+        brief: "Container id"
+        requirement_level: required
+      - id: container.name
+        type: string
+        stability: stable
+        brief: "Container name"
+        requirement_level: recommended
+
+  - id: entity.tenant
+    type: entity
+    name: tenant
+    stability: stable
+    brief: "A tenant"
+    attributes:
+      - id: tenant.id
+        type: string
+        stability: stable
+        brief: "Tenant id"
+        requirement_level: required
+
+  # --- Event with a nested one_of / all_of entity association ---
+  # The resource must be associated with the tenant entity AND with at least
+  # one of the host or container entities.
+  - id: event.thing.happened
+    type: event
+    name: thing.happened
+    stability: stable
+    brief: "Something happened"
+    entity_associations:
+      - all_of:
+          - tenant
+          - one_of:
+              - host
+              - container

--- a/crates/weaver_live_check/docs/finding.md
+++ b/crates/weaver_live_check/docs/finding.md
@@ -109,6 +109,7 @@ Custom Rego policies may emit additional finding IDs not listed here.
 | `entity_recommended_attribute_not_present` | ![Development](https://img.shields.io/badge/-development-blue) | A recommended entity attribute is absent from the resource |
 | `entity_opt_in_attribute_not_present` | ![Development](https://img.shields.io/badge/-development-blue) | An opt-in entity attribute is absent from the resource |
 | `entity_conditionally_required_attribute_not_present` | ![Development](https://img.shields.io/badge/-development-blue) | A conditionally required entity attribute is absent from the resource |
+| `entity_association_not_satisfied` | ![Development](https://img.shields.io/badge/-development-blue) | No entity in a one_of association group was satisfied by the resource |
 | `missing_namespace` | ![Development](https://img.shields.io/badge/-development-blue) | An attribute name has no dot-separated namespace |
 | `invalid_format` | ![Development](https://img.shields.io/badge/-development-blue) | An attribute or metric name does not match the required naming format |
 | `illegal_namespace` | ![Development](https://img.shields.io/badge/-development-blue) | An attribute name uses a namespace that collides with an existing attribute |

--- a/crates/weaver_live_check/model/live_check.yaml
+++ b/crates/weaver_live_check/model/live_check.yaml
@@ -80,6 +80,10 @@ attributes:
           value: "entity_conditionally_required_attribute_not_present"
           brief: "A conditionally required entity attribute is absent from the resource"
           stability: development
+        - id: entity_association_not_satisfied
+          value: "entity_association_not_satisfied"
+          brief: "No entity in a one_of association group was satisfied by the resource"
+          stability: development
         # Default Rego policy findings (otel.rego)
         - id: missing_namespace
           value: "missing_namespace"

--- a/crates/weaver_live_check/src/advice/mod.rs
+++ b/crates/weaver_live_check/src/advice/mod.rs
@@ -22,7 +22,7 @@ pub use deprecated_advisor::DeprecatedAdvisor;
 pub use enum_advisor::EnumAdvisor;
 pub use rego_advisor::RegoAdvisor;
 pub use stability_advisor::StabilityAdvisor;
-pub(crate) use type_advisor::check_entity_resource_attributes;
+pub(crate) use type_advisor::check_entity_associations;
 pub use type_advisor::TypeAdvisor;
 
 /// Provides advice on a sample

--- a/crates/weaver_live_check/src/advice/type_advisor.rs
+++ b/crates/weaver_live_check/src/advice/type_advisor.rs
@@ -12,13 +12,15 @@ use weaver_semconv::attribute::{
     TemplateTypeSpec,
 };
 
+use weaver_semconv::entity_association::EntityAssociation;
+
 use super::{emit_findings, Advisor, FindingBuilder};
 use crate::{
-    otlp_logger::OtlpEmitter, sample_attribute::SampleAttribute, sample_metric::SampleInstrument,
-    Error, FindingId, Sample, SampleRef, VersionedAttribute, VersionedEntity, VersionedSignal,
-    ATTRIBUTE_KEY_ADVICE_CONTEXT_KEY, ATTRIBUTE_TYPE_ADVICE_CONTEXT_KEY,
-    ENTITY_TYPE_ADVICE_CONTEXT_KEY, EXPECTED_VALUE_ADVICE_CONTEXT_KEY,
-    INSTRUMENT_ADVICE_CONTEXT_KEY, UNIT_ADVICE_CONTEXT_KEY,
+    live_checker::LiveChecker, otlp_logger::OtlpEmitter, sample_attribute::SampleAttribute,
+    sample_metric::SampleInstrument, Error, FindingId, Sample, SampleRef, VersionedAttribute,
+    VersionedEntity, VersionedSignal, ATTRIBUTE_KEY_ADVICE_CONTEXT_KEY,
+    ATTRIBUTE_TYPE_ADVICE_CONTEXT_KEY, ENTITY_TYPE_ADVICE_CONTEXT_KEY,
+    EXPECTED_VALUE_ADVICE_CONTEXT_KEY, INSTRUMENT_ADVICE_CONTEXT_KEY, UNIT_ADVICE_CONTEXT_KEY,
 };
 
 /// An advisor that checks if a sample has the correct type
@@ -99,24 +101,24 @@ pub(crate) fn check_entity_resource_attributes(
             RequirementLevel::Basic(BasicRequirementLevelSpec::Required) => (
                 FindingId::EntityRequiredAttributeNotPresent,
                 FindingLevel::Violation,
-                format!("Required attribute '{key}' for entity '{entity_type}' is not present in resource."),
+                format!("Required attribute '{key}' for entity '{entity_type}' is not present in the resource."),
             ),
             RequirementLevel::Basic(BasicRequirementLevelSpec::Recommended)
             | RequirementLevel::Recommended { .. } => (
                 FindingId::EntityRecommendedAttributeNotPresent,
                 FindingLevel::Improvement,
-                format!("Recommended attribute '{key}' for entity '{entity_type}' is not present in resource."),
+                format!("Recommended attribute '{key}' for entity '{entity_type}' is not present in the resource."),
             ),
             RequirementLevel::Basic(BasicRequirementLevelSpec::OptIn)
             | RequirementLevel::OptIn { .. } => (
                 FindingId::EntityOptInAttributeNotPresent,
                 FindingLevel::Information,
-                format!("Opt-in attribute '{key}' for entity '{entity_type}' is not present in resource."),
+                format!("Opt-in attribute '{key}' for entity '{entity_type}' is not present in the resource."),
             ),
             RequirementLevel::ConditionallyRequired { .. } => (
                 FindingId::EntityConditionallyRequiredAttributeNotPresent,
                 FindingLevel::Information,
-                format!("Conditionally required attribute '{key}' for entity '{entity_type}' is not present in resource."),
+                format!("Conditionally required attribute '{key}' for entity '{entity_type}' is not present in the resource."),
             ),
         };
         advice_list.push(PolicyFinding {
@@ -158,6 +160,151 @@ pub(crate) fn check_entity_resource_attributes(
     }
 
     advice_list
+}
+
+/// The outcome of evaluating an entity association expression against the resource.
+struct AssocEval {
+    /// Whether the expression is satisfied (all required attributes of the chosen path present).
+    satisfied: bool,
+    /// Findings to surface to the user for the chosen path.
+    findings: Vec<PolicyFinding>,
+}
+
+/// Evaluates a signal's entity associations against the resource and returns the findings to emit.
+///
+/// The top-level list is an implicit `one_of`: the telemetry must satisfy at least one entry.
+/// `one_of`/`all_of` combinators may be nested arbitrarily.
+pub(crate) fn check_entity_associations(
+    associations: &[EntityAssociation],
+    live_checker: &LiveChecker,
+    resource_attributes: &[SampleAttribute],
+    parent_signal: &Sample,
+) -> Vec<PolicyFinding> {
+    match associations {
+        [] => Vec::new(),
+        // A single top-level entry is evaluated directly so a lone `all_of` keeps its detailed
+        // per-attribute findings instead of being collapsed into an aggregate.
+        [single] => {
+            evaluate_association(single, live_checker, resource_attributes, parent_signal).findings
+        }
+        // Multiple top-level entries combine as an implicit `one_of`.
+        many => evaluate_one_of(many, live_checker, resource_attributes, parent_signal).findings,
+    }
+}
+
+/// Recursively evaluates a single entity association expression.
+fn evaluate_association(
+    assoc: &EntityAssociation,
+    live_checker: &LiveChecker,
+    resource_attributes: &[SampleAttribute],
+    parent_signal: &Sample,
+) -> AssocEval {
+    match assoc {
+        EntityAssociation::Ref(name) => match live_checker.find_entity(name) {
+            Some(entity) => {
+                let findings =
+                    check_entity_resource_attributes(&entity, resource_attributes, parent_signal);
+                // Satisfied when no required (Violation-level) attribute is missing. Any
+                // remaining recommended/opt-in/conditional findings are surfaced as improvements.
+                let satisfied = !findings.iter().any(|f| f.level == FindingLevel::Violation);
+                AssocEval {
+                    satisfied,
+                    findings,
+                }
+            }
+            // Unknown entity references are skipped (treated as neutral) to avoid spurious
+            // violations for entities that are not present in the registry.
+            None => AssocEval {
+                satisfied: true,
+                findings: Vec::new(),
+            },
+        },
+        EntityAssociation::OneOf { one_of } => {
+            evaluate_one_of(one_of, live_checker, resource_attributes, parent_signal)
+        }
+        EntityAssociation::AllOf { all_of } => {
+            evaluate_all_of(all_of, live_checker, resource_attributes, parent_signal)
+        }
+    }
+}
+
+/// Evaluates an `all_of` group: every child must be satisfied; all child findings are surfaced.
+fn evaluate_all_of(
+    children: &[EntityAssociation],
+    live_checker: &LiveChecker,
+    resource_attributes: &[SampleAttribute],
+    parent_signal: &Sample,
+) -> AssocEval {
+    let mut satisfied = true;
+    let mut findings = Vec::new();
+    for child in children {
+        let eval = evaluate_association(child, live_checker, resource_attributes, parent_signal);
+        satisfied &= eval.satisfied;
+        findings.extend(eval.findings);
+    }
+    AssocEval {
+        satisfied,
+        findings,
+    }
+}
+
+/// Evaluates a `one_of` group: at least one child must be satisfied. When satisfied, only the
+/// satisfied branches' improvement findings are surfaced; when none are satisfied, a single
+/// aggregate finding naming the candidate entities is emitted.
+fn evaluate_one_of(
+    children: &[EntityAssociation],
+    live_checker: &LiveChecker,
+    resource_attributes: &[SampleAttribute],
+    parent_signal: &Sample,
+) -> AssocEval {
+    let mut any_satisfied = false;
+    let mut findings = Vec::new();
+    for child in children {
+        let eval = evaluate_association(child, live_checker, resource_attributes, parent_signal);
+        if eval.satisfied {
+            any_satisfied = true;
+            findings.extend(eval.findings);
+        }
+    }
+    if any_satisfied {
+        AssocEval {
+            satisfied: true,
+            findings,
+        }
+    } else {
+        AssocEval {
+            satisfied: false,
+            findings: vec![entity_association_not_satisfied(children, parent_signal)],
+        }
+    }
+}
+
+/// Builds the aggregate finding emitted when no branch of a `one_of` group is satisfied.
+fn entity_association_not_satisfied(
+    children: &[EntityAssociation],
+    parent_signal: &Sample,
+) -> PolicyFinding {
+    // Collect the candidate entity names, de-duplicated while preserving order.
+    let mut seen = HashSet::new();
+    let entities: Vec<&str> = children
+        .iter()
+        .flat_map(EntityAssociation::referenced_entities)
+        .filter(|name| seen.insert(*name))
+        .collect();
+    let message = format!(
+        "None of the associated entities [{}] were satisfied by the resource.",
+        entities.join(", ")
+    );
+    PolicyFinding {
+        id: FindingId::EntityAssociationNotSatisfied.into(),
+        context: Some(json!({
+            ENTITY_TYPE_ADVICE_CONTEXT_KEY: entities,
+        })),
+        message,
+        level: FindingLevel::Violation,
+        signal_type: parent_signal.signal_type(),
+        signal_name: parent_signal.signal_name(),
+    }
 }
 
 /// Checks if attributes from a resolved group are present in a list of sample attributes

--- a/crates/weaver_live_check/src/generated/attributes.rs
+++ b/crates/weaver_live_check/src/generated/attributes.rs
@@ -89,6 +89,8 @@ pub enum FindingId {
     EntityOptInAttributeNotPresent,
     /// A conditionally required entity attribute is absent from the resource
     EntityConditionallyRequiredAttributeNotPresent,
+    /// No entity in a one_of association group was satisfied by the resource
+    EntityAssociationNotSatisfied,
     /// An attribute name has no dot-separated namespace
     MissingNamespace,
     /// An attribute or metric name does not match the required naming format

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -212,6 +212,7 @@ mod tests {
         span::{Span as V2Span, SpanAttribute},
     };
     use weaver_resolved_schema::attribute::Attribute;
+    use weaver_semconv::entity_association::EntityAssociation;
     use weaver_semconv::v2::{span::SpanName, CommonFields};
     use weaver_semconv::{
         attribute::{
@@ -2188,7 +2189,7 @@ mod tests {
                     events: vec![V2Event {
                         name: "deployment.started".to_owned().into(),
                         attributes: vec![],
-                        entity_associations: vec!["deployment".to_owned()],
+                        entity_associations: vec![EntityAssociation::Ref("deployment".to_owned())],
                         common: CommonFields {
                             brief: "A deployment has started".to_owned(),
                             note: "".to_owned(),
@@ -2362,7 +2363,7 @@ mod tests {
                         brief: "A deployment has started".to_owned(),
                         note: "".to_owned(),
                         prefix: "".to_owned(),
-                        entity_associations: vec!["deployment".to_owned()],
+                        entity_associations: vec![EntityAssociation::Ref("deployment".to_owned())],
                         extends: None,
                         stability: Some(Stability::Stable),
                         deprecated: None,
@@ -2595,6 +2596,217 @@ mod tests {
         );
     }
 
+    /// Builds a minimal required-only string attribute for entity-association tests.
+    fn required_string_attr(name: &str) -> Attribute {
+        Attribute {
+            name: name.to_owned(),
+            r#type: AttributeType::PrimitiveOrArray(PrimitiveOrArrayTypeSpec::String),
+            examples: None,
+            brief: String::new(),
+            tag: None,
+            requirement_level: RequirementLevel::Basic(BasicRequirementLevelSpec::Required),
+            sampling_relevant: None,
+            note: String::new(),
+            stability: Some(Stability::Stable),
+            deprecated: None,
+            prefix: false,
+            tags: None,
+            value: None,
+            annotations: None,
+            role: Default::default(),
+        }
+    }
+
+    /// Builds a V1 entity group with a single required identity attribute.
+    fn entity_group(type_name: &str, attr: Attribute) -> ResolvedGroup {
+        ResolvedGroup {
+            id: format!("entity.{type_name}"),
+            r#type: GroupType::Entity,
+            brief: String::new(),
+            note: String::new(),
+            prefix: String::new(),
+            entity_associations: vec![],
+            extends: None,
+            stability: Some(Stability::Stable),
+            deprecated: None,
+            attributes: vec![attr],
+            span_kind: None,
+            events: vec![],
+            metric_name: None,
+            instrument: None,
+            unit: None,
+            metric_requirement_level: None,
+            name: Some(type_name.to_owned()),
+            lineage: None,
+            display_name: None,
+            body: None,
+            annotations: None,
+        }
+    }
+
+    /// Builds a V1 event group carrying the given entity associations.
+    fn assoc_event_group(name: &str, associations: Vec<EntityAssociation>) -> ResolvedGroup {
+        ResolvedGroup {
+            id: format!("event.{name}"),
+            r#type: GroupType::Event,
+            brief: String::new(),
+            note: String::new(),
+            prefix: String::new(),
+            entity_associations: associations,
+            extends: None,
+            stability: Some(Stability::Stable),
+            deprecated: None,
+            attributes: vec![],
+            span_kind: None,
+            events: vec![],
+            metric_name: None,
+            instrument: None,
+            unit: None,
+            metric_requirement_level: None,
+            name: Some(name.to_owned()),
+            lineage: None,
+            display_name: None,
+            body: None,
+            annotations: None,
+        }
+    }
+
+    fn string_sample_attr(name: &str, value: &str) -> SampleAttribute {
+        SampleAttribute {
+            name: name.to_owned(),
+            value: Some(serde_json::json!(value)),
+            r#type: None,
+            live_check_result: None,
+        }
+    }
+
+    /// Runs live-check on a single log event and returns the accumulated findings.
+    fn run_event_check(
+        live_checker: &mut LiveChecker,
+        stats: &mut LiveCheckStatistics,
+        event_name: &str,
+        attrs: Vec<SampleAttribute>,
+    ) -> Vec<PolicyFinding> {
+        let mut sample = make_log_sample(event_name, attrs);
+        let snapshot = sample.clone();
+        sample
+            .run_live_check(live_checker, stats, None, &snapshot)
+            .expect("live check should not error");
+        match &sample {
+            Sample::Log(log) => log.live_check_result.as_ref().unwrap().all_advice.clone(),
+            _ => panic!("expected log sample"),
+        }
+    }
+
+    #[test]
+    fn test_entity_association_one_of_all_of() {
+        // host (required host.name) and container (required container.id) entities, plus events
+        // associated with a `one_of` and an `all_of` of those two entities.
+        let registry = VersionedRegistry::V1(Box::new(ResolvedRegistry {
+            registry_url: "TEST_ASSOC".to_owned(),
+            groups: vec![
+                entity_group("host", required_string_attr("host.name")),
+                entity_group("container", required_string_attr("container.id")),
+                assoc_event_group(
+                    "one_of.evt",
+                    vec![EntityAssociation::OneOf {
+                        one_of: vec![
+                            EntityAssociation::Ref("host".to_owned()),
+                            EntityAssociation::Ref("container".to_owned()),
+                        ],
+                    }],
+                ),
+                assoc_event_group(
+                    "all_of.evt",
+                    vec![EntityAssociation::AllOf {
+                        all_of: vec![
+                            EntityAssociation::Ref("host".to_owned()),
+                            EntityAssociation::Ref("container".to_owned()),
+                        ],
+                    }],
+                ),
+            ],
+        }));
+        let advisors: Vec<Box<dyn Advisor>> = vec![Box::new(TypeAdvisor)];
+        let mut live_checker = LiveChecker::new(Arc::new(registry), advisors);
+        let mut stats =
+            LiveCheckStatistics::Cumulative(CumulativeStatistics::new(&live_checker.registry));
+
+        // one_of satisfied by host → no entity findings at all.
+        let advice = run_event_check(
+            &mut live_checker,
+            &mut stats,
+            "one_of.evt",
+            vec![string_sample_attr("host.name", "h1")],
+        );
+        assert!(
+            advice.iter().all(|a| !a.id.starts_with("entity_")),
+            "one_of satisfied: expected no entity findings, got {advice:?}"
+        );
+
+        // one_of unsatisfied → exactly one aggregate finding, no per-branch required findings.
+        let advice = run_event_check(&mut live_checker, &mut stats, "one_of.evt", vec![]);
+        let aggregates: Vec<_> = advice
+            .iter()
+            .filter(|a| a.id == "entity_association_not_satisfied")
+            .collect();
+        assert_eq!(
+            aggregates.len(),
+            1,
+            "one_of unsatisfied: expected a single aggregate finding, got {advice:?}"
+        );
+        assert_eq!(aggregates[0].level, FindingLevel::Violation);
+        assert_eq!(
+            aggregates[0].context,
+            Some(json!({ "entity_type": ["host", "container"] }))
+        );
+        assert!(
+            advice
+                .iter()
+                .all(|a| a.id != "entity_required_attribute_not_present"),
+            "one_of unsatisfied: expected no per-branch required findings, got {advice:?}"
+        );
+
+        // all_of with only host present → container's required attribute is a violation, and no
+        // aggregate finding (all_of reports per-attribute).
+        let advice = run_event_check(
+            &mut live_checker,
+            &mut stats,
+            "all_of.evt",
+            vec![string_sample_attr("host.name", "h1")],
+        );
+        assert!(
+            advice
+                .iter()
+                .any(|a| a.id == "entity_required_attribute_not_present"
+                    && a.context
+                        .as_ref()
+                        .is_some_and(|c| c["entity_type"] == "container")),
+            "all_of: expected a container required-attribute violation, got {advice:?}"
+        );
+        assert!(
+            advice
+                .iter()
+                .all(|a| a.id != "entity_association_not_satisfied"),
+            "all_of: no aggregate finding expected, got {advice:?}"
+        );
+
+        // all_of fully satisfied → no entity findings.
+        let advice = run_event_check(
+            &mut live_checker,
+            &mut stats,
+            "all_of.evt",
+            vec![
+                string_sample_attr("host.name", "h1"),
+                string_sample_attr("container.id", "c1"),
+            ],
+        );
+        assert!(
+            advice.iter().all(|a| !a.id.starts_with("entity_")),
+            "all_of satisfied: expected no entity findings, got {advice:?}"
+        );
+    }
+
     #[test]
     fn test_metric_entity_validation() {
         run_metric_entity_validation_test(false);
@@ -2638,7 +2850,7 @@ mod tests {
                         unit: "s".to_owned(),
                         requirement_level: None,
                         attributes: vec![],
-                        entity_associations: vec!["host".to_owned()],
+                        entity_associations: vec![EntityAssociation::Ref("host".to_owned())],
                         common: CommonFields {
                             brief: "System uptime".to_owned(),
                             note: "".to_owned(),
@@ -2728,7 +2940,7 @@ mod tests {
                         brief: "System uptime".to_owned(),
                         note: "".to_owned(),
                         prefix: "".to_owned(),
-                        entity_associations: vec!["host".to_owned()],
+                        entity_associations: vec![EntityAssociation::Ref("host".to_owned())],
                         extends: None,
                         stability: Some(Stability::Stable),
                         deprecated: None,

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -2880,7 +2880,8 @@ mod tests {
             "neither group satisfied: expected a single aggregate finding, got {advice:?}"
         );
         assert_eq!(aggregates[0].level, FindingLevel::Violation);
-        let mut entities: Vec<&str> = aggregates[0].context.as_ref().expect("context")["entity_type"]
+        let mut entities: Vec<&str> = aggregates[0].context.as_ref().expect("context")
+            ["entity_type"]
             .as_array()
             .expect("entity_type array")
             .iter()

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -2808,6 +2808,99 @@ mod tests {
     }
 
     #[test]
+    fn test_entity_association_multiple_top_level_all_of() {
+        // Two `all_of` groups at the top level. The top-level list is an implicit `one_of`, so the
+        // telemetry must satisfy at least one of the two groups:
+        //   - all_of[tenant, host]
+        //   - all_of[container]
+        let registry = VersionedRegistry::V1(Box::new(ResolvedRegistry {
+            registry_url: "TEST_ASSOC_MULTI".to_owned(),
+            groups: vec![
+                entity_group("host", required_string_attr("host.name")),
+                entity_group("container", required_string_attr("container.id")),
+                entity_group("tenant", required_string_attr("tenant.id")),
+                assoc_event_group(
+                    "multi.evt",
+                    vec![
+                        EntityAssociation::AllOf {
+                            all_of: vec![
+                                EntityAssociation::Ref("tenant".to_owned()),
+                                EntityAssociation::Ref("host".to_owned()),
+                            ],
+                        },
+                        EntityAssociation::AllOf {
+                            all_of: vec![EntityAssociation::Ref("container".to_owned())],
+                        },
+                    ],
+                ),
+            ],
+        }));
+        let advisors: Vec<Box<dyn Advisor>> = vec![Box::new(TypeAdvisor)];
+        let mut live_checker = LiveChecker::new(Arc::new(registry), advisors);
+        let mut stats =
+            LiveCheckStatistics::Cumulative(CumulativeStatistics::new(&live_checker.registry));
+
+        // Satisfies the second group (container.id present) but not the first → overall satisfied
+        // via the implicit one_of, so no aggregate and no per-branch required violations.
+        let advice = run_event_check(
+            &mut live_checker,
+            &mut stats,
+            "multi.evt",
+            vec![string_sample_attr("container.id", "c1")],
+        );
+        assert!(
+            advice.iter().all(|a| !a.id.starts_with("entity_")),
+            "one all_of group satisfied: expected no entity findings, got {advice:?}"
+        );
+
+        // Satisfies the first group fully (tenant.id + host.name) → also satisfied.
+        let advice = run_event_check(
+            &mut live_checker,
+            &mut stats,
+            "multi.evt",
+            vec![
+                string_sample_attr("tenant.id", "t1"),
+                string_sample_attr("host.name", "h1"),
+            ],
+        );
+        assert!(
+            advice.iter().all(|a| !a.id.starts_with("entity_")),
+            "other all_of group satisfied: expected no entity findings, got {advice:?}"
+        );
+
+        // Satisfies neither group → single aggregate finding naming every candidate entity.
+        let advice = run_event_check(&mut live_checker, &mut stats, "multi.evt", vec![]);
+        let aggregates: Vec<_> = advice
+            .iter()
+            .filter(|a| a.id == "entity_association_not_satisfied")
+            .collect();
+        assert_eq!(
+            aggregates.len(),
+            1,
+            "neither group satisfied: expected a single aggregate finding, got {advice:?}"
+        );
+        assert_eq!(aggregates[0].level, FindingLevel::Violation);
+        let mut entities: Vec<&str> = aggregates[0].context.as_ref().expect("context")["entity_type"]
+            .as_array()
+            .expect("entity_type array")
+            .iter()
+            .map(|v| v.as_str().expect("string"))
+            .collect();
+        entities.sort_unstable();
+        assert_eq!(
+            entities,
+            vec!["container", "host", "tenant"],
+            "aggregate should list every candidate entity across both groups"
+        );
+        assert!(
+            advice
+                .iter()
+                .all(|a| a.id != "entity_required_attribute_not_present"),
+            "neither group satisfied: per-branch required findings should be suppressed, got {advice:?}"
+        );
+    }
+
+    #[test]
     fn test_metric_entity_validation() {
         run_metric_entity_validation_test(false);
     }

--- a/crates/weaver_live_check/src/sample_log.rs
+++ b/crates/weaver_live_check/src/sample_log.rs
@@ -7,9 +7,10 @@ use std::rc::Rc;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_checker::FindingLevel;
+use weaver_semconv::entity_association::EntityAssociation;
 
 use crate::{
-    advice::{check_entity_resource_attributes, emit_findings, FindingBuilder},
+    advice::{check_entity_associations, emit_findings, FindingBuilder},
     live_checker::LiveChecker,
     sample_attribute::SampleAttribute,
     sample_resource::SampleResource,
@@ -95,28 +96,30 @@ impl LiveCheckRunner for SampleLog {
             .resource()
             .map(|r| r.attributes.as_slice())
             .unwrap_or(&[]);
-        let entity_associations: &[String] = match semconv_event.as_deref() {
+        let entity_associations: &[EntityAssociation] = match semconv_event.as_deref() {
             Some(VersionedSignal::Group(g)) => &g.entity_associations,
             Some(VersionedSignal::Event(e)) => &e.entity_associations,
             _ => &[],
         };
-        for entity_type in entity_associations {
-            if let Some(entity) = live_checker.find_entity(entity_type) {
-                let findings =
-                    check_entity_resource_attributes(&entity, resource_attributes, parent_signal);
-                let sample_ref = SampleRef::Log(self);
-                emit_findings(
-                    &findings,
-                    &sample_ref,
-                    live_checker.otlp_emitter.as_deref(),
-                    parent_signal,
-                );
-                result.add_advice_list(
-                    findings,
-                    live_checker.finding_modifier.as_ref(),
-                    &sample_ref,
-                );
-            }
+        let findings = check_entity_associations(
+            entity_associations,
+            live_checker,
+            resource_attributes,
+            parent_signal,
+        );
+        if !findings.is_empty() {
+            let sample_ref = SampleRef::Log(self);
+            emit_findings(
+                &findings,
+                &sample_ref,
+                live_checker.otlp_emitter.as_deref(),
+                parent_signal,
+            );
+            result.add_advice_list(
+                findings,
+                live_checker.finding_modifier.as_ref(),
+                &sample_ref,
+            );
         }
 
         // Check attributes

--- a/crates/weaver_live_check/src/sample_metric.rs
+++ b/crates/weaver_live_check/src/sample_metric.rs
@@ -8,10 +8,11 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use weaver_checker::FindingLevel;
+use weaver_semconv::entity_association::EntityAssociation;
 use weaver_semconv::group::InstrumentSpec;
 
 use crate::{
-    advice::{check_entity_resource_attributes, emit_findings, FindingBuilder},
+    advice::{check_entity_associations, emit_findings, FindingBuilder},
     live_checker::LiveChecker,
     sample_attribute::SampleAttribute,
     sample_resource::SampleResource,
@@ -339,28 +340,30 @@ impl LiveCheckRunner for SampleMetric {
             .resource()
             .map(|r| r.attributes.as_slice())
             .unwrap_or(&[]);
-        let entity_associations: &[String] = match semconv_metric.as_deref() {
+        let entity_associations: &[EntityAssociation] = match semconv_metric.as_deref() {
             Some(VersionedSignal::Group(g)) => &g.entity_associations,
             Some(VersionedSignal::Metric(m)) => &m.entity_associations,
             _ => &[],
         };
-        for entity_type in entity_associations {
-            if let Some(entity) = live_checker.find_entity(entity_type) {
-                let findings =
-                    check_entity_resource_attributes(&entity, resource_attributes, parent_signal);
-                let sample_ref = SampleRef::Metric(self);
-                emit_findings(
-                    &findings,
-                    &sample_ref,
-                    live_checker.otlp_emitter.as_deref(),
-                    parent_signal,
-                );
-                result.add_advice_list(
-                    findings,
-                    live_checker.finding_modifier.as_ref(),
-                    &sample_ref,
-                );
-            }
+        let findings = check_entity_associations(
+            entity_associations,
+            live_checker,
+            resource_attributes,
+            parent_signal,
+        );
+        if !findings.is_empty() {
+            let sample_ref = SampleRef::Metric(self);
+            emit_findings(
+                &findings,
+                &sample_ref,
+                live_checker.otlp_emitter.as_deref(),
+                parent_signal,
+            );
+            result.add_advice_list(
+                findings,
+                live_checker.finding_modifier.as_ref(),
+                &sample_ref,
+            );
         }
 
         // Get advice for the data points

--- a/crates/weaver_live_check/tests/livecheck_emit.rs
+++ b/crates/weaver_live_check/tests/livecheck_emit.rs
@@ -316,7 +316,7 @@ async fn test_livecheck_emit_roundtrip() {
         let sample_ref = SampleRef::Log(&log);
         let finding = make_finding(
             "entity_required_attribute_not_present",
-            "Required attribute 'deployment.name' for entity 'deployment' is not present in resource.",
+            "Required attribute 'deployment.name' for entity 'deployment' is not present in the resource.",
             FindingLevel::Violation,
             Some("log"),
             Some("deployment.started"),

--- a/crates/weaver_resolved_schema/src/registry.rs
+++ b/crates/weaver_resolved_schema/src/registry.rs
@@ -18,6 +18,7 @@ use crate::registry::GroupStats::{
 use serde::{Deserialize, Serialize};
 use weaver_semconv::attribute::BasicRequirementLevelSpec;
 use weaver_semconv::deprecated::Deprecated;
+use weaver_semconv::entity_association::EntityAssociation;
 use weaver_semconv::group::{GroupType, InstrumentSpec, SpanKindSpec};
 use weaver_semconv::provenance::Provenance;
 use weaver_semconv::stability::Stability;
@@ -138,9 +139,11 @@ pub struct Group {
     pub annotations: Option<BTreeMap<String, YamlValue>>,
     /// Which resources this group should be associated with.
     /// Note: this is only viable for span, metric and event groups.
+    ///
+    /// The list is an implicit `one_of`: telemetry must satisfy at least one of the entries.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
     /// Visibility of the attribute group.
     /// This is only used for v2 conversion.
     #[serde(default)]

--- a/crates/weaver_resolved_schema/src/v2/event.rs
+++ b/crates/weaver_resolved_schema/src/v2/event.rs
@@ -4,6 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_semconv::{
     attribute::RequirementLevel,
+    entity_association::EntityAssociation,
     v2::{signal_id::SignalId, CommonFields},
 };
 
@@ -25,11 +26,11 @@ pub struct Event {
     // TODO - Should Entity Associations be "strong" links?
     /// Which entities this event should be associated with.
     ///
-    /// This list is an "any of" list, where a event may be associated with one or more entities, but should
-    /// be associated with at least one in this list.
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
 
     /// Common fields (like brief, note, annotations).
     #[serde(flatten)]

--- a/crates/weaver_resolved_schema/src/v2/metric.rs
+++ b/crates/weaver_resolved_schema/src/v2/metric.rs
@@ -5,6 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_semconv::{
     attribute::{BasicRequirementLevelSpec, RequirementLevel},
+    entity_association::EntityAssociation,
     group::InstrumentSpec,
     v2::{signal_id::SignalId, CommonFields},
 };
@@ -32,11 +33,11 @@ pub struct Metric {
     // TODO - Should Entity Associations be "strong" links?
     /// Which entities this metric should be associated with.
     ///
-    /// This list is an "any of" list, where a metric may be associated with one or more entities, but should
-    /// be associated with at least one in this list.
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
 
     /// The requirement level of the metric. Defaults to 'recommended' when omitted.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/weaver_resolved_schema/src/v2/span.rs
+++ b/crates/weaver_resolved_schema/src/v2/span.rs
@@ -4,6 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_semconv::{
     attribute::RequirementLevel,
+    entity_association::EntityAssociation,
     group::SpanKindSpec,
     v2::{signal_id::SignalId, span::SpanName, CommonFields},
 };
@@ -31,11 +32,11 @@ pub struct Span {
     // TODO - Should Entity Associations be "strong" links?
     /// Which entities this span should be associated with.
     ///
-    /// This list is an "any of" list, where a span may be associated with one or more entities, but should
-    /// be associated with at least one in this list.
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
 
     /// Common fields (like brief, note, annotations).
     #[serde(flatten)]

--- a/crates/weaver_semconv/src/entity_association.rs
+++ b/crates/weaver_semconv/src/entity_association.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Entity association expressions.
+//!
+//! An entity association declares which entities a signal (span, metric or event) should be
+//! associated with. The expression tree supports a reference to a single entity, plus `one_of`
+//! and `all_of` combinators that can be nested arbitrarily.
+//!
+//! A bare list of entity references (the historical syntax) is interpreted as an implicit
+//! `one_of`: the telemetry must satisfy at least one of the listed entities.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// An entity association expression.
+///
+/// In YAML this is either a bare string (an entity reference), a `{ one_of: [...] }` map or a
+/// `{ all_of: [...] }` map, where each list element is itself an [`EntityAssociation`].
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, JsonSchema)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(untagged)]
+pub enum EntityAssociation {
+    /// A reference to an entity by its type name.
+    Ref(String),
+    /// Satisfied when at least one of the contained expressions is satisfied.
+    OneOf {
+        /// The candidate expressions.
+        one_of: Vec<EntityAssociation>,
+    },
+    /// Satisfied when every contained expression is satisfied.
+    AllOf {
+        /// The required expressions.
+        all_of: Vec<EntityAssociation>,
+    },
+}
+
+impl EntityAssociation {
+    /// Returns an iterator over every entity name referenced anywhere in this expression tree.
+    pub fn referenced_entities(&self) -> impl Iterator<Item = &str> {
+        // A small explicit stack keeps this allocation-light and avoids recursion in a hot path.
+        let mut stack = vec![self];
+        std::iter::from_fn(move || {
+            while let Some(node) = stack.pop() {
+                match node {
+                    EntityAssociation::Ref(name) => return Some(name.as_str()),
+                    EntityAssociation::OneOf { one_of: children }
+                    | EntityAssociation::AllOf { all_of: children } => stack.extend(children),
+                }
+            }
+            None
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bare_string_parses_as_ref() {
+        let assoc: EntityAssociation = serde_yaml::from_str("service").expect("parse");
+        assert_eq!(assoc, EntityAssociation::Ref("service".to_owned()));
+    }
+
+    #[test]
+    fn test_nested_one_of_all_of() {
+        let yaml = r#"
+all_of:
+  - service
+  - deployment
+  - cloud
+  - one_of: [host, container]
+  - one_of:
+      - all_of: [x, y]
+      - z
+"#;
+        let assoc: EntityAssociation = serde_yaml::from_str(yaml).expect("parse");
+        let EntityAssociation::AllOf { all_of } = &assoc else {
+            panic!("expected all_of, got {assoc:?}");
+        };
+        assert_eq!(all_of.len(), 5);
+        assert_eq!(all_of[0], EntityAssociation::Ref("service".to_owned()));
+        assert_eq!(
+            all_of[3],
+            EntityAssociation::OneOf {
+                one_of: vec![
+                    EntityAssociation::Ref("host".to_owned()),
+                    EntityAssociation::Ref("container".to_owned()),
+                ],
+            }
+        );
+        // Round-trips.
+        let reparsed: EntityAssociation =
+            serde_yaml::from_str(&serde_yaml::to_string(&assoc).expect("serialize"))
+                .expect("parse");
+        assert_eq!(reparsed, assoc);
+    }
+
+    #[test]
+    fn test_referenced_entities() {
+        let yaml = r#"
+all_of:
+  - deployment
+  - one_of:
+      - all_of: [x, y]
+      - z
+"#;
+        let assoc: EntityAssociation = serde_yaml::from_str(yaml).expect("parse");
+        let mut names: Vec<_> = assoc.referenced_entities().collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["deployment", "x", "y", "z"]);
+    }
+}

--- a/crates/weaver_semconv/src/group.rs
+++ b/crates/weaver_semconv/src/group.rs
@@ -15,6 +15,7 @@ use crate::attribute::{
     AttributeSpec, AttributeType, BasicRequirementLevelSpec, PrimitiveOrArrayTypeSpec,
 };
 use crate::deprecated::Deprecated;
+use crate::entity_association::EntityAssociation;
 use crate::group::InstrumentSpec::{Counter, Gauge, Histogram, UpDownCounter};
 use crate::provenance::Provenance;
 use crate::semconv::Imports;
@@ -123,9 +124,12 @@ pub struct GroupSpec {
     pub annotations: Option<BTreeMap<String, YamlValue>>,
     /// Which resources this group should be associated with.
     /// Note: this is only viable for span, metric and event groups.
+    ///
+    /// The list is an implicit `one_of`: telemetry must satisfy at least one of the entries.
+    /// Each entry may be a bare entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
 
     /// Attribute groups to include - this parameter must not be provided
     /// in yaml, it's only used to convert v2 schema into v1
@@ -473,10 +477,49 @@ impl GroupSpec {
                     error: format!("Group with entity_associations cannot have type: {t:?}"),
                 }),
             }
+            // Reject empty `one_of`/`all_of` combinators and empty entity references.
+            for assoc in &self.entity_associations {
+                if let Err(error) = validate_entity_association(assoc) {
+                    errors.push(Error::InvalidGroup {
+                        path_or_url: path_or_url.to_owned(),
+                        group_id: self.id.clone(),
+                        error,
+                    });
+                }
+            }
         }
 
         WResult::with_non_fatal_errors((), errors)
     }
+}
+
+/// Recursively validates an entity association expression: combinators must be non-empty and
+/// entity references must be non-blank.
+fn validate_entity_association(assoc: &EntityAssociation) -> Result<(), String> {
+    match assoc {
+        EntityAssociation::Ref(name) => {
+            if name.trim().is_empty() {
+                return Err("entity_associations contains an empty entity reference".to_owned());
+            }
+        }
+        EntityAssociation::OneOf { one_of: children } => {
+            if children.is_empty() {
+                return Err("entity_associations contains an empty `one_of` group".to_owned());
+            }
+            for child in children {
+                validate_entity_association(child)?;
+            }
+        }
+        EntityAssociation::AllOf { all_of: children } => {
+            if children.is_empty() {
+                return Err("entity_associations contains an empty `all_of` group".to_owned());
+            }
+            for child in children {
+                validate_entity_association(child)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn validate_duplicate_attribute_ref(
@@ -1990,7 +2033,7 @@ mod tests {
             display_name: None,
             body: None,
             annotations: None,
-            entity_associations: vec!["test".to_owned()],
+            entity_associations: vec![EntityAssociation::Ref("test".to_owned())],
             visibility: None,
             is_v2: false,
             span_name_note: None,
@@ -1999,6 +2042,36 @@ mod tests {
             .validate("<test>")
             .into_result_failing_non_fatal()
             .is_ok());
+
+        // A nested one_of/all_of expression is valid.
+        group.entity_associations = vec![EntityAssociation::AllOf {
+            all_of: vec![
+                EntityAssociation::Ref("tenant".to_owned()),
+                EntityAssociation::OneOf {
+                    one_of: vec![
+                        EntityAssociation::Ref("host".to_owned()),
+                        EntityAssociation::Ref("container".to_owned()),
+                    ],
+                },
+            ],
+        }];
+        assert!(group
+            .validate("<test>")
+            .into_result_failing_non_fatal()
+            .is_ok());
+
+        // An empty combinator is rejected.
+        group.entity_associations = vec![EntityAssociation::OneOf { one_of: vec![] }];
+        let result = group.validate("<test>").into_result_failing_non_fatal();
+        assert_eq!(
+            Err(InvalidGroup {
+                path_or_url: "<test>".to_owned(),
+                group_id: "test".to_owned(),
+                error: "entity_associations contains an empty `one_of` group".to_owned(),
+            }),
+            result
+        );
+        group.entity_associations = vec![EntityAssociation::Ref("test".to_owned())];
 
         // Span should allow associations.
         group.r#type = GroupType::Span;

--- a/crates/weaver_semconv/src/lib.rs
+++ b/crates/weaver_semconv/src/lib.rs
@@ -15,6 +15,7 @@ use weaver_common::error::{format_errors, WeaverError};
 pub mod any_value;
 pub mod attribute;
 pub mod deprecated;
+pub mod entity_association;
 pub mod group;
 pub mod json_schema;
 pub mod manifest;

--- a/crates/weaver_semconv/src/v2/event.rs
+++ b/crates/weaver_semconv/src/v2/event.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     deprecated::Deprecated,
+    entity_association::EntityAssociation,
     group::{GroupSpec, GroupType},
     stability::Stability,
     v2::{
@@ -30,9 +31,12 @@ pub struct Event {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub attributes: Vec<AttributeOrGroupRef>,
     /// Which resources this event should be associated with.
+    ///
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
     /// Common fields (like brief, note, annotations).
     #[serde(flatten)]
     pub common: CommonFields,
@@ -51,9 +55,12 @@ pub struct EventRefinement {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub attributes: Vec<AttributeOrGroupRef>,
     /// Which resources this event should be associated with.
+    ///
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
 
     /// Refines the brief description of the signal.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/weaver_semconv/src/v2/metric.rs
+++ b/crates/weaver_semconv/src/v2/metric.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     attribute::BasicRequirementLevelSpec,
     deprecated::Deprecated,
+    entity_association::EntityAssociation,
     group::{GroupSpec, InstrumentSpec},
     stability::Stability,
     v2::{
@@ -41,9 +42,12 @@ pub struct Metric {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub attributes: Vec<AttributeOrGroupRef>,
     /// Which resources this metric should be associated with.
+    ///
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
     /// The requirement level of the metric. Defaults to 'recommended' when omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requirement_level: Option<BasicRequirementLevelSpec>,
@@ -65,9 +69,12 @@ pub struct MetricRefinement {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub attributes: Vec<AttributeOrGroupRef>,
     /// Which resources this metric should be associated with.
+    ///
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
 
     /// Refines the brief description of the signal.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/weaver_semconv/src/v2/span.rs
+++ b/crates/weaver_semconv/src/v2/span.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     attribute::AttributeSpec,
     deprecated::Deprecated,
+    entity_association::EntityAssociation,
     group::{GroupSpec, GroupType, SpanKindSpec},
     stability::Stability,
     v2::{attribute::AttributeRef, signal_id::SignalId, CommonFields},
@@ -74,9 +75,12 @@ pub struct Span {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub attributes: Vec<SpanAttributeOrGroupRef>,
     /// Which resources this span should be associated with.
+    ///
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
     /// Common fields (like brief, note, annotations).
     #[serde(flatten)]
     pub common: CommonFields,
@@ -95,10 +99,13 @@ pub struct SpanRefinement {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub attributes: Vec<SpanAttributeOrGroupRef>,
     /// Which resources this span should be associated with.
+    ///
+    /// The list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an
+    /// entity reference or a nested `one_of`/`all_of` expression.
     /// Note: This field is currently not propagated during resolution.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub entity_associations: Vec<String>,
+    pub entity_associations: Vec<EntityAssociation>,
 
     /// Refines the brief description of the signal.
     /// Note: This field is currently not propagated during resolution.

--- a/schemas/semconv.materialized.v2.json
+++ b/schemas/semconv.materialized.v2.json
@@ -343,6 +343,47 @@
         "stability"
       ]
     },
+    "EntityAssociation": {
+      "description": "An entity association expression.\n\nIn YAML this is either a bare string (an entity reference), a `{ one_of: [...] }` map or a\n`{ all_of: [...] }` map, where each list element is itself an [`EntityAssociation`].",
+      "anyOf": [
+        {
+          "description": "A reference to an entity by its type name.",
+          "type": "string"
+        },
+        {
+          "description": "Satisfied when at least one of the contained expressions is satisfied.",
+          "type": "object",
+          "properties": {
+            "one_of": {
+              "description": "The candidate expressions.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/EntityAssociation"
+              }
+            }
+          },
+          "required": [
+            "one_of"
+          ]
+        },
+        {
+          "description": "Satisfied when every contained expression is satisfied.",
+          "type": "object",
+          "properties": {
+            "all_of": {
+              "description": "The required expressions.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/EntityAssociation"
+              }
+            }
+          },
+          "required": [
+            "all_of"
+          ]
+        }
+      ]
+    },
     "EntityAttribute": {
       "description": "A special type of reference to attributes that remembers entity-specific information.",
       "type": "object",
@@ -516,7 +557,7 @@
           "description": "Which resources this event should be associated with.\n\nThis list is an \"any of\" list, where a event may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "name": {
@@ -651,7 +692,7 @@
           "description": "Which resources this event should be associated with.\n\nThis list is an \"any of\" list, where a event may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "id": {
@@ -850,7 +891,7 @@
           "description": "Which resources this metric should be associated with.\n\nThis list is an \"any of\" list, where a metric may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "instrument": {
@@ -1006,7 +1047,7 @@
           "description": "Which resources this metric should be associated with.\n\nThis list is an \"any of\" list, where a metric may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "id": {
@@ -1324,7 +1365,7 @@
           "description": "Which resources this span should be associated with.\n\nThis list is an \"any of\" list, where a span may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "kind": {
@@ -1520,7 +1561,7 @@
           "description": "Which resources this span should be associated with.\n\nThis list is an \"any of\" list, where a span may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "id": {

--- a/schemas/semconv.materialized.v2.json
+++ b/schemas/semconv.materialized.v2.json
@@ -554,7 +554,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this event should be associated with.\n\nThis list is an \"any of\" list, where a event may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which resources this event should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -689,7 +689,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this event should be associated with.\n\nThis list is an \"any of\" list, where a event may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which resources this event should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -888,7 +888,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this metric should be associated with.\n\nThis list is an \"any of\" list, where a metric may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which resources this metric should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -1044,7 +1044,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this metric should be associated with.\n\nThis list is an \"any of\" list, where a metric may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which resources this metric should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -1362,7 +1362,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this span should be associated with.\n\nThis list is an \"any of\" list, where a span may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which resources this span should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -1558,7 +1558,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this span should be associated with.\n\nThis list is an \"any of\" list, where a span may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which resources this span should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"

--- a/schemas/semconv.resolved.v2.json
+++ b/schemas/semconv.resolved.v2.json
@@ -378,6 +378,47 @@
         "stability"
       ]
     },
+    "EntityAssociation": {
+      "description": "An entity association expression.\n\nIn YAML this is either a bare string (an entity reference), a `{ one_of: [...] }` map or a\n`{ all_of: [...] }` map, where each list element is itself an [`EntityAssociation`].",
+      "anyOf": [
+        {
+          "description": "A reference to an entity by its type name.",
+          "type": "string"
+        },
+        {
+          "description": "Satisfied when at least one of the contained expressions is satisfied.",
+          "type": "object",
+          "properties": {
+            "one_of": {
+              "description": "The candidate expressions.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/EntityAssociation"
+              }
+            }
+          },
+          "required": [
+            "one_of"
+          ]
+        },
+        {
+          "description": "Satisfied when every contained expression is satisfied.",
+          "type": "object",
+          "properties": {
+            "all_of": {
+              "description": "The required expressions.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/EntityAssociation"
+              }
+            }
+          },
+          "required": [
+            "all_of"
+          ]
+        }
+      ]
+    },
     "EntityAttributeRef": {
       "description": "A special type of reference to attributes that remembers entity-specicific information.",
       "type": "object",
@@ -499,7 +540,7 @@
           "description": "Which entities this event should be associated with.\n\nThis list is an \"any of\" list, where a event may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "name": {
@@ -582,7 +623,7 @@
           "description": "Which entities this event should be associated with.\n\nThis list is an \"any of\" list, where a event may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "id": {
@@ -781,7 +822,7 @@
           "description": "Which entities this metric should be associated with.\n\nThis list is an \"any of\" list, where a metric may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "instrument": {
@@ -885,7 +926,7 @@
           "description": "Which entities this metric should be associated with.\n\nThis list is an \"any of\" list, where a metric may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "id": {
@@ -1196,7 +1237,7 @@
           "description": "Which entities this span should be associated with.\n\nThis list is an \"any of\" list, where a span may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "kind": {
@@ -1340,7 +1381,7 @@
           "description": "Which entities this span should be associated with.\n\nThis list is an \"any of\" list, where a span may be associated with one or more entities, but should\nbe associated with at least one in this list.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "id": {

--- a/schemas/semconv.resolved.v2.json
+++ b/schemas/semconv.resolved.v2.json
@@ -537,7 +537,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which entities this event should be associated with.\n\nThis list is an \"any of\" list, where a event may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which entities this event should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -620,7 +620,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which entities this event should be associated with.\n\nThis list is an \"any of\" list, where a event may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which entities this event should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -819,7 +819,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which entities this metric should be associated with.\n\nThis list is an \"any of\" list, where a metric may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which entities this metric should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -923,7 +923,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which entities this metric should be associated with.\n\nThis list is an \"any of\" list, where a metric may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which entities this metric should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -1234,7 +1234,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which entities this span should be associated with.\n\nThis list is an \"any of\" list, where a span may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which entities this span should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -1378,7 +1378,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which entities this span should be associated with.\n\nThis list is an \"any of\" list, where a span may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "description": "Which entities this span should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"

--- a/schemas/semconv.schema.json
+++ b/schemas/semconv.schema.json
@@ -850,8 +850,43 @@
 			]
 		},
 		"EntityAssociation": {
-			"type": "string",
-			"description": "The name of the associated entity."
+			"description": "An entity association: a bare entity reference, or a `one_of`/`all_of` group of nested associations.",
+			"anyOf": [
+				{
+					"type": "string",
+					"description": "The name of the associated entity."
+				},
+				{
+					"type": "object",
+					"additionalProperties": false,
+					"required": [
+						"one_of"
+					],
+					"properties": {
+						"one_of": {
+							"type": "array",
+							"items": {
+								"$ref": "#/$defs/EntityAssociation"
+							}
+						}
+					}
+				},
+				{
+					"type": "object",
+					"additionalProperties": false,
+					"required": [
+						"all_of"
+					],
+					"properties": {
+						"all_of": {
+							"type": "array",
+							"items": {
+								"$ref": "#/$defs/EntityAssociation"
+							}
+						}
+					}
+				}
+			]
 		}
 	}
 }

--- a/schemas/semconv.schema.v2.json
+++ b/schemas/semconv.schema.v2.json
@@ -737,7 +737,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this event should be associated with.",
+          "description": "Which resources this event should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -800,7 +800,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this event should be associated with.",
+          "description": "Which resources this event should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -1079,7 +1079,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this metric should be associated with.",
+          "description": "Which resources this metric should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -1163,7 +1163,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this metric should be associated with.",
+          "description": "Which resources this metric should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -1338,7 +1338,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this span should be associated with.",
+          "description": "Which resources this span should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"
@@ -1568,7 +1568,7 @@
           ]
         },
         "entity_associations": {
-          "description": "Which resources this span should be associated with.\nNote: This field is currently not propagated during resolution.",
+          "description": "Which resources this span should be associated with.\n\nThe list is an implicit `one_of` (telemetry must satisfy at least one entry); each entry is an\nentity reference or a nested `one_of`/`all_of` expression.\nNote: This field is currently not propagated during resolution.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/EntityAssociation"

--- a/schemas/semconv.schema.v2.json
+++ b/schemas/semconv.schema.v2.json
@@ -528,6 +528,47 @@
         "stability"
       ]
     },
+    "EntityAssociation": {
+      "description": "An entity association expression.\n\nIn YAML this is either a bare string (an entity reference), a `{ one_of: [...] }` map or a\n`{ all_of: [...] }` map, where each list element is itself an [`EntityAssociation`].",
+      "anyOf": [
+        {
+          "description": "A reference to an entity by its type name.",
+          "type": "string"
+        },
+        {
+          "description": "Satisfied when at least one of the contained expressions is satisfied.",
+          "type": "object",
+          "properties": {
+            "one_of": {
+              "description": "The candidate expressions.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/EntityAssociation"
+              }
+            }
+          },
+          "required": [
+            "one_of"
+          ]
+        },
+        {
+          "description": "Satisfied when every contained expression is satisfied.",
+          "type": "object",
+          "properties": {
+            "all_of": {
+              "description": "The required expressions.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/EntityAssociation"
+              }
+            }
+          },
+          "required": [
+            "all_of"
+          ]
+        }
+      ]
+    },
     "EntityRefinement": {
       "description": "A refinement of an existing entity.",
       "type": "object",
@@ -699,7 +740,7 @@
           "description": "Which resources this event should be associated with.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "name": {
@@ -762,7 +803,7 @@
           "description": "Which resources this event should be associated with.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "id": {
@@ -1041,7 +1082,7 @@
           "description": "Which resources this metric should be associated with.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "instrument": {
@@ -1125,7 +1166,7 @@
           "description": "Which resources this metric should be associated with.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "id": {
@@ -1300,7 +1341,7 @@
           "description": "Which resources this span should be associated with.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "kind": {
@@ -1530,7 +1571,7 @@
           "description": "Which resources this span should be associated with.\nNote: This field is currently not propagated during resolution.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/EntityAssociation"
           }
         },
         "id": {


### PR DESCRIPTION
Closes #1296 

With this PR you can now express nested one_of and all_of in the entity association structure like so:

```yaml
  # --- Event with a nested one_of / all_of entity association ---
  # The resource must be associated with the tenant entity AND with at least
  # one of the host or container entities.
  - id: event.thing.happened
    type: event
    name: thing.happened
    stability: stable
    brief: "Something happened"
    entity_associations:
      - all_of:
          - tenant
          - one_of:
              - host
              - container
```

With the above you can now get live-check output like so:

<img width="801" height="276" alt="image" src="https://github.com/user-attachments/assets/a6cfb9eb-8467-4825-a0e4-98a0200f60c3" />
