### PR TITLE
Reinstate check_external_types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,33 +186,21 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
   check-external-types:
-    name: Check external types
-    runs-on: ubuntu-latest
-    steps:
-      - name: Skip check
-        run: echo "External types check skipped"
-  #################################################################################
-  # TODO Enable this once check-external-types support is available in a version
-  #      that is compatible with our current MSRV.
-  # See: https://github.com/open-telemetry/weaver/pull/651#issuecomment-2747851893
-  #################################################################################
-  # check-external-types:
-  #   name: Check external types
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #     - name: Install Rust
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         # cargo check-external-types is only available on this specific nightly
-  #         toolchain: nightly-2024-06-30
-  #     - uses: Swatinem/rust-cache@v2
-  #     - name: check-external-types
-  #       run: |
-  #         cargo install cargo-check-external-types
-  #         ./scripts/check_external_types.sh
-  #################################################################################
+     name: Check external types
+     runs-on: ubuntu-latest
+     steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          # cargo check-external-types is only available on this specific nightly
+          toolchain: nightly-2026-03-20
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: check-external-types
+        run: |
+          cargo install cargo-check-external-types
+          ./scripts/check_external_types.sh
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/crates/weaver_checker/allowed-external-types.toml
+++ b/crates/weaver_checker/allowed-external-types.toml
@@ -3,8 +3,10 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
-    "serde::de::Deserialize",
+    "serde_core::ser::Serialize",
+    "serde_core::de::Deserialize",
     "weaver_common::error::WeaverError",
     "miette::protocol::Diagnostic",
+    "schemars::JsonSchema",
+    "serde_json::value::Value",
 ]

--- a/crates/weaver_common/allowed-external-types.toml
+++ b/crates/weaver_common/allowed-external-types.toml
@@ -4,5 +4,9 @@
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
     "miette::protocol::*",
-    "serde::ser::Serialize",
+    "serde_core::ser::Serialize",
+    "serde_core::de::Deserialize",
+    "schemars::JsonSchema",
+    "log::Log",
+    "log::Level",
 ]

--- a/crates/weaver_config/allowed-external-types.toml
+++ b/crates/weaver_config/allowed-external-types.toml
@@ -3,7 +3,10 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::de::Deserialize",
+    "serde_core::de::Deserialize",
+    "serde_core::de::DeserializeOwned",
     "schemars::JsonSchema",
     "weaver_checker::*",
+    "weaver_macros::*",
+    "weaver_common::*",
 ]

--- a/crates/weaver_emit/allowed-external-types.toml
+++ b/crates/weaver_emit/allowed-external-types.toml
@@ -3,7 +3,11 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
+    "serde_core::ser::Serialize",
     "miette::protocol::Diagnostic",
     "weaver_forge::registry::ResolvedRegistry",
+    "opentelemetry::common::KeyValue",
+    "weaver_resolved_schema::attribute::Attribute",
+    "weaver_forge::v2::attribute::Attribute",
+    "weaver_forge::v2::registry::ForgeResolvedRegistry",
 ]

--- a/crates/weaver_forge/allowed-external-types.toml
+++ b/crates/weaver_forge/allowed-external-types.toml
@@ -3,15 +3,16 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
-    "serde::de::Deserialize",
+    "serde_core::ser::Serialize",
+    "serde_core::de::Deserialize",
     "serde_json::value::Value",
     "serde_yaml::value::Value",
     "weaver_common::*",
     "weaver_resolved_schema::*",
     "weaver_semconv::*",
-    "minijinja::value::Value",
     "miette::protocol::Diagnostic",
     "include_dir::dir::Dir",
     "schemars::JsonSchema",
+    "utoipa::ToSchema",
+    "utoipa::__dev::ComposeSchema",
 ]

--- a/crates/weaver_infer/allowed-external-types.toml
+++ b/crates/weaver_infer/allowed-external-types.toml
@@ -3,6 +3,7 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
+    "serde_core::ser::Serialize",
     "weaver_semconv::group::GroupSpec",
