### PR TITLE
Replace ptrace with llvm engine for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,7 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Gather coverage
-        run: cargo tarpaulin --workspace --output-dir coverage --out lcov --ignore-tests -e xtask -e weaver -e weaver_macros -e weaver_test_support --exclude-files 'crates/weaver_forge/codegen_examples/expected_codegen/*' 'crates/weaver_live_check/tests/*'
+        run: cargo tarpaulin --engine llvm --workspace --output-dir coverage --out lcov --ignore-tests -e xtask -e weaver -e weaver_macros -e weaver_test_support --exclude-files 'crates/weaver_forge/codegen_examples/expected_codegen/*' 'crates/weaver_live_check/tests/*'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:


### PR DESCRIPTION
Codecov reports ~21 "uncovered" patch lines on PR #1539. These lines are **actually covered**

`cargo tarpaulin` has two tracing backends, `Ptrace` and `Llvm`, selected by `Auto` based on platform:

- **CI (Ubuntu / x86_64)** resolves `Auto` → **Ptrace**
- **Local (macOS)** resolves `Auto` → **Llvm** (ptrace is Linux-only)

https://github.com/xd009642/tarpaulin and https://github.com/xd009642/tarpaulin/issues/549 claim llvm to be more accurate.

There are some nuances with llvm

> If a test has a non-zero exit code coverage data isn't returned
> Some areas of thread unsafety
> Unable to handle fork and similar syscalls (one process will overwrite another's profraw file
