### PR TITLE
Add local osv scan and fix scorecard vulns

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -32,7 +32,6 @@ ignore = [
     "RUSTSEC-2024-0436", # paste - unmaintained
     "RUSTSEC-2023-0081", # safemem - unmaintained
     "RUSTSEC-2021-0146", # twoway - unmaintained
-    "RUSTSEC-2026-0173", # proc-macro-error2 - unmaintained; transitive via jiff's optional defmt feature (not enabled, never compiled)
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2497,9 +2497,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/fuzz/osv-scanner.toml
+++ b/fuzz/osv-scanner.toml
@@ -1,0 +1,5 @@
+# OSV-Scanner / OSSF Scorecard vulnerability ignore list for the fuzz workspace.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0173"
+reason = "proc-macro-error2 is unmaintained with no patched release. It is an orphan Cargo.lock entry pulled transitively via jiff's optional `defmt` feature, which is never enabled or compiled in this project."

--- a/justfile
+++ b/justfile
@@ -62,3 +62,9 @@ fuzz-all seconds="30":
 
 check-external-types:
   scripts/check_external_types.sh
+
+# Vulnerabilities check (OSV). Honors the osv-scanner.toml ignore files.
+# Install: `brew install osv-scanner` (or see https://google.github.io/osv-scanner/installation/)
+# Scan both lockfiles for known vulnerabilities, mirroring the OSSF Scorecard
+osv-scan:
+    osv-scanner scan source --lockfile Cargo.lock --lockfile fuzz/Cargo.lock

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,5 @@
+# OSV-Scanner / OSSF Scorecard vulnerability ignore list.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0173"
+reason = "proc-macro-error2 is unmaintained with no patched release. It is an orphan Cargo.lock entry pulled transitively via jiff's optional `defmt` feature, which is never enabled or compiled in this project."


### PR DESCRIPTION
Scorecard uses `osv-scanner` to check for vulnerabilities in cargo lock files. My previous PR that adjusted deny.toml for an exclusion was ignored.

Added a new justfile recipe so we can run an osv scan locally to check before making future PRs.

Also fixed a missing dep upgrade in the fuzzer's lock file.