### PR TITLE
Don't require registry root for templates with update-markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix `registry update-markdown` so it does not require `registry` subdirectory matching `registry generate` behavior. ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @lmolkova)
+- Fix `registry update-markdown` so it does not require `registry` subdirectory matching `registry generate` behavior. ([#1544](https://github.com/open-telemetry/weaver/pull/1544) by @lmolkova)
 - Refactor resolution engine so we can support multiple schema urls registered
   and cached ([#1504](https://github.com/open-telemetry/weaver/pull/1504) by @jsuereth).
 - Change `--include-unreferenced` so that this is the same as creating a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Fix `registry update-markdown` so it does not require `registry` subdirectory matching `registry generate` behavior. ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @lmolkova)
 - Refactor resolution engine so we can support multiple schema urls registered
   and cached ([#1504](https://github.com/open-telemetry/weaver/pull/1504) by @jsuereth).
 - Change `--include-unreferenced` so that this is the same as creating a

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -328,8 +328,8 @@ Update markdown files that contain markers indicating the templates used to upda
 * `--attribute-registry-base-url <ATTRIBUTE_REGISTRY_BASE_URL>` — Optional path to the attribute registry. If provided, all attributes will be linked here
 * `-D`, `--param <PARAM>` — Parameters key=value, defined in the command line, to pass to the templates. The value must be a valid YAML value
 * `--params <PARAMS>` — Parameters, defined in a YAML file, to pass to the templates
-* `-t`, `--templates <TEMPLATES>` — Path to the directory where the templates are located. Note: `registry update-markdown` will look for a specific jinja template: {templates}/{target}/snippet.md.j2. [default: templates]
-* `--target <TARGET>` — The target to generate snippets with. Note: `registry update-markdown` will look for a specific jinja template: {templates}/{target}/snippet.md.j2
+* `-t`, `--templates <TEMPLATES>` — Path to the directory where the templates are located. Note: `registry update-markdown` will look for a specific jinja template: {templates}/{target}/snippet.md.j2, or {templates}/registry/{target}/snippet.md.j2 if a `registry` subdirectory is present. [default: templates]
+* `--target <TARGET>` — The target to generate snippets with. Note: `registry update-markdown` will look for a specific jinja template: {templates}/{target}/snippet.md.j2, or {templates}/registry/{target}/snippet.md.j2 if a `registry` subdirectory is present
 * `--diagnostic-format <DIAGNOSTIC_FORMAT>` — Format used to render the diagnostic messages. Predefined formats are: ansi, json, gh_workflow_command. [default: ansi]
 * `--diagnostic-template <DIAGNOSTIC_TEMPLATE>` — Path to the directory where the diagnostic templates are located. [default: diagnostic_templates]
 * `--diagnostic-stdout <DIAGNOSTIC_STDOUT>` — Send the output to stdout instead of stderr. [default: false]

--- a/schemas/weaver-config.json
+++ b/schemas/weaver-config.json
@@ -465,7 +465,7 @@
           "default": null
         },
         "target": {
-          "description": "The target to generate snippets with.\nNote: `registry update-markdown` will look for a specific jinja template:\n  {templates}/{target}/snippet.md.j2.",
+          "description": "The target to generate snippets with.\nNote: `registry update-markdown` will look for a specific jinja template:\n  {templates}/{target}/snippet.md.j2, or {templates}/registry/{target}/snippet.md.j2\n  if a `registry` subdirectory is present.",
           "type": [
             "string",
             "null"
@@ -473,7 +473,7 @@
           "default": null
         },
         "templates": {
-          "description": "Path to the directory where the templates are located.\nNote: `registry update-markdown` will look for a specific jinja template:\n  {templates}/{target}/snippet.md.j2.\n[default: templates]",
+          "description": "Path to the directory where the templates are located.\nNote: `registry update-markdown` will look for a specific jinja template:\n  {templates}/{target}/snippet.md.j2, or {templates}/registry/{target}/snippet.md.j2\n  if a `registry` subdirectory is present.\n[default: templates]",
           "type": "string",
           "default": "templates"
         }

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -160,7 +160,7 @@ pub(crate) fn command(
 /// Compute the effective templates root.
 /// If a `registry` subdirectory exists under the provided templates directory,
 /// that subdirectory is returned, otherwise the original directory path is returned.
-fn resolve_templates_root(templates_dir: &VirtualDirectory) -> PathBuf {
+pub(crate) fn resolve_templates_root(templates_dir: &VirtualDirectory) -> PathBuf {
     let base = templates_dir.path();
     let candidate = base.join("registry");
     if candidate.is_dir() {

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -264,6 +264,19 @@ mod tests {
 
     #[test]
     fn test_registry_update_markdown_templates_without_registry_subdir() {
+        // Build a templates directory that has NO `registry` subdirectory and holds
+        // the target template directly at `{templates}/{target}/snippet.md.j2`. This
+        // verifies update-markdown resolves templates without requiring a wrapping
+        // `registry` subdir, matching `registry generate`.
+        let temp_dir = tempfile::TempDir::new().expect("failed to create temp dir");
+        let target_dir = temp_dir.path().join("markdown");
+        std::fs::create_dir_all(&target_dir).expect("failed to create target dir");
+        let _ = std::fs::copy(
+            "data/update_markdown/templates/registry/markdown/snippet.md.j2",
+            target_dir.join("snippet.md.j2"),
+        )
+        .expect("failed to copy snippet template");
+
         let cli = Cli {
             debug: 0,
             quiet: false,
@@ -281,7 +294,7 @@ mod tests {
                     },
                     dry_run: Some(true),
                     attribute_registry_base_url: Some("/docs/attributes-registry".to_owned()),
-                    templates: Some("data/update_markdown/templates/registry".to_owned()),
+                    templates: Some(temp_dir.path().to_str().unwrap().to_owned()),
                     diagnostic: Default::default(),
                     target: Some("markdown".to_owned()),
                     param: None,

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -292,7 +292,13 @@ mod tests {
                     },
                     dry_run: Some(true),
                     attribute_registry_base_url: Some("/docs/attributes-registry".to_owned()),
-                    templates: Some(temp_dir.path().to_str().expect("temp dir path is valid UTF-8").to_owned()),
+                    templates: Some(
+                        temp_dir
+                            .path()
+                            .to_str()
+                            .expect("temp dir path is valid UTF-8")
+                            .to_owned(),
+                    ),
                     diagnostic: Default::default(),
                     target: Some("markdown".to_owned()),
                     param: None,

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -265,9 +265,7 @@ mod tests {
     #[test]
     fn test_registry_update_markdown_templates_without_registry_subdir() {
         // Build a templates directory that has NO `registry` subdirectory and holds
-        // the target template directly at `{templates}/{target}/snippet.md.j2`. This
-        // verifies update-markdown resolves templates without requiring a wrapping
-        // `registry` subdir, matching `registry generate`.
+        // the target template directly at `{templates}/{target}/snippet.md.j2`.
         let temp_dir = tempfile::TempDir::new().expect("failed to create temp dir");
         let target_dir = temp_dir.path().join("markdown");
         std::fs::create_dir_all(&target_dir).expect("failed to create target dir");

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -292,7 +292,7 @@ mod tests {
                     },
                     dry_run: Some(true),
                     attribute_registry_base_url: Some("/docs/attributes-registry".to_owned()),
-                    templates: Some(temp_dir.path().to_str().unwrap().to_owned()),
+                    templates: Some(temp_dir.path().to_str().expect("temp dir path is valid UTF-8").to_owned()),
                     diagnostic: Default::default(),
                     target: Some("markdown".to_owned()),
                     param: None,

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -3,7 +3,7 @@
 //! Update markdown files that contain markers indicating the templates used to
 //! update the specified sections.
 
-use crate::registry::generate::generate_params_shared;
+use crate::registry::generate::{generate_params_shared, resolve_templates_root};
 use crate::registry::{load_config, RegistryArgs};
 use crate::weaver::WeaverEngine;
 use crate::{DiagnosticArgs, ExitDirectives};
@@ -69,14 +69,16 @@ pub struct RegistryUpdateMarkdownArgs {
 
     /// Path to the directory where the templates are located.
     /// Note: `registry update-markdown` will look for a specific jinja template:
-    ///   {templates}/{target}/snippet.md.j2.
+    ///   {templates}/{target}/snippet.md.j2, or {templates}/registry/{target}/snippet.md.j2
+    ///   if a `registry` subdirectory is present.
     #[arg(short = 't', long)]
     #[config(default = "templates")]
     pub templates: Option<String>,
 
     /// The target to generate snippets with.
     /// Note: `registry update-markdown` will look for a specific jinja template:
-    ///   {templates}/{target}/snippet.md.j2.
+    ///   {templates}/{target}/snippet.md.j2, or {templates}/registry/{target}/snippet.md.j2
+    ///   if a `registry` subdirectory is present.
     #[arg(long)]
     #[config]
     pub target: Option<String>,
@@ -136,7 +138,8 @@ pub(crate) fn command(
             }
         })?;
     let output = {
-        let loader = FileSystemFileLoader::try_new(templates_dir.path().join("registry"), &target)?;
+        let loader =
+            FileSystemFileLoader::try_new(resolve_templates_root(&templates_dir), &target)?;
         let config = WeaverConfig::try_from_loader(&loader)?;
         OutputProcessor::from_template_config(config, loader, params, OutputTarget::Stdout)?
     };
@@ -246,6 +249,39 @@ mod tests {
                     dry_run: Some(true),
                     attribute_registry_base_url: Some("/docs/attributes-registry".to_owned()),
                     templates: Some("data/update_markdown/templates".to_owned()),
+                    diagnostic: Default::default(),
+                    target: Some("markdown".to_owned()),
+                    param: None,
+                    params: None,
+                }),
+            })),
+        };
+
+        let exit_directive = run_command(&cli);
+        // The command should succeed.
+        assert_eq!(exit_directive.exit_code, 0);
+    }
+
+    #[test]
+    fn test_registry_update_markdown_templates_without_registry_subdir() {
+        let cli = Cli {
+            debug: 0,
+            quiet: false,
+            future: false,
+            allow_git_credentials: false,
+            config: None,
+            command: Some(Commands::Registry(RegistryCommand {
+                command: RegistrySubCommand::UpdateMarkdown(RegistryUpdateMarkdownArgs {
+                    markdown_dir: Some("data/update_markdown/markdown".to_owned()),
+                    registry: RegistryArgs {
+                        registry: Some(VirtualDirectoryPath::LocalFolder {
+                            path: "data/update_markdown/registry".to_owned(),
+                        }),
+                        ..Default::default()
+                    },
+                    dry_run: Some(true),
+                    attribute_registry_base_url: Some("/docs/attributes-registry".to_owned()),
+                    templates: Some("data/update_markdown/templates/registry".to_owned()),
                     diagnostic: Default::default(),
                     target: Some("markdown".to_owned()),
                     param: None,


### PR DESCRIPTION
`weaver registry update-markdown -t ` was requiring -t pointing to`registry/{target}`, relaxing it similarly to how it's already done for `registry generate`