### PR TITLE
Live-check custom policies: support additional data 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,7 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Gather coverage
-        run: cargo tarpaulin --workspace --output-dir coverage --out lcov --ignore-tests -e xtask -e weaver -e weaver_macros -e weaver_test_support --exclude-files 'crates/weaver_forge/codegen_examples/expected_codegen/*' 'crates/weaver_live_check/tests/*'
+        run: cargo tarpaulin --engine llvm --workspace --output-dir coverage --out lcov --ignore-tests -e xtask -e weaver -e weaver_macros -e weaver_test_support --exclude-files 'crates/weaver_forge/codegen_examples/expected_codegen/*' 'crates/weaver_live_check/tests/*'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,7 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Gather coverage
-        run: cargo tarpaulin --engine llvm --workspace --output-dir coverage --out lcov --ignore-tests -e xtask -e weaver -e weaver_macros -e weaver_test_support --exclude-files 'crates/weaver_forge/codegen_examples/expected_codegen/*' 'crates/weaver_live_check/tests/*'
+        run: cargo tarpaulin --workspace --output-dir coverage --out lcov --ignore-tests -e xtask -e weaver -e weaver_macros -e weaver_test_support --exclude-files 'crates/weaver_forge/codegen_examples/expected_codegen/*' 'crates/weaver_live_check/tests/*'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Live-check: support loading additional Rego data from glob patterns via `--advice-data`. ([#1539](https://github.com/open-telemetry/weaver/pull/1539) by @lmolkova).
 - Refactor resolution engine so we can support multiple schema urls registered
   and cached ([#1504](https://github.com/open-telemetry/weaver/pull/1504) by @jsuereth).
 - Change `--include-unreferenced` so that this is the same as creating a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6163,12 +6163,14 @@ name = "weaver_checker"
 version = "0.24.2"
 dependencies = [
  "globset",
+ "log",
  "miette",
  "regorus",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror 2.0.18",
  "walkdir",
  "weaver_common",

--- a/crates/weaver_checker/Cargo.toml
+++ b/crates/weaver_checker/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 weaver_common = { path = "../weaver_common" }
 
 thiserror.workspace = true
+log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
@@ -45,4 +46,4 @@ regorus = { version = "0.10.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-# Required for testing
+tempfile.workspace = true

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -334,7 +334,8 @@ impl Engine {
             if entry_path.is_file() {
                 let rel_path = entry_path
                     .strip_prefix(&base)
-                    .map_err(|e| Error::InvalidData {
+                    .map_err(|e| Error::AccessDenied {
+                        path: entry_path.to_string_lossy().to_string(),
                         error: format!("Failed to get relative path: {e}"),
                     })?;
                 if glob.is_match(rel_path) {
@@ -975,7 +976,7 @@ mod tests {
         for (pattern, expected_base, expected_glob) in cases {
             let (base, glob) = split_glob(pattern);
             assert_eq!(
-                base.to_str().unwrap(),
+                base.to_string_lossy().replace('\\', "/"),
                 expected_base,
                 "Pattern: {}",
                 pattern

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -80,6 +80,19 @@ pub enum Error {
         error: String,
     },
 
+    /// An invalid data glob pattern.
+    #[error("Invalid data glob pattern '{pattern}', error: {error})")]
+    #[diagnostic(
+        url("https://docs.rs/globset/latest/globset/"),
+        help("Check the glob pattern for syntax errors.")
+    )]
+    InvalidDataGlobPattern {
+        /// The glob pattern that caused the error.
+        pattern: String,
+        /// The error that occurred.
+        error: String,
+    },
+
     /// An invalid data.
     #[error("Invalid data, error: {error})")]
     #[diagnostic()]
@@ -279,9 +292,16 @@ impl Engine {
             base = PathBuf::from(".");
         }
 
+        // Fail fast if the base path doesn't exist / isn't accessible.
+        // Otherwise, WalkDir errors would be silently ignored or dropped by WalkDir.
+        let md = metadata(&base).map_err(|err| Error::AccessDenied {
+            path: base.to_string_lossy().to_string(),
+            error: err.to_string(),
+        })?;
+
         // If glob pattern is empty, load all files under base path.
         if glob_pattern.is_empty() {
-            if base.is_file() {
+            if md.is_file() {
                 let root = base.parent().unwrap_or_else(|| Path::new("."));
                 return self.add_data_file_from_dir(root, &base);
             }
@@ -289,7 +309,7 @@ impl Engine {
         }
 
         let glob = Glob::new(&glob_pattern)
-            .map_err(|e| Error::InvalidPolicyGlobPattern {
+            .map_err(|e| Error::InvalidDataGlobPattern {
                 pattern: glob_pattern.clone(),
                 error: e.to_string(),
             })?
@@ -299,8 +319,17 @@ impl Engine {
         for entry in walkdir::WalkDir::new(&base)
             .into_iter()
             .filter_entry(|e| !is_hidden(e))
-            .flatten()
         {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(err) => {
+                    errors.push(Error::AccessDenied {
+                        path: base.to_string_lossy().to_string(),
+                        error: err.to_string(),
+                    });
+                    continue;
+                }
+            };
             let entry_path = entry.path();
             if entry_path.is_file() {
                 let rel_path = entry_path
@@ -953,5 +982,17 @@ mod tests {
             );
             assert_eq!(glob, expected_glob, "Pattern: {}", pattern);
         }
+    }
+
+    #[test]
+    fn test_add_data_from_file_or_dir_invalid_paths() {
+        let mut engine = Engine::new();
+        // A non-existent file/directory should return an AccessDenied error
+        let result = engine.add_data_from_file_or_dir("/non/existent/path/to/data");
+        assert!(matches!(result, Err(Error::AccessDenied { .. })));
+
+        // A non-existent base path for a glob pattern should also return AccessDenied
+        let result = engine.add_data_from_file_or_dir("/non/existent/path/*.json");
+        assert!(matches!(result, Err(Error::AccessDenied { .. })));
     }
 }

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -6,7 +6,7 @@
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::fs::metadata;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use globset::Glob;
 use miette::Diagnostic;
@@ -269,6 +269,122 @@ impl Engine {
         };
         Ok(())
     }
+
+    /// Adds OPA data document from a JSON/YAML file, directory or a glob pattern.
+    pub fn add_data_from_file_or_dir(&mut self, pattern: &str) -> Result<(), Error> {
+        let (mut base, mut glob_pattern) = split_glob(pattern);
+
+        // If the base path is empty, use the current directory.
+        if base.as_os_str().is_empty() {
+            base = PathBuf::from(".");
+        }
+
+        // If glob pattern is empty, load all files under base path.
+        if glob_pattern.is_empty() {
+            if base.is_file() {
+                let root = base.parent().unwrap_or_else(|| Path::new("."));
+                return self.add_data_file_from_dir(root, &base);
+            }
+            glob_pattern = "**/*".to_owned();
+        }
+
+        let glob = Glob::new(&glob_pattern)
+            .map_err(|e| Error::InvalidPolicyGlobPattern {
+                pattern: glob_pattern.clone(),
+                error: e.to_string(),
+            })?
+            .compile_matcher();
+
+        let mut errors = Vec::new();
+        for entry in walkdir::WalkDir::new(&base)
+            .into_iter()
+            .filter_entry(|e| !is_hidden(e))
+            .flatten()
+        {
+            let entry_path = entry.path();
+            if entry_path.is_file() {
+                let rel_path = entry_path
+                    .strip_prefix(&base)
+                    .map_err(|e| Error::InvalidData {
+                        error: format!("Failed to get relative path: {e}"),
+                    })?;
+                if glob.is_match(rel_path) {
+                    if let Err(err) = self.add_data_file_from_dir(&base, entry_path) {
+                        errors.push(err);
+                    }
+                }
+            }
+        }
+        handle_errors(errors)?;
+        Ok(())
+    }
+
+    fn add_data_file_from_dir<P1: AsRef<Path>, P2: AsRef<Path>>(
+        &mut self,
+        root_dir: P1,
+        path: P2,
+    ) -> Result<(), Error> {
+        let root = root_dir.as_ref();
+        let file_path = path.as_ref();
+
+        let rel_path = file_path
+            .strip_prefix(root)
+            .map_err(|e| Error::InvalidData {
+                error: format!("Failed to get relative path: {e}"),
+            })?;
+
+        let extension = file_path.extension().and_then(|s| s.to_str()).unwrap_or("");
+        let content = std::fs::read_to_string(file_path).map_err(|e| Error::AccessDenied {
+            path: file_path.to_string_lossy().to_string(),
+            error: e.to_string(),
+        })?;
+
+        // OPA Rego requires data documents to be structured values. We deserialize the
+        // content here to validate the structure and pass it to the engine.
+        let parsed_value: serde_json::Value = match extension {
+            "json" => {
+                log::debug!("Including JSON data file {}", file_path.display());
+                serde_json::from_str(&content).map_err(|e| Error::InvalidData {
+                    error: format!("Invalid JSON file {}: {}", file_path.display(), e),
+                })?
+            }
+            "yaml" | "yml" => {
+                log::debug!("Including YAML data file {}", file_path.display());
+                serde_yaml::from_str(&content).map_err(|e| Error::InvalidData {
+                    error: format!("Invalid YAML file {}: {}", file_path.display(), e),
+                })?
+            }
+            _ => {
+                log::debug!(
+                    "Skipping file {} (unsupported extension)",
+                    file_path.display()
+                );
+                return Ok(());
+            }
+        };
+
+        let mut components: Vec<String> = Vec::new();
+        if let Some(parent) = rel_path.parent() {
+            for comp in parent.components() {
+                if let std::path::Component::Normal(os_str) = comp {
+                    components.push(os_str.to_string_lossy().into_owned());
+                }
+            }
+        }
+        if let Some(stem) = file_path.file_stem() {
+            components.push(stem.to_string_lossy().into_owned());
+        }
+
+        let mut wrapped = parsed_value;
+        for key in components.into_iter().rev() {
+            let mut map = serde_json::Map::new();
+            let _ = map.insert(key, wrapped);
+            wrapped = serde_json::Value::Object(map);
+        }
+
+        self.add_data(&wrapped)?;
+        Ok(())
+    }
     /// Adds a policy file to the policy engine.
     /// A policy file is a `rego` file that contains the policies to be evaluated.
     ///
@@ -315,14 +431,6 @@ impl Engine {
         policy_dir: P,
         policy_glob_pattern: &str,
     ) -> Result<usize, Error> {
-        fn is_hidden(entry: &DirEntry) -> bool {
-            entry
-                .file_name()
-                .to_str()
-                .map(|s| s.starts_with('.'))
-                .unwrap_or(false)
-        }
-
         let mut errors = Vec::new();
         let mut added_policy_count = 0;
 
@@ -339,10 +447,11 @@ impl Engine {
         };
 
         // Visit recursively all the files in the policy directory
-        for entry in walkdir::WalkDir::new(policy_dir).into_iter().flatten() {
-            if is_hidden(&entry) {
-                continue;
-            }
+        for entry in walkdir::WalkDir::new(policy_dir)
+            .into_iter()
+            .filter_entry(|e| !is_hidden(e))
+            .flatten()
+        {
             if is_policy_file(&entry) {
                 if let Err(err) = self.add_policy_from_file(entry.path()) {
                     errors.push(err);
@@ -470,6 +579,44 @@ impl Engine {
     }
 }
 
+fn split_glob(pattern: &str) -> (PathBuf, String) {
+    let path = Path::new(pattern);
+    let mut base = PathBuf::new();
+    let mut rest = Vec::new();
+    let mut found_wildcard = false;
+
+    for component in path.components() {
+        let component_str = component.as_os_str().to_string_lossy();
+        if found_wildcard
+            || component_str.contains('*')
+            || component_str.contains('?')
+            || component_str.contains('[')
+        {
+            found_wildcard = true;
+            rest.push(component_str.into_owned());
+        } else {
+            base.push(component);
+        }
+    }
+
+    if rest.is_empty() {
+        (base, "".to_owned())
+    } else {
+        (base, rest.join("/"))
+    }
+}
+
+fn is_hidden(entry: &DirEntry) -> bool {
+    if entry.depth() == 0 {
+        return false;
+    }
+    entry
+        .file_name()
+        .to_str()
+        .map(|s| s.starts_with('.'))
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -479,7 +626,7 @@ mod tests {
     use weaver_common::error::format_errors;
 
     use crate::finding::PolicyFinding;
-    use crate::{Engine, Error, PolicyStage};
+    use crate::{split_glob, Engine, Error, PolicyStage};
 
     #[test]
     fn test_policy() -> Result<(), Box<dyn std::error::Error>> {
@@ -671,5 +818,140 @@ mod tests {
         engine.add_policy_from_file_or_dir("data/multi-policies")?;
         assert!(engine.has_stage(PolicyStage::BeforeResolution));
         Ok(())
+    }
+
+    #[test]
+    fn test_add_policy_from_file_or_dir_with_nested_data() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let temp_path = temp_dir.path();
+        let policy_path = temp_path.join("policy.rego");
+        let schemas_dir = temp_path.join("schemas");
+        let _ = std::fs::create_dir_all(&schemas_dir);
+        let schema_path = schemas_dir.join("user.json");
+
+        let rego_content = r#"
+            package before_resolution
+
+            import rego.v1
+
+            deny contains {
+                "id": "user_id_invalid",
+                "message": sprintf("User ID '%v' is invalid", [input.user_id]),
+                "level": "violation"
+            } if {
+                input.user_id
+                not is_number(input.user_id)
+                data.schemas.user.properties.user_id.type == "number"
+            }
+        "#;
+        std::fs::write(&policy_path, rego_content)?;
+
+        let json_content = r#"
+            {
+                "properties": {
+                    "user_id": {
+                        "type": "number"
+                    }
+                }
+            }
+        "#;
+        std::fs::write(&schema_path, json_content)?;
+
+        let mut engine = Engine::new();
+        engine.add_policy_from_file_or_dir(temp_path)?;
+        let glob_pattern = format!("{}/**/*.json", temp_path.to_str().unwrap());
+        engine.add_data_from_file_or_dir(&glob_pattern)?;
+
+        // Set input that triggers the rule (user_id is a string, not a number)
+        let input = serde_json::json!({
+            "user_id": "not-a-number"
+        });
+        engine.set_input(&input)?;
+
+        let violations = engine.check(PolicyStage::BeforeResolution)?;
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].id, "user_id_invalid");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_data_from_file_or_dir_with_paths() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let temp_path = temp_dir.path();
+
+        let policy_path = temp_path.join("policy.rego");
+        let schemas_dir = temp_path.join("schemas");
+        let _ = std::fs::create_dir_all(&schemas_dir);
+        let user_schema_path = schemas_dir.join("user.json");
+        let admin_schema_path = schemas_dir.join("admin.yaml");
+
+        let rego_content = r#"
+            package before_resolution
+            import rego.v1
+            deny contains {
+                "id": "test_err",
+                "message": "test error",
+                "level": "violation"
+            } if {
+                data.user.properties.user_id.type == "number"
+                data.admin.properties.role.type == "string"
+            }
+        "#;
+        std::fs::write(&policy_path, rego_content)?;
+
+        let user_json = r#"{"properties": {"user_id": {"type": "number"}}}"#;
+        std::fs::write(&user_schema_path, user_json)?;
+
+        let admin_yaml = r#"
+            properties:
+              role:
+                type: string
+        "#;
+        std::fs::write(&admin_schema_path, admin_yaml)?;
+
+        // Test loading direct directory path (with no wildcards)
+        let mut engine_dir = Engine::new();
+        engine_dir.add_policy_from_file_or_dir(temp_path)?;
+        engine_dir.add_data_from_file_or_dir(schemas_dir.to_str().unwrap())?;
+        let violations = engine_dir.check(PolicyStage::BeforeResolution)?;
+        assert!(!violations.is_empty());
+
+        // Test loading direct individual file paths
+        let mut engine_files = Engine::new();
+        engine_files.add_policy_from_file_or_dir(temp_path)?;
+        engine_files.add_data_from_file_or_dir(user_schema_path.to_str().unwrap())?;
+        engine_files.add_data_from_file_or_dir(admin_schema_path.to_str().unwrap())?;
+        let violations = engine_files.check(PolicyStage::BeforeResolution)?;
+        assert!(!violations.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_split_glob() {
+        let cases = vec![
+            ("schemas/*.json", "schemas", "*.json"),
+            ("schemas/**/*.json", "schemas", "**/*.json"),
+            ("user.json", "user.json", ""),
+            (
+                "/absolute/path/to/schemas/*.json",
+                "/absolute/path/to/schemas",
+                "*.json",
+            ),
+            ("a/b/c/d", "a/b/c/d", ""),
+        ];
+
+        for (pattern, expected_base, expected_glob) in cases {
+            let (base, glob) = split_glob(pattern);
+            assert_eq!(
+                base.to_str().unwrap(),
+                expected_base,
+                "Pattern: {}",
+                pattern
+            );
+            assert_eq!(glob, expected_glob, "Pattern: {}", pattern);
+        }
     }
 }

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -983,4 +983,51 @@ mod tests {
         let result = engine.add_data_from_file_or_dir("/non/existent/path/*.json");
         assert!(matches!(result, Err(Error::AccessDenied { .. })));
     }
+
+    #[test]
+    fn test_add_data_from_file_or_dir_invalid_glob_pattern() {
+        // The base path exists, but the glob portion is malformed (unclosed character class).
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pattern = format!("{}/[", temp_dir.path().to_str().unwrap());
+        let mut engine = Engine::new();
+        let result = engine.add_data_from_file_or_dir(&pattern);
+        assert!(matches!(result, Err(Error::InvalidGlobPattern { .. })));
+    }
+
+    #[test]
+    fn test_add_data_from_file_or_dir_invalid_json() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        std::fs::write(temp_dir.path().join("bad.json"), "{ not valid json").unwrap();
+        let mut engine = Engine::new();
+        // Loading a directory collects per-file errors; an invalid JSON file surfaces as InvalidData.
+        let result = engine.add_data_from_file_or_dir(temp_dir.path().to_str().unwrap());
+        assert!(matches!(result, Err(Error::InvalidData { .. })));
+    }
+
+    #[test]
+    fn test_add_data_from_file_or_dir_invalid_yaml() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        std::fs::write(temp_dir.path().join("bad.yaml"), "foo: [bar").unwrap();
+        let mut engine = Engine::new();
+        let result = engine.add_data_from_file_or_dir(temp_dir.path().to_str().unwrap());
+        assert!(matches!(result, Err(Error::InvalidData { .. })));
+    }
+
+    #[test]
+    fn test_add_data_from_file_or_dir_skips_unsupported_extension() {
+        // A file with an unsupported extension is silently skipped rather than erroring.
+        let temp_dir = tempfile::tempdir().unwrap();
+        std::fs::write(temp_dir.path().join("notes.txt"), "ignored").unwrap();
+        let mut engine = Engine::new();
+        let result = engine.add_data_from_file_or_dir(temp_dir.path().to_str().unwrap());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_add_policies_invalid_glob_pattern() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut engine = Engine::new();
+        let result = engine.add_policies(temp_dir.path(), "[");
+        assert!(matches!(result, Err(Error::InvalidGlobPattern { .. })));
+    }
 }

--- a/crates/weaver_checker/src/lib.rs
+++ b/crates/weaver_checker/src/lib.rs
@@ -35,7 +35,7 @@ pub const SEMCONV_REGO: &str = include_str!("../../../defaults/rego/semconv.rego
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Error {
     /// An invalid policy.
-    #[error("Invalid policy file '{file}', error: {error})")]
+    #[error("Invalid policy file '{file}', error: {error}")]
     #[diagnostic(
         url("https://www.openpolicyagent.org/docs/latest/policy-language/"),
         help("Check the policy file for syntax errors.")
@@ -67,26 +67,13 @@ pub enum Error {
         error: String,
     },
 
-    /// An invalid policy glob pattern.
-    #[error("Invalid policy glob pattern '{pattern}', error: {error})")]
+    /// An invalid glob pattern.
+    #[error("Invalid glob pattern '{pattern}', error: {error}")]
     #[diagnostic(
         url("https://docs.rs/globset/latest/globset/"),
         help("Check the glob pattern for syntax errors.")
     )]
-    InvalidPolicyGlobPattern {
-        /// The glob pattern that caused the error.
-        pattern: String,
-        /// The error that occurred.
-        error: String,
-    },
-
-    /// An invalid data glob pattern.
-    #[error("Invalid data glob pattern '{pattern}', error: {error})")]
-    #[diagnostic(
-        url("https://docs.rs/globset/latest/globset/"),
-        help("Check the glob pattern for syntax errors.")
-    )]
-    InvalidDataGlobPattern {
+    InvalidGlobPattern {
         /// The glob pattern that caused the error.
         pattern: String,
         /// The error that occurred.
@@ -94,7 +81,7 @@ pub enum Error {
     },
 
     /// An invalid data.
-    #[error("Invalid data, error: {error})")]
+    #[error("Invalid data, error: {error}")]
     #[diagnostic()]
     InvalidData {
         /// The error that occurred.
@@ -102,7 +89,7 @@ pub enum Error {
     },
 
     /// An invalid input.
-    #[error("Invalid input, error: {error})")]
+    #[error("Invalid input, error: {error}")]
     #[diagnostic()]
     InvalidInput {
         /// The error that occurred.
@@ -309,7 +296,7 @@ impl Engine {
         }
 
         let glob = Glob::new(&glob_pattern)
-            .map_err(|e| Error::InvalidDataGlobPattern {
+            .map_err(|e| Error::InvalidGlobPattern {
                 pattern: glob_pattern.clone(),
                 error: e.to_string(),
             })?
@@ -465,7 +452,7 @@ impl Engine {
         let mut added_policy_count = 0;
 
         let policy_glob = Glob::new(policy_glob_pattern)
-            .map_err(|e| Error::InvalidPolicyGlobPattern {
+            .map_err(|e| Error::InvalidGlobPattern {
                 pattern: policy_glob_pattern.to_owned(),
                 error: e.to_string(),
             })?

--- a/crates/weaver_config/src/live_check.rs
+++ b/crates/weaver_config/src/live_check.rs
@@ -46,6 +46,10 @@ pub struct LiveCheckConfig {
     /// Advice policies directory. Overrides the built-in default policies.
     pub advice_policies: Option<PathBuf>,
 
+    /// Glob pattern pointing to additional JSON/YAML files to load into OPA rego data.
+    /// Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).
+    pub advice_data: Option<String>,
+
     /// Advice preprocessor — a jq script run once over the registry data before
     /// being passed to rego policies.
     pub advice_preprocessor: Option<PathBuf>,
@@ -69,6 +73,7 @@ impl Default for LiveCheckConfig {
             no_stats: false,
             output: None,
             advice_policies: None,
+            advice_data: None,
             advice_preprocessor: None,
             otlp: LiveCheckOtlpConfig::default(),
             emit: LiveCheckEmitConfig::default(),
@@ -227,6 +232,7 @@ no_stream = false
 no_stats = true
 output = "reports"
 advice_policies = "policies"
+advice_data = "data"
 advice_preprocessor = "pre.jq"
 
 ["live-check".otlp]
@@ -250,6 +256,7 @@ otlp_logs_stdout = false
         assert!(lc.no_stats);
         assert_eq!(lc.output.as_deref(), Some(Path::new("reports")));
         assert_eq!(lc.advice_policies.as_deref(), Some(Path::new("policies")));
+        assert_eq!(lc.advice_data.as_deref(), Some("data"));
         assert_eq!(lc.advice_preprocessor.as_deref(), Some(Path::new("pre.jq")));
 
         assert_eq!(lc.otlp.grpc_address, "127.0.0.1");

--- a/crates/weaver_live_check/README.md
+++ b/crates/weaver_live_check/README.md
@@ -421,3 +421,59 @@ weaver registry emit --skip-policies
 kill -HUP $LIVE_CHECK_PID
 wait $LIVE_CHECK_PID
 ```
+
+## Loading Additional Rego Data
+
+You can load additional JSON/YAML files (e.g. schemas, configuration mapping) into OPA `data` namespace using the `--advice-data` flag,
+or the corresponding `advice_data` property under the `[live-check]` section in the `.weaver.toml` config file:
+
+```toml
+["live-check"]
+advice_data = "schemas/**/*.json"
+```
+
+Files are nested under `data` using their relative path inside the glob pattern base directory. Other file extensions are ignored.
+
+For example, if you run:
+```sh
+weaver registry live-check --advice-data "schemas/**/*.json"
+```
+
+And you have the file `schemas/user.json` with the following content:
+```json
+{
+  "allowed_ids": [
+    "usr_123",
+    "usr_456"
+  ]
+}
+```
+
+It will be parsed and loaded into the OPA engine under the `data.user` path:
+* `data.user.allowed_ids` => `["usr_123", "usr_456"]`
+
+You can then write a Rego rule to check whether the incoming telemetry attribute matches one of the allowed IDs:
+```rego
+package live_check_advice
+
+import rego.v1
+
+deny contains make_advice(advice_type, advice_level, advice_context, message) if {
+    attr := input.sample.attribute
+    attr.name == "user.id"
+    
+    # Check if the incoming attribute value is not in the allowed list
+    not attr.value in data.user.allowed_ids
+    
+    advice_type := "invalid_user_id"
+    advice_level := "violation"
+    advice_context := {
+        "attribute_key": attr.name,
+        "attribute_value": attr.value,
+        "allowed_ids": data.user.allowed_ids
+    }
+    message := sprintf("User ID '%s' is not in the allowed list: %v", [attr.value, data.user.allowed_ids])
+}
+```
+
+

--- a/crates/weaver_live_check/data/policies/bad_advice/bad.rego
+++ b/crates/weaver_live_check/data/policies/bad_advice/bad.rego
@@ -8,10 +8,3 @@ deny contains make_advice("foo", "violation", attribute_name, "bar") if {
 	not attribu1te_name
 }
 
-make_advice(advice_type, advice_level, advice_context, message) := {
-	"type": "advice",
-	"advice_type": advice_type,
-	"advice_level": advice_level,
-	"advice_context": advice_context,
-	"message": message,
-}

--- a/crates/weaver_live_check/data/policies/bad_advice/bad.rego
+++ b/crates/weaver_live_check/data/policies/bad_advice/bad.rego
@@ -2,6 +2,14 @@ package live_check_advice
 
 import rego.v1
 
+make_advice(advice_type, advice_level, advice_context, message) := {
+    "type": "advice",
+    "advice_type": advice_type,
+    "advice_level": advice_level,
+    "advice_context": advice_context,
+    "message": message,
+}
+
 # Causes: "error: use of undefined variable `attribu1te_name` is unsafe"
 deny contains make_advice("foo", "violation", attribute_name, "bar") if {
 	attribute_name := "foo"

--- a/crates/weaver_live_check/data/policies/live_check_advice/test.rego
+++ b/crates/weaver_live_check/data/policies/live_check_advice/test.rego
@@ -77,6 +77,14 @@ deny contains make_advice(advice_type, advice_level, advice_context, message) if
     message := sprintf("This is a low number of seconds: %v", [input.sample.exemplar.value])
 }
 
+make_advice(advice_type, advice_level, advice_context, message) := {
+    "type": "advice",
+    "advice_type": advice_type,
+    "advice_level": advice_level,
+    "advice_context": advice_context,
+    "message": message,
+}
+
 
 # Log with an event_name that we can compare against the matched event in the model.
 # If the registry_group is present, check for an annotation that specifies a phrase

--- a/crates/weaver_live_check/data/policies/live_check_advice/test.rego
+++ b/crates/weaver_live_check/data/policies/live_check_advice/test.rego
@@ -77,13 +77,6 @@ deny contains make_advice(advice_type, advice_level, advice_context, message) if
     message := sprintf("This is a low number of seconds: %v", [input.sample.exemplar.value])
 }
 
-make_advice(advice_type, advice_level, advice_context, message) := {
-    "type": "advice",
-    "advice_type": advice_type,
-    "advice_level": advice_level,
-    "advice_context": advice_context,
-    "message": message,
-}
 
 # Log with an event_name that we can compare against the matched event in the model.
 # If the registry_group is present, check for an annotation that specifies a phrase

--- a/crates/weaver_live_check/src/advice/rego_advisor.rs
+++ b/crates/weaver_live_check/src/advice/rego_advisor.rs
@@ -25,7 +25,7 @@ impl RegoAdvisor {
         live_checker: &LiveChecker,
         policy_dir: &Option<PathBuf>,
         jq_preprocessor: &Option<PathBuf>,
-        policy_data: &Option<String>,
+        advice_data: &Option<String>,
     ) -> Result<Self, Error> {
         let mut engine = Engine::new();
         if let Some(path) = policy_dir {
@@ -42,7 +42,7 @@ impl RegoAdvisor {
                 })?;
         }
 
-        if let Some(pattern) = policy_data {
+        if let Some(pattern) = advice_data {
             engine
                 .add_data_from_file_or_dir(pattern)
                 .map_err(|e| Error::AdviceError {

--- a/crates/weaver_live_check/src/advice/rego_advisor.rs
+++ b/crates/weaver_live_check/src/advice/rego_advisor.rs
@@ -25,6 +25,7 @@ impl RegoAdvisor {
         live_checker: &LiveChecker,
         policy_dir: &Option<PathBuf>,
         jq_preprocessor: &Option<PathBuf>,
+        policy_data: &Option<String>,
     ) -> Result<Self, Error> {
         let mut engine = Engine::new();
         if let Some(path) = policy_dir {
@@ -36,6 +37,14 @@ impl RegoAdvisor {
         } else {
             let _ = engine
                 .add_policy(DEFAULT_LIVE_CHECK_REGO_POLICY_PATH, DEFAULT_LIVE_CHECK_REGO)
+                .map_err(|e| Error::AdviceError {
+                    error: e.to_string(),
+                })?;
+        }
+
+        if let Some(pattern) = policy_data {
+            engine
+                .add_data_from_file_or_dir(pattern)
                 .map_err(|e| Error::AdviceError {
                     error: e.to_string(),
                 })?;

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -3361,4 +3361,19 @@ mod tests {
             advice
         );
     }
+
+    #[test]
+    fn test_rego_advisor_advice_data_invalid_path() {
+        let registry = make_registry(false);
+        let live_checker = LiveChecker::new(Arc::new(registry), vec![]);
+
+        // A non-existent advice_data path should surface as an AdviceError.
+        let result = RegoAdvisor::new(
+            &live_checker,
+            &None,
+            &None,
+            &Some("/non/existent/path/*.json".to_owned()),
+        );
+        assert!(matches!(result, Err(crate::Error::AdviceError { .. })));
+    }
 }

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -273,8 +273,8 @@ mod tests {
         ];
 
         let mut live_checker = LiveChecker::new(Arc::new(registry), advisors);
-        let rego_advisor =
-            RegoAdvisor::new(&live_checker, &None, &None).expect("Failed to create Rego advisor");
+        let rego_advisor = RegoAdvisor::new(&live_checker, &None, &None, &None)
+            .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
 
         let mut stats =
@@ -1172,6 +1172,7 @@ mod tests {
             &live_checker,
             &Some("data/policies/live_check_advice/".into()),
             &Some("data/jq/test.jq".into()),
+            &None,
         )
         .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
@@ -1257,8 +1258,8 @@ mod tests {
         ];
 
         let mut live_checker = LiveChecker::new(Arc::new(registry), advisors);
-        let rego_advisor =
-            RegoAdvisor::new(&live_checker, &None, &None).expect("Failed to create Rego advisor");
+        let rego_advisor = RegoAdvisor::new(&live_checker, &None, &None, &None)
+            .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
 
         let mut stats =
@@ -1323,6 +1324,7 @@ mod tests {
             &live_checker,
             &Some("data/policies/live_check_advice/".into()),
             &Some("data/jq/test.jq".into()),
+            &None,
         )
         .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
@@ -1376,8 +1378,8 @@ mod tests {
         ];
 
         let mut live_checker = LiveChecker::new(Arc::new(registry), advisors);
-        let rego_advisor =
-            RegoAdvisor::new(&live_checker, &None, &None).expect("Failed to create Rego advisor");
+        let rego_advisor = RegoAdvisor::new(&live_checker, &None, &None, &None)
+            .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
 
         let mut stats =
@@ -1462,6 +1464,7 @@ mod tests {
             &live_checker,
             &Some("data/policies/live_check_advice/".into()),
             &Some("data/jq/test.jq".into()),
+            &None,
         )
         .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
@@ -1511,6 +1514,7 @@ mod tests {
             &live_checker,
             &Some("data/policies/live_check_advice/".into()),
             &Some("data/jq/test.jq".into()),
+            &None,
         )
         .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
@@ -1803,8 +1807,8 @@ mod tests {
         ];
 
         let mut live_checker = LiveChecker::new(Arc::new(registry), advisors);
-        let rego_advisor =
-            RegoAdvisor::new(&live_checker, &None, &None).expect("Failed to create Rego advisor");
+        let rego_advisor = RegoAdvisor::new(&live_checker, &None, &None, &None)
+            .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
 
         let mut stats =
@@ -1888,6 +1892,7 @@ mod tests {
             &live_checker,
             &Some("data/policies/bad_advice/".into()),
             &Some("data/jq/test.jq".into()),
+            &None,
         )
         .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
@@ -2029,6 +2034,7 @@ mod tests {
             &live_checker,
             &Some("data/policies/live_check_advice/".into()),
             &Some("data/jq/test.jq".into()),
+            &None,
         )
         .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
@@ -3131,6 +3137,204 @@ mod tests {
                 .iter()
                 .all(|a| a.id != "entity_required_attribute_not_present"),
             "no entity findings expected when host.name present in resource"
+        );
+    }
+
+    #[test]
+    fn test_live_checker_loads_only_custom_policies() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let temp_path = temp_dir.path();
+        let policy_path = temp_path.join("custom.rego");
+
+        let rego_content = r#"
+            package live_check_advice
+
+            import rego.v1
+
+            deny contains make_advice(advice_type, advice_level, advice_context, message) if {
+                input.sample.attribute
+                input.sample.attribute.name == "test.custom_trigger"
+                advice_type := "custom_advice_finding"
+                advice_level := "violation"
+                advice_context := {"trigger": "test.custom_trigger"}
+                message := "Custom advisor rule triggered"
+            }
+        "#;
+        std::fs::write(&policy_path, rego_content).expect("Failed to write custom policy");
+
+        let registry = make_registry(false);
+        let mut live_checker = LiveChecker::new(Arc::new(registry), vec![]);
+
+        let rego_advisor =
+            RegoAdvisor::new(&live_checker, &Some(temp_path.to_path_buf()), &None, &None)
+                .expect("Failed to create Rego advisor");
+        live_checker.add_advisor(Box::new(rego_advisor));
+
+        let mut sample =
+            Sample::Attribute(SampleAttribute::try_from("test.custom_trigger=val").unwrap());
+        let mut stats =
+            LiveCheckStatistics::Cumulative(CumulativeStatistics::new(&live_checker.registry));
+
+        let result = sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
+        assert!(result.is_ok());
+
+        let advice = get_all_advice(&mut sample);
+        assert!(!advice.is_empty(), "Expected advice findings");
+
+        let has_default_advice = advice.iter().any(|a| a.id == "missing_attribute");
+        assert!(
+            !has_default_advice,
+            "Expected default missing_attribute advice to be absent. Found: {:?}",
+            advice
+        );
+
+        let has_custom_advice = advice.iter().any(|a| a.id == "custom_advice_finding");
+        assert!(
+            has_custom_advice,
+            "Expected custom_advice_finding to be present. Found: {:?}",
+            advice
+        );
+    }
+
+    #[test]
+    fn test_live_checker_loads_advice_data() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let temp_path = temp_dir.path();
+        let policy_dir = temp_path.join("policies");
+        let _ = std::fs::create_dir_all(&policy_dir);
+        let data_dir = temp_path.join("data");
+        let _ = std::fs::create_dir_all(&data_dir);
+
+        let policy_path = policy_dir.join("custom.rego");
+        let schema_path = data_dir.join("user.json");
+
+        let rego_content = r#"
+            package live_check_advice
+
+            import rego.v1
+
+            deny contains make_advice(advice_type, advice_level, advice_context, message) if {
+                input.sample.attribute
+                input.sample.attribute.name == "test.custom_trigger"
+                data.user.properties.user_id.type == "number"
+                advice_type := "custom_advice_finding"
+                advice_level := "violation"
+                advice_context := {"trigger": "test.custom_trigger"}
+                message := "Custom advisor rule triggered with data"
+            }
+        "#;
+        std::fs::write(&policy_path, rego_content).expect("Failed to write custom policy");
+
+        let json_content = r#"
+            {
+                "properties": {
+                    "user_id": {
+                        "type": "number"
+                    }
+                }
+            }
+        "#;
+        std::fs::write(&schema_path, json_content).expect("Failed to write schema json");
+
+        let registry = make_registry(false);
+        let mut live_checker = LiveChecker::new(Arc::new(registry), vec![]);
+
+        let rego_advisor = RegoAdvisor::new(
+            &live_checker,
+            &Some(policy_dir),
+            &None,
+            &Some(format!("{}/**/*.json", data_dir.to_str().unwrap())),
+        )
+        .expect("Failed to create Rego advisor");
+        live_checker.add_advisor(Box::new(rego_advisor));
+
+        let mut sample =
+            Sample::Attribute(SampleAttribute::try_from("test.custom_trigger=val").unwrap());
+        let mut stats =
+            LiveCheckStatistics::Cumulative(CumulativeStatistics::new(&live_checker.registry));
+
+        let result = sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
+        assert!(result.is_ok());
+
+        let advice = get_all_advice(&mut sample);
+        assert!(!advice.is_empty(), "Expected advice findings");
+
+        let has_custom_advice = advice.iter().any(|a| a.id == "custom_advice_finding");
+        assert!(
+            has_custom_advice,
+            "Expected custom_advice_finding to be present. Found: {:?}",
+            advice
+        );
+    }
+
+    #[test]
+    fn test_live_checker_loads_advice_data_with_glob() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let temp_path = temp_dir.path();
+        let policy_dir = temp_path.join("policies");
+        let _ = std::fs::create_dir_all(&policy_dir);
+        let data_dir = temp_path.join("data");
+        let _ = std::fs::create_dir_all(&data_dir);
+
+        let policy_path = policy_dir.join("custom.rego");
+        let schema_path_load = data_dir.join("user.json");
+        let schema_path_skip = data_dir.join("admin.txt");
+
+        let rego_content = r#"
+            package live_check_advice
+
+            import rego.v1
+
+            deny contains make_advice(advice_type, advice_level, advice_context, message) if {
+                input.sample.attribute
+                input.sample.attribute.name == "test.custom_trigger"
+                data.user.properties.user_id.type == "number"
+                advice_type := "custom_advice_finding"
+                advice_level := "violation"
+                advice_context := {"trigger": "test.custom_trigger"}
+                message := "Custom advisor rule triggered with glob data"
+            }
+        "#;
+        std::fs::write(&policy_path, rego_content).expect("Failed to write custom policy");
+
+        let json_content = r#"
+            {
+                "properties": {
+                    "user_id": {
+                        "type": "number"
+                    }
+                }
+            }
+        "#;
+        std::fs::write(&schema_path_load, json_content).expect("Failed to write schema json");
+        std::fs::write(&schema_path_skip, "some dummy text").expect("Failed to write dummy file");
+
+        let registry = make_registry(false);
+        let mut live_checker = LiveChecker::new(Arc::new(registry), vec![]);
+
+        let glob_pattern = format!("{}/data/*.json", temp_path.to_str().unwrap());
+
+        let rego_advisor =
+            RegoAdvisor::new(&live_checker, &Some(policy_dir), &None, &Some(glob_pattern))
+                .expect("Failed to create Rego advisor");
+        live_checker.add_advisor(Box::new(rego_advisor));
+
+        let mut sample =
+            Sample::Attribute(SampleAttribute::try_from("test.custom_trigger=val").unwrap());
+        let mut stats =
+            LiveCheckStatistics::Cumulative(CumulativeStatistics::new(&live_checker.registry));
+
+        let result = sample.run_live_check(&mut live_checker, &mut stats, None, &sample.clone());
+        assert!(result.is_ok());
+
+        let advice = get_all_advice(&mut sample);
+        assert!(!advice.is_empty(), "Expected advice findings");
+
+        let has_custom_advice = advice.iter().any(|a| a.id == "custom_advice_finding");
+        assert!(
+            has_custom_advice,
+            "Expected custom_advice_finding to be present. Found: {:?}",
+            advice
         );
     }
 }

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -3151,6 +3151,14 @@ mod tests {
 
             import rego.v1
 
+            make_advice(advice_type, advice_level, advice_context, message) := {
+                "type": "advice",
+                "advice_type": advice_type,
+                "advice_level": advice_level,
+                "advice_context": advice_context,
+                "message": message,
+            }
+
             deny contains make_advice(advice_type, advice_level, advice_context, message) if {
                 input.sample.attribute
                 input.sample.attribute.name == "test.custom_trigger"
@@ -3183,8 +3191,8 @@ mod tests {
 
         let has_default_advice = advice.iter().any(|a| a.id == "missing_attribute");
         assert!(
-            !has_default_advice,
-            "Expected default missing_attribute advice to be absent. Found: {:?}",
+            has_default_advice,
+            "Expected default missing_attribute advice to be present. Found: {:?}",
             advice
         );
 
@@ -3212,6 +3220,14 @@ mod tests {
             package live_check_advice
 
             import rego.v1
+
+            make_advice(advice_type, advice_level, advice_context, message) := {
+                "type": "advice",
+                "advice_type": advice_type,
+                "advice_level": advice_level,
+                "advice_context": advice_context,
+                "message": message,
+            }
 
             deny contains make_advice(advice_type, advice_level, advice_context, message) if {
                 input.sample.attribute
@@ -3284,6 +3300,14 @@ mod tests {
             package live_check_advice
 
             import rego.v1
+
+            make_advice(advice_type, advice_level, advice_context, message) := {
+                "type": "advice",
+                "advice_type": advice_type,
+                "advice_level": advice_level,
+                "advice_context": advice_context,
+                "message": message,
+            }
 
             deny contains make_advice(advice_type, advice_level, advice_context, message) if {
                 input.sample.attribute

--- a/crates/weaver_mcp/src/lib.rs
+++ b/crates/weaver_mcp/src/lib.rs
@@ -34,6 +34,10 @@ pub struct McpConfig {
     /// If None, default built-in policies are used.
     pub advice_policies: Option<PathBuf>,
 
+    /// Glob pattern pointing to additional JSON/YAML files to load into OPA rego data.
+    /// Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).
+    pub advice_data: Option<String>,
+
     /// Path to a jq preprocessor script for Rego policies.
     /// The script transforms registry data before passing to Rego.
     pub advice_preprocessor: Option<PathBuf>,
@@ -47,6 +51,7 @@ impl Default for McpConfig {
     fn default() -> Self {
         Self {
             advice_policies: None,
+            advice_data: None,
             advice_preprocessor: None,
             namespace_separator: ".".to_owned(),
         }
@@ -76,7 +81,7 @@ impl std::error::Error for McpError {}
 ///
 /// # Errors
 ///
-/// Returns an error if there's an IO error during communication.
+/// Errors if there's an IO error during communication.
 pub fn run(registry: ForgeResolvedRegistry) -> Result<(), McpError> {
     run_with_config(registry, McpConfig::default())
 }
@@ -92,7 +97,7 @@ pub fn run(registry: ForgeResolvedRegistry) -> Result<(), McpError> {
 ///
 /// # Errors
 ///
-/// Returns an error if there's an IO error during communication.
+/// Errors if there's an IO error during communication.
 pub fn run_with_config(registry: ForgeResolvedRegistry, config: McpConfig) -> Result<(), McpError> {
     // Create a tokio runtime for the async rmcp server
     let rt = tokio::runtime::Runtime::new().map_err(|e| McpError(e.to_string()))?;
@@ -143,6 +148,7 @@ mod tests {
     fn test_mcp_config_default() {
         let config = McpConfig::default();
         assert!(config.advice_policies.is_none());
+        assert!(config.advice_data.is_none());
         assert!(config.advice_preprocessor.is_none());
     }
 
@@ -150,6 +156,7 @@ mod tests {
     fn test_mcp_config_with_paths() {
         let config = McpConfig {
             advice_policies: Some(PathBuf::from("/path/to/policies")),
+            advice_data: Some("/path/to/data".to_owned()),
             advice_preprocessor: Some(PathBuf::from("/path/to/preprocessor.jq")),
             namespace_separator: ".".to_owned(),
         };
@@ -157,6 +164,7 @@ mod tests {
             config.advice_policies,
             Some(PathBuf::from("/path/to/policies"))
         );
+        assert_eq!(config.advice_data, Some("/path/to/data".to_owned()));
         assert_eq!(
             config.advice_preprocessor,
             Some(PathBuf::from("/path/to/preprocessor.jq"))

--- a/crates/weaver_mcp/src/service.rs
+++ b/crates/weaver_mcp/src/service.rs
@@ -46,6 +46,8 @@ pub struct WeaverMcpService {
     versioned_registry: Arc<VersionedRegistry>,
     /// Path to custom Rego advice policies directory.
     advice_policies: Option<PathBuf>,
+    /// Path to the directory or file containing additional rego data (JSON/YAML files) or a glob pattern.
+    advice_data: Option<String>,
     /// Path to jq preprocessor script for Rego policies.
     advice_preprocessor: Option<PathBuf>,
 }
@@ -66,6 +68,7 @@ impl WeaverMcpService {
             search_context,
             versioned_registry,
             advice_policies: config.advice_policies,
+            advice_data: config.advice_data,
             advice_preprocessor: config.advice_preprocessor,
         }
     }
@@ -83,6 +86,7 @@ impl WeaverMcpService {
             &live_checker,
             &self.advice_policies,
             &self.advice_preprocessor,
+            &self.advice_data,
         )
         .map_err(|e| format!("Failed to initialize RegoAdvisor: {e}"))?;
         live_checker.add_advisor(Box::new(rego_advisor));

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -537,6 +537,7 @@ Includes: Flexible input ingestion, configurable assessment, and template-based 
 * `--admin-port <ADMIN_PORT>` — Port used by the HTTP admin port (endpoints: /stop)
 * `--inactivity-timeout <INACTIVITY_TIMEOUT>` — Max inactivity time in seconds before stopping the listener
 * `--advice-policies <ADVICE_POLICIES>` — Advice policies directory. Set this to override the default policies
+* `--advice-data <ADVICE_DATA>` — Glob pattern pointing to additional JSON/YAML files to load into OPA rego data (other extensions are ignored). Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user)
 * `--advice-preprocessor <ADVICE_PREPROCESSOR>` — Advice preprocessor. A jq script to preprocess the registry data before passing to rego
 
 
@@ -576,6 +577,7 @@ The server communicates over stdio using JSON-RPC.
 
 * `--advice-policies <ADVICE_POLICIES>` — Advice policies directory. Set this to override the default policies
 * `--advice-preprocessor <ADVICE_PREPROCESSOR>` — Advice preprocessor. A jq script to preprocess the registry data before passing to rego
+* `--advice-data <ADVICE_DATA>` — Glob pattern pointing to additional JSON/YAML files to load into OPA rego data. Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user)
 * `--namespace-separator <NAMESPACE_SEPARATOR>` — Namespace separator used in attribute keys. Defaults to ".". Used by namespace browsing and search token splitting. [default: .]
 
 

--- a/schemas/weaver-config.json
+++ b/schemas/weaver-config.json
@@ -208,6 +208,14 @@
       "description": "Validate live telemetry against a semantic convention registry.",
       "type": "object",
       "properties": {
+        "advice_data": {
+          "description": "Glob pattern pointing to additional JSON/YAML files to load into OPA rego data.\nFiles are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
         "advice_policies": {
           "description": "Advice policies directory. Overrides the built-in default policies.",
           "type": [
@@ -283,6 +291,14 @@
       "description": "Expose a semantic convention registry over the Model Context Protocol (MCP).",
       "type": "object",
       "properties": {
+        "advice_data": {
+          "description": "Glob pattern pointing to additional JSON/YAML files to load into OPA rego data.\nFiles are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
         "advice_policies": {
           "description": "Advice policies directory. Set this to override the default policies.",
           "type": [

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -177,6 +177,11 @@ pub struct RegistryLiveCheckArgs {
     #[config]
     advice_policies: Option<PathBuf>,
 
+    /// Glob pattern pointing to additional JSON/YAML files to load into OPA rego data (other extensions are ignored). Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).
+    #[arg(long)]
+    #[config]
+    advice_data: Option<String>,
+
     /// Advice preprocessor. A jq script to preprocess the registry data before passing to rego.
     #[arg(long)]
     #[config]
@@ -285,6 +290,7 @@ pub(crate) fn command(
         &live_checker,
         &config.advice_policies,
         &config.advice_preprocessor,
+        &config.advice_data,
     )?;
     live_checker.add_advisor(Box::new(rego_advisor));
 

--- a/src/registry/mcp.rs
+++ b/src/registry/mcp.rs
@@ -43,6 +43,12 @@ pub struct RegistryMcpArgs {
     #[config]
     pub advice_preprocessor: Option<PathBuf>,
 
+    /// Glob pattern pointing to additional JSON/YAML files to load into OPA rego data.
+    /// Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).
+    #[arg(long)]
+    #[config]
+    pub advice_data: Option<String>,
+
     /// Namespace separator used in attribute keys. Defaults to ".".
     /// Used by namespace browsing and search token splitting.
     #[arg(long)]
@@ -78,6 +84,7 @@ pub(crate) fn command(
     // Build MCP config from effective config
     let mcp_config = weaver_mcp::McpConfig {
         advice_policies: cmd_config.config.advice_policies,
+        advice_data: cmd_config.config.advice_data,
         advice_preprocessor: cmd_config.config.advice_preprocessor,
         namespace_separator: cmd_config.config.namespace_separator,
     };


### PR DESCRIPTION
Related to #1362

It fixes the  
> 2. maybe related: allow to add json to policies dir (it should be translated to data)

Allows to provide additional data (via --advice-data or weaver toml) to live check policies. They are loaded into `data` and available for custom policies. 

E.g. we use it to validate complex attributes against schema in genai. This PR would allow to remove most of the hacks in https://github.com/open-telemetry/opentelemetry-python-genai/blob/27d84260b43c972bad41f615ca43cdd3f44a6f8e/util/opentelemetry-test-util-genai/src/opentelemetry/test_util_genai/_setup_weaver.py#L237 
