### PR TITLE
Update to rust 1.96 and prevent renovate updating the nightly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,6 +74,14 @@
       ],
       automerge: true,
     },
+    {
+      // cargo check-external-types only works on this pinned nightly — don't let Renovate bump it
+      matchFileNames: [
+        '.github/workflows/ci.yml',
+      ],
+      matchCurrentValue: '/^nightly-/',
+      enabled: false,
+    },
   ],
   customManagers: [
     {

--- a/crates/weaver_common/src/http_auth.rs
+++ b/crates/weaver_common/src/http_auth.rs
@@ -74,7 +74,7 @@ impl HttpAuthResolver {
     /// internally; caller need not pre-sort.
     #[must_use]
     pub fn new(mut rules: Vec<AuthMatchRule>) -> Self {
-        rules.sort_by(|a, b| b.url_prefix.len().cmp(&a.url_prefix.len()));
+        rules.sort_by_key(|b| std::cmp::Reverse(b.url_prefix.len()));
         Self {
             inner: Arc::new(Inner {
                 rules,

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -125,7 +125,7 @@ impl LiveChecker {
         }
 
         // Sort templates by name length in descending order
-        templates_by_length.sort_by(|(a, _), (b, _)| b.len().cmp(&a.len()));
+        templates_by_length.sort_by_key(|(b, _)| std::cmp::Reverse(b.len()));
 
         LiveChecker {
             registry,

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -584,7 +584,7 @@ pub fn convert_v1_to_v2(
             }
         }
     }
-    attributes.sort_by(|a, b| a.0.cmp(&b.0));
+    attributes.sort_by_key(|a| a.0);
     attributes.dedup();
 
     let v2_registry = Registry {

--- a/crates/weaver_search/src/lib.rs
+++ b/crates/weaver_search/src/lib.rs
@@ -100,7 +100,7 @@ impl SearchContext {
         }
 
         // Sort templates by key length descending (longest first for prefix matching)
-        templates_by_length.sort_by(|(a, _), (b, _)| b.len().cmp(&a.len()));
+        templates_by_length.sort_by_key(|(b, _)| std::cmp::Reverse(b.len()));
 
         // Index all metrics
         for metric in &registry.registry.metrics {
@@ -346,7 +346,7 @@ fn search_mode_with_total(
         .collect();
 
     // Sort by score descending
-    scored_items.sort_by(|a, b| b.0.cmp(&a.0));
+    scored_items.sort_by_key(|b| std::cmp::Reverse(b.0));
 
     // Calculate total before taking limit
     let total = scored_items.len();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
-components = [ "rustfmt", "clippy" ]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Replaces: #1526 

We can't allow renovate to shift the nightly for the check-external-types since the nightly version is a dependency.