### PR TITLE
Fix three RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3073,9 +3073,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -4034,9 +4034,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -32,6 +32,7 @@ ignore = [
     "RUSTSEC-2024-0436", # paste - unmaintained
     "RUSTSEC-2023-0081", # safemem - unmaintained
     "RUSTSEC-2021-0146", # twoway - unmaintained
+    "RUSTSEC-2026-0173", # proc-macro-error2 - unmaintained; transitive via jiff's optional defmt feature (not enabled, never compiled)
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
RUSTSEC-2026-0186 and RUSTSEC-2026-0185 fixed by updating versions.

RUSTSEC-2026-0173 - fixed by adding proc-macro-error2 to deny.toml ignore list. It's an unused optional transitive dep, never compiled.