+    "weaver_live_check::Sample",
 ]

--- a/crates/weaver_live_check/allowed-external-types.toml
+++ b/crates/weaver_live_check/allowed-external-types.toml
@@ -3,12 +3,19 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
-    "serde::de::Deserialize",
+    "serde_core::ser::Serialize",
+    "serde_core::de::Deserialize",
     "miette::protocol::Diagnostic",
-    "weaver_forge::registry::ResolvedRegistry",
+    "weaver_forge::*",
     "serde_json::value::Value",
     "weaver_resolved_schema::attribute::Attribute",
-    "weaver_semconv::attribute::PrimitiveOrArrayTypeSpec",
-    "weaver_common::Logger",
+    "schemars::JsonSchema",
+    "strum::ParseError",
+    "opentelemetry::common::KeyValue",
+    "weaver_semconv::*",
+    "weaver_checker::*",
+    "weaver_config::live_check::FindingFilter",
+    "weaver_config::live_check::LiveCheckConfig",
+    "opentelemetry::common::Key",
+    "opentelemetry::logs::record::*",
 ]

--- a/crates/weaver_mcp/allowed-external-types.toml
+++ b/crates/weaver_mcp/allowed-external-types.toml
@@ -3,9 +3,9 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
-    "serde::de::Deserialize",
+    "serde_core::ser::Serialize",
     "miette::protocol::Diagnostic",
     "weaver_forge::v2::registry::ForgeResolvedRegistry",
-    "schemars::JsonSchema",
+    "rmcp::model::tool::Tool",
+    "rmcp::handler::server::ServerHandler",
 ]

--- a/crates/weaver_otel_schema/allowed-external-types.toml
+++ b/crates/weaver_otel_schema/allowed-external-types.toml
@@ -3,9 +3,8 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
-    "serde::de::Deserialize",
+    "serde_core::ser::Serialize",
+    "serde_core::de::Deserialize",
     "miette::protocol::Diagnostic",
-
     "weaver_version::*",
 ]

--- a/crates/weaver_resolved_schema/allowed-external-types.toml
+++ b/crates/weaver_resolved_schema/allowed-external-types.toml
@@ -3,10 +3,12 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
-    "serde::de::Deserialize",
+    "serde_core::ser::Serialize",
+    "serde_core::de::Deserialize",
     "weaver_common::*",
     "weaver_semconv::*",
     "weaver_version::*",
     "schemars::JsonSchema",
+    "utoipa::ToSchema",
+    "utoipa::__dev::ComposeSchema",
 ]

--- a/crates/weaver_resolver/allowed-external-types.toml
+++ b/crates/weaver_resolver/allowed-external-types.toml
@@ -3,13 +3,10 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
-    "serde::de::Deserialize",
+    "serde_core::ser::Serialize",
     "miette::protocol::Diagnostic",
 
     "weaver_resolved_schema::*",
     "weaver_semconv::*",
     "weaver_common::*",
-    "weaver_cache::*",
-    "weaver_version::*",
 ]

--- a/crates/weaver_search/allowed-external-types.toml
+++ b/crates/weaver_search/allowed-external-types.toml
@@ -3,8 +3,10 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
-    "serde::de::Deserialize",
+    "serde_core::ser::Serialize",
+    "serde_core::de::Deserialize",
     "weaver_forge::*",
     "weaver_semconv::*",
+    "utoipa::ToSchema",
+    "utoipa::__dev::ComposeSchema",
 ]

--- a/crates/weaver_semconv/allowed-external-types.toml
+++ b/crates/weaver_semconv/allowed-external-types.toml
@@ -3,12 +3,19 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
-    "serde::de::Deserialize",
-    "serde::de::Deserializer",
+    "serde_core::ser::Serialize",
+    "serde_core::de::Deserialize",
+    "serde_core::de::Deserializer",
+    "serde_yaml::error::Error",
     "weaver_common::*",
-    "weaver_cache::RegistryRepo",
     "miette::protocol::Diagnostic",
