### PR TITLE
Updated docs for entity associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Add `one_of` and `all_of` combinators to `entity_associations`, letting a signal (span, metric, or event) require any-of or all-of a set of entities, nested arbitrarily. A bare list of entity references remains supported and is treated as an implicit `one_of`. See [`semconv-syntax.v2.md`](schemas/semconv-syntax.v2.md#entity-associations). ([#1493](https://github.com/open-telemetry/weaver/pull/1493) by @jerbly)
 - Add `weaver-live-check-start` and `weaver-live-check-stop` composite GitHub Actions for CI integration. ([#1448](https://github.com/open-telemetry/weaver/pull/1448))
 - Rename `resolved_schema_uri` to `resolved_registry_uri` in publication manifest and in `package` command. ([#1425](https://github.com/open-telemetry/weaver/pull/1425))
 - Fix V2 resolver overwriting `SpanName.note` with the span type id during resolution. ([#1401](https://github.com/open-telemetry/weaver/pull/1401))

--- a/schemas/semconv-syntax.md
+++ b/schemas/semconv-syntax.md
@@ -44,7 +44,7 @@ All attributes are lower case.
 groups ::= semconv [imports]
        | semconv [imports] groups
 
-semconv ::= id convtype brief [note] [extends] [stability] [deprecated] [display_name] [attributes]  [annotations] specificfields
+semconv ::= id convtype brief [note] [extends] [stability] [deprecated] [display_name] [attributes] [entity_associations] [annotations] specificfields
 
 imports := [metrics] [events] [entities] [spans] [attribute_groups]
 metrics := <wildcard> {<wildcard>}         # e.g. "db.*"
@@ -123,6 +123,18 @@ examples ::= <example_value> {<example_value>}
 role ::= "identifying" # Default if not specified
          | "descriptive"
 
+entity_associations ::= entity_association {entity_association}
+
+entity_association ::= entity_ref
+                   |   one_of
+                   |   all_of
+
+entity_ref ::= string # MUST be the name of an existing entity
+
+one_of ::= entity_association {entity_association} # satisfied when at least one holds
+
+all_of ::= entity_association {entity_association} # satisfied when all hold
+
 specificfields ::= spanfields
                |   eventfields
                |   metricfields
@@ -195,8 +207,48 @@ The field `semconv` represents a semantic convention and it is made by:
 - `deprecated`, optional, when present marks the semantic convention as deprecated.
   The string provided as `<description>` MUST specify why it's deprecated and/or what to use instead.
 - `attributes`, list of attributes that belong to the semantic convention.
+- `entity_associations`, optional list of [entity association expressions](#entity-associations) describing which
+  entities telemetry in this group is expected to be associated with.
 - `annotations`, optional map of annotations. Annotations are key-value pairs that provide additional information about
   the group. The keys are strings and the values are any YAML value.
+
+#### Entity associations
+
+The `entity_associations` field declares which entities telemetry in a group is expected to be associated with. Each
+list element is an *entity association expression*, which is one of:
+
+- an **entity reference** — the name of an entity, written as a bare string;
+- **`one_of`** — a map with a list of expressions, satisfied when *at least one* of them is satisfied;
+- **`all_of`** — a map with a list of expressions, satisfied when *every* one of them is satisfied.
+
+`one_of` and `all_of` may be nested arbitrarily. A bare list of entity references (the historical syntax) is
+interpreted as an implicit `one_of` — telemetry must be associated with at least one of the listed entities. The
+following two forms are therefore equivalent:
+
+```yaml
+# Implicit one_of
+entity_associations:
+  - host
+  - container
+
+# Explicit one_of
+entity_associations:
+  - one_of:
+      - host
+      - container
+```
+
+A nested example — telemetry must be associated with the `tenant` entity **and** with at least one of `host` or
+`container`:
+
+```yaml
+entity_associations:
+  - all_of:
+      - tenant
+      - one_of:
+          - host
+          - container
+```
 
 #### Span semantic convention
 

--- a/schemas/semconv-syntax.v2.md
+++ b/schemas/semconv-syntax.v2.md
@@ -324,7 +324,7 @@ The spans section contains a list of span definitions. A span definition consist
 - `name` - Required. Specification of how the [span name](#span-name) should be formatted.
 - `deprecated` - Optional. When present, marks the span as deprecated. See [deprecated](#deprecated-structure) for details
 - `attributes` - Optional. List of [attribute references](#attribute-reference) applicable to this span.
-- `entity_associations` - Optional. List of entity types that can be associated with this span type
+- `entity_associations` - Optional. List of [entity association expressions](#entity-associations) describing which entities this span type can be associated with.
 - `annotations` - Optional. Map of annotations. Annotations are key-value pairs that provide additional information about the span. See [annotations](#annotations) for details
 
 Example:
@@ -346,7 +346,7 @@ spans:
         sampling_relevant: true
       # ...
     entity_associations:
-      - ref: service.instance
+      - service.instance
 ```
 
 ### `span_refinements` definition
@@ -358,7 +358,7 @@ A span refinement definition consists of the following properties:
 - `id` - Required. Uniquely identifies the span refinement.
 - `ref` - Required. The type of the span being refined.
 - `attributes` - Optional. List of [attribute references](#attribute-reference) that belong to the semantic convention.
-- `entity_associations` - Optional. Which resources this span should be associated with.
+- `entity_associations` - Optional. [Entity association expressions](#entity-associations) describing which entities this span should be associated with.
 - `brief` - Optional. Refines the brief description of the signal.
 - `note` - Optional. Refines the more elaborate description of the signal.
 - `stability` - Optional. Refines the stability of the signal.
@@ -417,6 +417,41 @@ An entity refinement definition consists of the following properties:
 - `deprecated` - Optional. Specifies if the signal is deprecated.
 - `annotations` - Optional. Additional annotations for the signal.
 
+### Entity associations
+
+The `entity_associations` field on spans, metrics, and events (and their refinements) declares which [entities](#entities-definition) a signal is expected to be associated with. Each list element is an *entity association expression*, which is one of:
+
+- An **entity reference** — the `type` of an entity, written as a bare string.
+- **`one_of`** — a map with a list of expressions; satisfied when *at least one* of them is satisfied.
+- **`all_of`** — a map with a list of expressions; satisfied when *every* one of them is satisfied.
+
+`one_of` and `all_of` may be nested arbitrarily, so complex requirements can be expressed.
+
+A bare list of entity references (the historical syntax) is interpreted as an implicit `one_of` — the telemetry must be associated with at least one of the listed entities. These two forms are therefore equivalent:
+
+```yaml
+# Implicit one_of
+entity_associations:
+  - host
+  - container
+
+# Explicit one_of
+entity_associations:
+  - one_of:
+      - host
+      - container
+```
+
+A nested example — the signal must be associated with the `tenant` entity **and** with at least one of `host` or `container`:
+
+```yaml
+entity_associations:
+  - all_of:
+      - tenant
+      - one_of:
+          - host
+          - container
+```
 
 ### `events` definition
 
@@ -429,7 +464,7 @@ An event definition consists of the following properties:
 - `note` - Optional. A more elaborate description of the event.
 - `stability` - Required. Specifies the [stability](#stability-levels) of the event definition.
 - `attributes` - Optional. List of [attribute references](#attribute-reference) that can be set on this event type.
-- `entity_associations` - Optional. List of entities that this event can be associated with.
+- `entity_associations` - Optional. List of [entity association expressions](#entity-associations) describing which entities this event can be associated with.
 - `deprecated` - Optional. When present, marks the event as deprecated. See [deprecated](#deprecated-structure) for details.
 - `annotations` - Optional. Map of annotations. Annotations are key-value pairs that provide additional information about the event. See [annotations](#annotations) for details.
 
@@ -448,7 +483,7 @@ events:
       - ref: exception.stacktrace
         requirement_level: recommended
     entity_associations:
-      - ref: service.instance
+      - service.instance
 ```
 
 ### `event_refinements` definition
@@ -460,7 +495,7 @@ An event refinement definition consists of the following properties:
 - `id` - Required. Uniquely identifies the event refinement.
 - `ref` - Required. The name of the event being refined.
 - `attributes` - Optional. List of [attribute references](#attribute-reference) that belong to the semantic convention.
-- `entity_associations` - Optional. Which resources this event should be associated with.
+- `entity_associations` - Optional. [Entity association expressions](#entity-associations) describing which entities this event should be associated with.
 - `brief` - Optional. Refines the brief description of the signal.
 - `note` - Optional. Refines the more elaborate description of the signal.
 - `stability` - Optional. Refines the stability of the signal.
@@ -484,7 +519,7 @@ A metric definition consists of the following properties:
   - `histogram` - Distribution of recorded values, used for latencies or request sizes
 - `stability` - Required. Specifies the [stability](#stability-levels) of the metric definition.
 - `attributes` - Optional. List of [attribute references](#attribute-reference) that can be set on this metric.
-- `entity_associations` - Optional. List of entity types that this metric can be associated with.
+- `entity_associations` - Optional. List of [entity association expressions](#entity-associations) describing which entities this metric can be associated with.
 - `deprecated` - Optional. When present, marks the metric as deprecated. See [deprecated](#deprecated-structure) for details.
 - `annotations` - Optional. Map of annotations. Annotations are key-value pairs that provide additional information about the metric. See [annotations](#annotations) for details.
 
@@ -504,7 +539,7 @@ metrics:
         requirement_level: required
       # ...
     entity_associations:
-      - ref: service.instance
+      - service.instance
 ```
 
 ### `metric_refinements` definition
@@ -516,7 +551,7 @@ A metric refinement definition consists of the following properties:
 - `id` - Required. Uniquely identifies the metric refinement.
 - `ref` - Required. The name of the metric being refined.
 - `attributes` - Optional. List of [attribute references](#attribute-reference) that belong to the semantic convention.
-- `entity_associations` - Optional. Which resources this metric should be associated with.
+- `entity_associations` - Optional. [Entity association expressions](#entity-associations) describing which entities this metric should be associated with.
 - `brief` - Optional. Refines the brief description of the signal.
 - `note` - Optional. Refines the more elaborate description of the signal.
 - `stability` - Optional. Refines the stability of the signal.


### PR DESCRIPTION
In the PR #1493 I did not update the docs for the change of syntax. This corrects that omission.