### PR TITLE
Fix stack overflow when generating OpenAPI spec

### DIFF
--- a/crates/weaver_semconv/src/entity_association.rs
+++ b/crates/weaver_semconv/src/entity_association.rs
@@ -25,11 +25,15 @@ pub enum EntityAssociation {
     /// Satisfied when at least one of the contained expressions is satisfied.
     OneOf {
         /// The candidate expressions.
+        // `no_recursion` stops utoipa from inlining the self-referential schema
+        // forever (it would otherwise overflow the stack at generation time).
+        #[cfg_attr(feature = "openapi", schema(no_recursion))]
         one_of: Vec<EntityAssociation>,
     },
     /// Satisfied when every contained expression is satisfied.
     AllOf {
         /// The required expressions.
+        #[cfg_attr(feature = "openapi", schema(no_recursion))]
         all_of: Vec<EntityAssociation>,
     },
 }

--- a/src/serve/server.rs
+++ b/src/serve/server.rs
@@ -230,3 +230,26 @@ async fn serve_ui(uri: axum::http::Uri) -> impl IntoResponse {
     // No UI available
     (StatusCode::NOT_FOUND, "UI not available").into_response()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for the OpenAPI schema generation.
+    ///
+    /// Recursive schemas such as `EntityAssociation` (a `one_of`/`all_of` tree)
+    /// must break their cycle with `#[schema(no_recursion)]`; otherwise
+    /// `ApiDoc::openapi()` inlines them forever and overflows the stack, taking
+    /// down the whole `weaver serve` process when `/api/v1/openapi.json` is hit.
+    #[test]
+    fn openapi_spec_generates_without_overflow() {
+        let doc = ApiDoc::openapi();
+        assert!(!doc.paths.paths.is_empty(), "expected at least one path");
+
+        let components = doc.components.expect("components should be present");
+        assert!(
+            components.schemas.contains_key("EntityAssociation"),
+            "the recursive EntityAssociation schema should be registered as a component",
+        );
+    }
+}


### PR DESCRIPTION
`GET /api/v1/openapi.json` crashes `weaver serve` process with `fatal runtime error: stack overflow, aborting`.

`ApiDoc::openapi()` walks every registered schema, and `EntityAssociation` is a recursive untagged enum.

Fixed with utoipa's `#[schema(no_recursion)]` on the recursive fields.

Added a regression test that generates the full `ApiDoc` spec.