+    "miette::protocol::SourceSpan",
+    "miette::named_source::NamedSource",
     "schemars::JsonSchema",
     "serde_yaml::value::Value",
+    "utoipa::ToSchema",
+    "utoipa::__dev::ComposeSchema",
+    "utoipa::PartialSchema",
+    "schemars::schema::Schema",
+    "globset::glob::Glob",
 ]

--- a/crates/weaver_semconv_gen/allowed-external-types.toml
+++ b/crates/weaver_semconv_gen/allowed-external-types.toml
@@ -4,12 +4,14 @@
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
     "weaver_semconv::Error",
-    "weaver_semconv::path::RegistryPath",
-    "weaver_resolver::Error",
-    "weaver_cache::*",
     "weaver_common::*",
     "weaver_forge::error::Error",
-    "weaver_forge::TemplateEngine",
     "miette::protocol::Diagnostic",
-    "serde::ser::Serialize",
+    "serde_core::ser::Serialize",
+    "weaver_resolved_schema::v2::ResolvedTelemetrySchema",
+    "weaver_forge::v2::registry::ForgeResolvedRegistry",
+    "weaver_forge::output_processor::OutputProcessor",
+    "weaver_resolved_schema::ResolvedTelemetrySchema",
+    "weaver_semconv::registry_repo::RegistryRepo",
+    "weaver_resolver::error::Error",
 ]

--- a/crates/weaver_version/allowed-external-types.toml
+++ b/crates/weaver_version/allowed-external-types.toml
@@ -3,7 +3,8 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "serde::ser::Serialize",
-    "serde::de::Deserialize",
+    "serde_core::ser::Serialize",
+    "serde_core::de::Deserialize",
     "schemars::JsonSchema",
+    "weaver_semconv::schema_url::SchemaUrl",
 ]

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ install:
     cargo install cargo-machete@0.9.2 --locked
     cargo install cargo-depgraph@1.6.0 --locked
     cargo install cargo-edit@0.13.11 --locked
-    cargo install cargo-check-external-types@0.4.0 --locked
+    cargo install cargo-check-external-types@0.5.0 --locked
     cargo install git-cliff@2.13.1 --locked
     cargo install cargo-tarpaulin@0.35.4 --locked
     cargo install cargo-nextest@0.9.137 --locked
@@ -57,10 +57,4 @@ fuzz-all seconds="30":
     done; exit $failed
 
 check-external-types:
-  ##################################################################################
-  # TODO Enable this once check-external-types support is available in a version
-  #      that is compatible with our current MSRV.
-  # See: https://github.com/open-telemetry/weaver/pull/651#issuecomment-2747851893
-  ##################################################################################
-  #  scripts/check_external_types.sh
-  ##################################################################################
+  scripts/check_external_types.sh

--- a/scripts/check_external_types.sh
+++ b/scripts/check_external_types.sh
@@ -10,10 +10,14 @@ for dir in crates/*/; do
   if [ "$dir" = "crates/xtask/" ]; then
     continue
   fi
+  # Skip crate weaver_macros
+  if [ "$dir" = "crates/weaver_macros/" ]; then
+    continue
+  fi
   
   # Check if the public API is compliant with the allowed-external-types.toml
   echo "Checking the public API of $dir"
-  cargo +nightly-2024-10-29 check-external-types --all-features --manifest-path "$dir/Cargo.toml" --config "$dir/allowed-external-types.toml" || exit 1
+  cargo +nightly-2026-03-20 check-external-types --all-features --manifest-path "$dir/Cargo.toml" --config "$dir/allowed-external-types.toml" || exit 1
 done
 
 echo "The Cargo workspace is compliant with the 'allowed external types' policies."


### PR DESCRIPTION
Closes: #652 

A new version has been released which is compatible: https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.5.0

Reinstated the just recipe and CI workflow. Updated all the `allowed-external-types.toml` files in the crates to match what is now exposed by each crate. Worth checking if we think these new external types shouldn't be there.