### PR TITLE
Reinstate bare flag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# [Unreleased]
+
+- Fix boolean flags (`--v2`, `--skip-policies`, etc.) consuming the following positional argument; bare flags work again and `--flag=false` overrides `.weaver.toml`. ([#1532](https://github.com/open-telemetry/weaver/pull/1532) by @jerbly)
+
 # [0.24.1] - 2026-06-21
 
 - Fix stack overflow when generating OpenAPI spec ([#1521](https://github.com/open-telemetry/weaver/pull/1521) by @jerbly)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,25 +91,25 @@ The process exits with a code of 0 if the registry validation is successful.
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
 * `--baseline-registry <BASELINE_REGISTRY>` — Parameters to specify the baseline semantic convention registry
 * `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
-* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. [default: false]
+* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. A bare `--skip-policies` means `true`; use the `=` form (e.g. `--skip-policies=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). [default: false]
+* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). A bare `--display-policy-coverage` means `true`; use the `=` form (e.g. `--display-policy-coverage=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -146,24 +146,24 @@ The process exits with a code of 0 if the generation is successful.
 * `-D`, `--param <PARAM>` — Parameters key=value, defined in the command line, to pass to the templates. The value must be a valid YAML value
 * `--params <PARAMS>` — Parameters, defined in a YAML file, to pass to the templates
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
 * `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
-* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. [default: false]
+* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. A bare `--skip-policies` means `true`; use the `=` form (e.g. `--skip-policies=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). [default: false]
+* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). A bare `--display-policy-coverage` means `true`; use the `=` form (e.g. `--display-policy-coverage=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -189,15 +189,15 @@ Please use 'weaver registry generate' or 'weaver registry package' instead.
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -209,11 +209,11 @@ Please use 'weaver registry generate' or 'weaver registry package' instead.
 
   Default value: `yaml`
 * `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
-* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. [default: false]
+* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. A bare `--skip-policies` means `true`; use the `=` form (e.g. `--skip-policies=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). [default: false]
+* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). A bare `--display-policy-coverage` means `true`; use the `=` form (e.g. `--display-policy-coverage=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -239,15 +239,15 @@ DEPRECATED - Searches a registry. This command is deprecated and will be removed
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -272,15 +272,15 @@ Calculate a set of general statistics on a semantic convention registry
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -309,15 +309,15 @@ Update markdown files that contain markers indicating the templates used to upda
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -401,15 +401,15 @@ This diff can then be rendered in multiple formats:
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -437,24 +437,24 @@ This uses the standard OpenTelemetry SDK, defaulting to OTLP gRPC on localhost:4
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
 * `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
-* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. [default: false]
+* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. A bare `--skip-policies` means `true`; use the `=` form (e.g. `--skip-policies=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). [default: false]
+* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). A bare `--display-policy-coverage` means `true`; use the `=` form (e.g. `--display-policy-coverage=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -483,24 +483,24 @@ Includes: Flexible input ingestion, configurable assessment, and template-based 
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
 * `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
-* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. [default: false]
+* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. A bare `--skip-policies` means `true`; use the `=` form (e.g. `--skip-policies=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). [default: false]
+* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). A bare `--display-policy-coverage` means `true`; use the `=` form (e.g. `--display-policy-coverage=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -556,15 +556,15 @@ The server communicates over stdio using JSON-RPC.
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -611,26 +611,26 @@ Packages a semantic convention registry into a self-contained artifact.
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
 * `-o`, `--output <OUTPUT>` — Path to the directory where the package will be written. [default: output]
 * `--resolved-registry-uri <RESOLVED_REGISTRY_URI>` — URI where the resolved registry artifact will eventually be published. This value is embedded in the publication manifest as `resolved_registry_uri`
 * `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
-* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. [default: false]
+* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. A bare `--skip-policies` means `true`; use the `=` form (e.g. `--skip-policies=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). [default: false]
+* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). A bare `--display-policy-coverage` means `true`; use the `=` form (e.g. `--display-policy-coverage=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
@@ -705,24 +705,24 @@ Start the API server (Experimental)
 ###### **Options:**
 
 * `-r`, `--registry <REGISTRY>` — Local folder, Git repo URL, or Git archive URL of the semantic convention registry. For Git URLs, a reference can be specified using the `@refspec` syntax and a sub-folder can be specified using the `[sub-folder]` syntax after the URL. [default: `https://github.com/open-telemetry/semantic-conventions.git[model]`]
-* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. [default: false]
+* `-s`, `--follow-symlinks <FOLLOW_SYMLINKS>` — Boolean flag to specify whether to follow symlinks when loading the registry. A bare `--follow-symlinks` means `true`; use the `=` form (e.g. `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. [default: false]
+* `--include-unreferenced <INCLUDE_UNREFERENCED>` — Boolean flag to include signals and attributes defined in dependency registries, even if they are not explicitly referenced in the current (custom) registry. A bare `--include-unreferenced` means `true`; use the `=` form (e.g. `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. [default: false]
+* `--v2 <V2>` — Whether or not to output version 2 of the schema. Note: this will impact both output to templates *and* policies. A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
 * `-p`, `--policy <POLICIES>` — Optional list of policy files or directories to check against the files of the semantic convention registry.  If a directory is provided all `.rego` files in the directory will be loaded
-* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. [default: false]
+* `--skip-policies <SKIP_POLICIES>` — Skip the policy checks. A bare `--skip-policies` means `true`; use the `=` form (e.g. `--skip-policies=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 
-* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). [default: false]
+* `--display-policy-coverage <DISPLAY_POLICY_COVERAGE>` — Display the policy coverage report (useful for debugging). A bare `--display-policy-coverage` means `true`; use the `=` form (e.g. `--display-policy-coverage=false`) to override a `.weaver.toml` value from the CLI. [default: false]
 
   Possible values: `true`, `false`
 

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -185,20 +185,26 @@ pub struct RegistryArgs {
     pub registry: Option<VirtualDirectoryPath>,
 
     /// Boolean flag to specify whether to follow symlinks when loading the registry.
+    /// A bare `--follow-symlinks` means `true`; use the `=` form (e.g.
+    /// `--follow-symlinks=false`) to override a `.weaver.toml` value from the CLI.
     /// [default: false]
-    #[arg(short = 's', long, num_args = 0, default_missing_value = "true")]
+    #[arg(short = 's', long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
     pub(crate) follow_symlinks: Option<bool>,
 
     /// Boolean flag to include signals and attributes defined in dependency registries,
     /// even if they are not explicitly referenced in the current (custom) registry.
+    /// A bare `--include-unreferenced` means `true`; use the `=` form (e.g.
+    /// `--include-unreferenced=false`) to override a `.weaver.toml` value from the CLI.
     /// [default: false]
-    #[arg(long, num_args = 0, default_missing_value = "true")]
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
     pub(crate) include_unreferenced: Option<bool>,
 
     /// Whether or not to output version 2 of the schema.
     /// Note: this will impact both output to templates *and* policies.
+    /// A bare `--v2` means `true`; use the `=` form (e.g. `--v2=false`) to
+    /// override a `.weaver.toml` value from the CLI.
     /// [default: false]
-    #[arg(long, num_args = 0, default_missing_value = "true")]
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
     pub v2: Option<bool>,
 }
 
@@ -237,12 +243,18 @@ pub struct PolicyArgs {
     #[arg(short = 'p', long = "policy")]
     pub policies: Option<Vec<VirtualDirectoryPath>>,
 
-    /// Skip the policy checks. [default: false]
-    #[arg(long, num_args = 0, default_missing_value = "true")]
+    /// Skip the policy checks.
+    /// A bare `--skip-policies` means `true`; use the `=` form (e.g.
+    /// `--skip-policies=false`) to override a `.weaver.toml` value from the CLI.
+    /// [default: false]
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
     pub skip_policies: Option<bool>,
 
-    /// Display the policy coverage report (useful for debugging). [default: false]
-    #[arg(long, num_args = 0, default_missing_value = "true")]
+    /// Display the policy coverage report (useful for debugging).
+    /// A bare `--display-policy-coverage` means `true`; use the `=` form (e.g.
+    /// `--display-policy-coverage=false`) to override a `.weaver.toml` value from the CLI.
+    /// [default: false]
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
     pub display_policy_coverage: Option<bool>,
 }
 

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -186,19 +186,19 @@ pub struct RegistryArgs {
 
     /// Boolean flag to specify whether to follow symlinks when loading the registry.
     /// [default: false]
-    #[arg(short = 's', long, num_args = 0..=1, default_missing_value = "true")]
+    #[arg(short = 's', long, num_args = 0, default_missing_value = "true")]
     pub(crate) follow_symlinks: Option<bool>,
 
     /// Boolean flag to include signals and attributes defined in dependency registries,
     /// even if they are not explicitly referenced in the current (custom) registry.
     /// [default: false]
-    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    #[arg(long, num_args = 0, default_missing_value = "true")]
     pub(crate) include_unreferenced: Option<bool>,
 
     /// Whether or not to output version 2 of the schema.
     /// Note: this will impact both output to templates *and* policies.
     /// [default: false]
-    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    #[arg(long, num_args = 0, default_missing_value = "true")]
     pub v2: Option<bool>,
 }
 
@@ -238,11 +238,11 @@ pub struct PolicyArgs {
     pub policies: Option<Vec<VirtualDirectoryPath>>,
 
     /// Skip the policy checks. [default: false]
-    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    #[arg(long, num_args = 0, default_missing_value = "true")]
     pub skip_policies: Option<bool>,
 
     /// Display the policy coverage report (useful for debugging). [default: false]
-    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    #[arg(long, num_args = 0, default_missing_value = "true")]
     pub display_policy_coverage: Option<bool>,
 }
 

--- a/tests/registry_check.rs
+++ b/tests/registry_check.rs
@@ -31,8 +31,6 @@ fn test_cli_interface() {
         .arg("check")
         .arg("-r")
         .arg("crates/weaver_codegen_test/semconv_registry/")
-        .arg("--skip-policies")
-        .arg("false")
         .arg("--diagnostic-format")
         .arg("json")
         .arg("--diagnostic-stdout")

--- a/tests/registry_check.rs
+++ b/tests/registry_check.rs
@@ -31,6 +31,7 @@ fn test_cli_interface() {
         .arg("check")
         .arg("-r")
         .arg("crates/weaver_codegen_test/semconv_registry/")
+        .arg("--skip-policies=false")
         .arg("--diagnostic-format")
         .arg("json")
         .arg("--diagnostic-stdout")

--- a/tests/registry_emit.rs
+++ b/tests/registry_emit.rs
@@ -33,7 +33,7 @@ fn run_emit_with_live_check_test(use_v2: bool) {
     let admin_port = reserve_test_port();
 
     // Build the arguments for live check command
-    // Note: --input-source otlp and --skip-policies false are explicitly set
+    // Note: --input-source otlp and --skip-policies (bare flag) are explicitly set
     // to ensure the test is not affected by a local .weaver.toml config file.
     let mut live_check_args = vec![
         "registry".to_owned(),
@@ -43,7 +43,6 @@ fn run_emit_with_live_check_test(use_v2: bool) {
         "--input-source".to_owned(),
         "otlp".to_owned(),
         "--skip-policies".to_owned(),
-        "true".to_owned(),
         "--format".to_owned(),
         "json".to_owned(),
         "--output".to_owned(),
@@ -163,7 +162,7 @@ fn test_emit_with_resource_attributes() {
         .expect("Failed to convert temp directory path to string");
 
     // --- Start weaver3: receives OTLP logs from weaver2, writes JSON report ---
-    // Note: --input-source otlp and --skip-policies true are explicitly set
+    // Note: --input-source otlp and --skip-policies (bare flag) are explicitly set
     // to ensure the test is not affected by a local .weaver.toml config file.
     let mut w3_cmd = StdCommand::new(env!("CARGO_BIN_EXE_weaver"))
         .args([
@@ -174,7 +173,6 @@ fn test_emit_with_resource_attributes() {
             "--input-source",
             "otlp",
             "--skip-policies",
-            "true",
             "--format",
             "json",
             "--output",
@@ -192,7 +190,7 @@ fn test_emit_with_resource_attributes() {
     sleep(Duration::from_secs(2));
 
     // --- Start weaver2: receives OTLP from weaver1, emits findings as OTLP logs to weaver3 ---
-    // Note: --input-source otlp and --skip-policies true are explicitly set
+    // Note: --input-source otlp and --skip-policies (bare flag) are explicitly set
     // to ensure the test is not affected by a local .weaver.toml config file.
     let mut w2_cmd = StdCommand::new(env!("CARGO_BIN_EXE_weaver"))
         .args([
@@ -203,7 +201,6 @@ fn test_emit_with_resource_attributes() {
             "--input-source",
             "otlp",
             "--skip-policies",
-            "true",
             "--output",
             "none",
             "--no-stats",

--- a/tests/registry_generate.rs
+++ b/tests/registry_generate.rs
@@ -31,6 +31,7 @@ fn test_cli_interface() {
         .arg("crates/weaver_codegen_test/semconv_registry/")
         .arg("-t")
         .arg("crates/weaver_codegen_test/templates/")
+        .arg("--skip-policies=false")
         .arg("--diagnostic-format")
         .arg("json")
         .arg("--diagnostic-stdout")

--- a/tests/registry_generate.rs
+++ b/tests/registry_generate.rs
@@ -31,8 +31,6 @@ fn test_cli_interface() {
         .arg("crates/weaver_codegen_test/semconv_registry/")
         .arg("-t")
         .arg("crates/weaver_codegen_test/templates/")
-        .arg("--skip-policies")
-        .arg("false")
         .arg("--diagnostic-format")
         .arg("json")
         .arg("--diagnostic-stdout")


### PR DESCRIPTION
A backwards compatible issue in 0.24.*

We lost bare flag command line options e.g. `--v2` vs `--v2 true`

This means if you place an arg after `--v2` it is expecting that to be `true/false` so some previous command lines may now fail. An example is the failure in #1525.

The trade-off with this is if this is set `v2 = true` in the config file it can be overridden back to false on the command line provided the "equals" form is used: `--v2=false`. This is documented in the `--help` and `usage.md`.