### PR TITLE
Add stats dashboard to the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Add a stats dashboard with charts to the `serve` UI. ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @jerbly)
+- Add a stats dashboard with charts to the `serve` UI. ([#1570](https://github.com/open-telemetry/weaver/pull/1570) by @jerbly)
 - Add `semconv_grouped_entities` JQ helper. ([#1560](https://github.com/open-telemetry/weaver/pull/1560) by @lmolkova)
 - Add optional `when` clause to template entries in `weaver.yaml` — a JQ expression that gates whether a template is applied. ([#1561](https://github.com/open-telemetry/weaver/pull/1561) by @lmolkova)
 - Add `[template]` section to `.weaver.toml` with `acronyms` and `text_maps`, applied on top of every template's `weaver.yaml`. ([#1561](https://github.com/open-telemetry/weaver/pull/1561) by @lmolkova)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Add a stats dashboard with charts to the `serve` UI. ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @jerbly)
 - Add `semconv_grouped_entities` JQ helper. ([#1560](https://github.com/open-telemetry/weaver/pull/1560) by @lmolkova)
 - Add optional `when` clause to template entries in `weaver.yaml` — a JQ expression that gates whether a template is applied. ([#1561](https://github.com/open-telemetry/weaver/pull/1561) by @lmolkova)
 - Add `[template]` section to `.weaver.toml` with `acronyms` and `text_maps`, applied on top of every template's `weaver.yaml`. ([#1561](https://github.com/open-telemetry/weaver/pull/1561) by @lmolkova)

--- a/crates/weaver_resolved_schema/src/v2/registry.rs
+++ b/crates/weaver_resolved_schema/src/v2/registry.rs
@@ -388,4 +388,48 @@ mod test {
         assert_eq!(stats.events.common.total_with_note, 0);
         assert_eq!(stats.events.event_names.len(), 0);
     }
+
+    #[test]
+    fn test_stats_empty_registry() {
+        // A registry with no signals of any kind must still produce zeroed stats
+        // without panicking (e.g. no division-by-zero, empty breakdown maps).
+        let catalog: Vec<Attribute> = vec![];
+        let registry = Registry {
+            attribute_groups: vec![],
+            spans: vec![],
+            metrics: vec![],
+            events: vec![],
+            entities: vec![],
+            attributes: vec![],
+        };
+        let stats = registry.stats(&catalog);
+
+        assert_eq!(stats.attributes.attribute_count, 0);
+        assert!(stats.attributes.attribute_type_breakdown.is_empty());
+        assert!(stats.attributes.stability_breakdown.is_empty());
+        assert_eq!(stats.attributes.deprecated_count, 0);
+
+        assert_eq!(stats.metrics.common.count, 0);
+        assert_eq!(stats.metrics.common.deprecated_count, 0);
+        assert_eq!(stats.metrics.common.total_with_note, 0);
+        assert!(stats.metrics.common.stability_breakdown.is_empty());
+        assert!(stats.metrics.metric_names.is_empty());
+        assert!(stats.metrics.instrument_breakdown.is_empty());
+        assert!(stats.metrics.unit_breakdown.is_empty());
+
+        assert_eq!(stats.spans.common.count, 0);
+        assert!(stats.spans.span_kind_breakdown.is_empty());
+
+        assert_eq!(stats.events.common.count, 0);
+        assert!(stats.events.event_names.is_empty());
+
+        assert_eq!(stats.entities.common.count, 0);
+        assert!(stats.entities.entity_types.is_empty());
+        assert!(stats
+            .entities
+            .entity_identity_length_distribution
+            .is_empty());
+
+        assert_eq!(stats.attribute_groups.common.count, 0);
+    }
 }

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -17,7 +17,7 @@ use weaver_forge::run_filter_raw;
 use crate::serve::types::FilterParams;
 
 use super::server::AppState;
-use super::types::{RegistryCounts, RegistryStats, SearchParams, SearchResponse};
+use super::types::{SearchParams, SearchResponse};
 
 /// Health check.
 #[utoipa::path(
@@ -78,30 +78,25 @@ pub async fn get_schema(Path(name): Path<String>) -> impl IntoResponse {
 }
 
 /// Get statistics for the registry.
+///
+/// Returns the full `weaver registry stats` output: counts, and type/stability/
+/// instrument/unit/span-kind breakdowns plus deprecation and documentation coverage.
 #[utoipa::path(
     get,
     path = "/api/v1/registry/stats",
     responses(
-        (status = 200, description = "Registry stats", body = RegistryStats)
+        (status = 200, description = "Registry stats", content_type = "application/json")
     ),
     tag = "registry"
 )]
 pub async fn get_registry_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let registry = &state.registry;
-
-    let stats = RegistryStats {
-        schema_url: registry.schema_url.to_string(),
-        counts: RegistryCounts {
-            attributes: registry.registry.attributes.len(),
-            metrics: registry.registry.metrics.len(),
-            spans: registry.registry.spans.len(),
-            events: registry.registry.events.len(),
-            entities: registry.registry.entities.len(),
-            attribute_groups: registry.registry.attribute_groups.len(),
-        },
-    };
-
-    Json(stats)
+    // The stats are static for the life of the process, so they are serialized
+    // once at startup and served verbatim here.
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        state.stats_json.clone(),
+    )
 }
 
 /// Get an attribute by key.

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -88,7 +88,20 @@ fn run_serve(
         crate::weaver::Resolved::V1(v) => v.try_into().map_err(DiagnosticMessages::from_error)?,
         crate::weaver::Resolved::V2(v) => v,
     };
+
+    // Compute the full registry stats once, before the resolved schema is consumed
+    // into the template (forge) representation.
+    let stats = resolved_v2.resolved_schema().stats();
     let forge_registry = resolved_v2.into_template_schema();
+
+    let stats_response = types::RegistryStatsResponse {
+        schema_url: forge_registry.schema_url.to_string(),
+        version: "v2",
+        stats,
+    };
+    let stats_json = serde_json::to_string(&stats_response)
+        .map_err(server::Error::from)
+        .map_err(DiagnosticMessages::from_error)?;
 
     if !diag_msgs.is_empty() {
         // Log warnings but continue
@@ -112,7 +125,7 @@ fn run_serve(
     // Run the async server using tokio runtime
     tokio::runtime::Runtime::new()
         .expect("Failed to create tokio runtime")
-        .block_on(async { run_server(bind, forge_registry, cors_origins).await })
+        .block_on(async { run_server(bind, forge_registry, stats_json, cors_origins).await })
         .map_err(DiagnosticMessages::from_error)?;
 
     Ok(ExitDirectives {

--- a/src/serve/server.rs
+++ b/src/serve/server.rs
@@ -24,7 +24,7 @@ use weaver_forge::v2::{
 use weaver_semconv::stability::Stability;
 
 use super::handlers;
-use super::types::{RegistryCounts, RegistryStats, SearchResponse};
+use super::types::SearchResponse;
 use super::ui::UI_DIST;
 use weaver_search::{ScoredResult, SearchContext, SearchResult, SearchType};
 
@@ -34,6 +34,8 @@ pub struct AppState {
     pub registry: ForgeResolvedRegistry,
     /// Pre-built search context for fast lookups.
     pub search_ctx: SearchContext,
+    /// Full registry statistics, serialized once at startup and served verbatim.
+    pub stats_json: String,
 }
 
 /// Error type for server operations.
@@ -45,11 +47,25 @@ pub enum Error {
         /// The error message.
         error: String,
     },
+    /// JSON serialization error
+    #[error("Serialization error: {error}")]
+    Serialization {
+        /// The error message.
+        error: String,
+    },
 }
 
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
         Error::Io {
+            error: err.to_string(),
+        }
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Error::Serialization {
             error: err.to_string(),
         }
     }
@@ -85,8 +101,6 @@ impl From<std::io::Error> for Error {
     ),
     components(
         schemas(
-            RegistryStats,
-            RegistryCounts,
             SearchType,
             SearchResponse,
             SearchResult,
@@ -122,10 +136,12 @@ async fn openapi_spec() -> Json<utoipa::openapi::OpenApi> {
 ///
 /// * `bind_addr` - The address to bind the server to.
 /// * `registry` - The resolved V2 registry to serve.
+/// * `stats_json` - Full registry statistics, pre-serialized to JSON at startup.
 /// * `cors_origins` - Optional CORS origins. Use "*" for any origin, comma-separated for specific origins, or None for no CORS.
 pub async fn run_server(
     bind_addr: SocketAddr,
     registry: ForgeResolvedRegistry,
+    stats_json: String,
     cors_origins: Option<&str>,
 ) -> Result<(), Error> {
     // Build search context once at startup
@@ -134,6 +150,7 @@ pub async fn run_server(
     let state = Arc::new(AppState {
         registry,
         search_ctx,
+        stats_json,
     });
 
     let mut app = Router::new()

--- a/src/serve/types.rs
+++ b/src/serve/types.rs
@@ -4,35 +4,23 @@
 
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
+use weaver_resolved_schema::v2::stats::Stats;
 use weaver_search::{SearchResult, SearchType};
 use weaver_semconv::stability::Stability;
 
 /// Registry stats response.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct RegistryStats {
+///
+/// Serves the full output of `weaver registry stats` (the same `Stats` struct
+/// computed by the CLI) so the UI can render detailed breakdowns and charts.
+#[derive(Debug, Serialize)]
+pub struct RegistryStatsResponse {
     /// The schema URL.
     pub schema_url: String,
-    /// Counts of different entity types.
-    pub counts: RegistryCounts,
-    // TODO: It would be better to serve the output of `weaver registry stats` here
-    // then we could draw graphs in the UI.
-}
-
-/// Counts of different entity types in the registry.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct RegistryCounts {
-    /// Number of attributes.
-    pub attributes: usize,
-    /// Number of metrics.
-    pub metrics: usize,
-    /// Number of spans.
-    pub spans: usize,
-    /// Number of events.
-    pub events: usize,
-    /// Number of entities.
-    pub entities: usize,
-    /// Number of attribute groups.
-    pub attribute_groups: usize,
+    /// The resolved schema version these stats were computed from.
+    pub version: &'static str,
+    /// The full registry and refinement statistics.
+    #[serde(flatten)]
+    pub stats: Stats,
 }
 
 /// Query parameters for search endpoint.

--- a/ui/e2e/empty-sections.spec.ts
+++ b/ui/e2e/empty-sections.spec.ts
@@ -1,0 +1,99 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import process from 'node:process'
+import { expect, test } from '@playwright/test'
+
+// The stats dashboard hides a signal type's section when that signal has no
+// members. The shared render-registry fixture has every signal type, so this
+// spec launches a second server against an attributes-only fixture and asserts
+// the empty sections disappear.
+//
+// Skipped under WEAVER_EXTERNAL_SERVER (the Docker publish job), which serves a
+// single fixed registry on a container and can't launch another weaver process.
+
+const PORT = 8232
+const BASE = `http://127.0.0.1:${PORT}`
+
+async function waitForHealth(deadlineMs: number): Promise<void> {
+  const deadline = Date.now() + deadlineMs
+  for (;;) {
+    try {
+      const res = await fetch(`${BASE}/health`)
+      if (res.ok) return
+    } catch {
+      // Server not accepting connections yet.
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`attributes-only server did not become healthy on ${BASE}`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
+}
+
+test.describe('empty-section hiding', () => {
+  test.skip(
+    Boolean(process.env.WEAVER_EXTERNAL_SERVER),
+    'cannot launch a second weaver server in the external-server (Docker) job'
+  )
+
+  let server: ChildProcess | undefined
+
+  test.beforeAll(async () => {
+    // The first `cargo run` may compile; allow a generous startup window.
+    test.setTimeout(180_000)
+    // `pnpm test:e2e` runs from ui/, so the repo root (weaver binary + fixtures)
+    // is one level up — mirrors playwright.config.ts's webServer cwd.
+    server = spawn(
+      'cargo',
+      [
+        'run',
+        '--',
+        'serve',
+        '-r',
+        'ui/e2e/fixtures/attributes-only-registry',
+        '--bind',
+        `127.0.0.1:${PORT}`,
+      ],
+      { cwd: '..', stdio: 'ignore', detached: true }
+    )
+    await waitForHealth(170_000)
+  })
+
+  test.afterAll(() => {
+    // Kill the whole process group (cargo + the weaver child it spawned).
+    if (server?.pid) {
+      try {
+        process.kill(-server.pid, 'SIGTERM')
+      } catch {
+        // Already exited.
+      }
+    }
+  })
+
+  test('sections for empty signals are hidden, present ones remain', async ({ page }) => {
+    // Confirm the fixture shape: attributes present, everything else empty.
+    const res = await fetch(`${BASE}/api/v1/registry/stats`)
+    expect(res.ok).toBeTruthy()
+    const stats = await res.json()
+    expect(stats.registry.attributes.attribute_count).toBeGreaterThan(0)
+    for (const signal of ['metrics', 'spans', 'events', 'entities'] as const) {
+      expect(stats.registry[signal].common.count).toBe(0)
+    }
+
+    await page.goto(`${BASE}/stats`)
+    await expect(page.getByRole('heading', { name: 'Registry Stats' })).toBeVisible()
+
+    // Signals that exist keep their sections.
+    await expect(page.getByRole('heading', { name: 'Attributes', exact: true })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'Stability & Deprecation', exact: true })
+    ).toBeVisible()
+
+    // Signals with zero members have no section at all.
+    for (const hidden of ['Metrics', 'Spans', 'Entities', 'Documentation Coverage']) {
+      await expect(page.getByRole('heading', { name: hidden, exact: true })).toHaveCount(0)
+    }
+
+    // The KPI overview still lists every signal type (including the empty ones).
+    await expect(page.locator('a.stat')).toHaveCount(5)
+  })
+})

--- a/ui/e2e/fixtures/attributes-only-registry/manifest.yaml
+++ b/ui/e2e/fixtures/attributes-only-registry/manifest.yaml
@@ -1,0 +1,6 @@
+name: weaver-attributes-only-fixture
+description: >
+  A registry containing only attributes (no metrics, spans, events, or
+  entities). Used by e2e/empty-sections.spec.ts to verify the stats dashboard
+  hides the sections for signal types that have no members.
+schema_url: https://github.com/open-telemetry/weaver/ui/e2e/fixtures/attributes-only-registry/0.1.0

--- a/ui/e2e/fixtures/attributes-only-registry/registry.yaml
+++ b/ui/e2e/fixtures/attributes-only-registry/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../../../../schemas/semconv.schema.v2.json
+file_format: definition/2
+
+# Attributes only — deliberately no metrics, spans, events, or entities so the
+# stats dashboard has empty sections to hide. See e2e/empty-sections.spec.ts.
+attributes:
+  - key: attronly.string
+    type: string
+    brief: A stable string attribute.
+    stability: stable
+    examples: "example"
+
+  - key: attronly.int
+    type: int
+    brief: A development int attribute.
+    stability: development
+    examples: 1

--- a/ui/e2e/stats.spec.ts
+++ b/ui/e2e/stats.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test'
+
+// Rich stats dashboard tests. Model-agnostic; run against the same self-contained
+// render-registry fixture the other specs use. The dashboard is driven by the full
+// `weaver registry stats` output served at /api/v1/registry/stats.
+
+test('stats dashboard renders KPIs, sections and charts', async ({ page }) => {
+  await page.goto('/stats')
+
+  await expect(page.getByRole('heading', { name: 'Registry Stats' })).toBeVisible()
+  await expect(page.getByText(/Error loading registry stats/)).toHaveCount(0)
+
+  // Five KPI tiles, each showing a non-negative count.
+  const tiles = page.locator('a.stat')
+  await expect(tiles).toHaveCount(5)
+  for (const label of ['Attributes', 'Metrics', 'Spans', 'Events', 'Entities']) {
+    const tile = page.locator('a.stat', { hasText: label })
+    const value = await tile.locator('.stat-value').innerText()
+    expect(Number.parseInt(value.replace(/,/g, ''), 10)).toBeGreaterThanOrEqual(0)
+  }
+
+  // Section headings for each analytical area.
+  for (const heading of [
+    'Stability & Deprecation',
+    'Attributes',
+    'Metrics',
+    'Spans',
+    'Entities',
+    'Documentation Coverage',
+  ]) {
+    await expect(page.getByRole('heading', { name: heading, exact: true })).toBeVisible()
+  }
+
+  // Recharts renders one SVG surface per chart card. There are seven charts;
+  // wait for the first to paint, then assert the bulk are present.
+  const surfaces = page.locator('.recharts-surface')
+  await expect(surfaces.first()).toBeVisible()
+  expect(await surfaces.count()).toBeGreaterThanOrEqual(6)
+})
+
+test('stats dashboard KPI matches the stats API', async ({ page, request }) => {
+  const response = await request.get('/api/v1/registry/stats')
+  expect(response.ok()).toBeTruthy()
+  const stats = await response.json()
+
+  // The full stats shape is served (not just counts).
+  expect(stats.registry.attributes).toHaveProperty('attribute_type_breakdown')
+  expect(stats.registry.metrics).toHaveProperty('instrument_breakdown')
+
+  const apiAttributeCount = stats.registry.attributes.attribute_count as number
+
+  await page.goto('/stats')
+  const tileValue = await page
+    .locator('a.stat', { hasText: 'Attributes' })
+    .locator('.stat-value')
+    .innerText()
+  expect(Number.parseInt(tileValue.replace(/,/g, ''), 10)).toBe(apiAttributeCount)
+})

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,7 @@
     "marked": "^18.0.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "recharts": "^3.9.2",
     "swagger-ui-react": "^5.32.8",
     "yaml": "^2.8.2"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,7 +33,7 @@
     "@types/react-dom": "19.2.3",
     "@types/swagger-ui-react": "^5.18.0",
     "@vitejs/plugin-react": "6.0.3",
-    "daisyui": "5.6.10",
+    "daisyui": "5.6.13",
     "eslint": "10.5.0",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "0.5.3",
@@ -49,6 +49,13 @@
   "pnpm": {
     "overrides": {
       "monaco-editor>dompurify": ">=3.4.2"
+    },
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "react-copy-to-clipboard>react": "19",
+        "react-debounce-input>react": "19",
+        "react-inspector>react": "19"
+      }
     }
   }
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: 6.0.3
         version: 6.0.3(vite@8.0.16(@types/node@25.9.4)(jiti@2.7.0)(yaml@2.9.0))
       daisyui:
-        specifier: 5.6.10
-        version: 5.6.10
+        specifier: 5.6.13
+        version: 5.6.13
       eslint:
         specifier: 10.5.0
         version: 10.5.0(jiti@2.7.0)
@@ -989,8 +989,8 @@ packages:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
 
-  daisyui@5.6.10:
-    resolution: {integrity: sha512-vk2E+iIETWGd/jUAC0Bu6OLU4HJSSj7Q2vvsZGiJN/+vt1RK3/UEiLYC9GTldQdD3yQkjNzWb8AYYpmTenQzJg==}
+  daisyui@5.6.13:
+    resolution: {integrity: sha512-0UHyNG3TzF7pDIbPcWyLKQfgtGhJcIq2x26jwsDKp7ZhL0GwaqIMZ12+TWfp8p+mE4NNc29SJk63hEXTz3MQkg==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -3193,7 +3193,7 @@ snapshots:
 
   d3-timer@3.0.1: {}
 
-  daisyui@5.6.6: {}
+  daisyui@5.6.13: {}
 
   debug@4.4.3:
     dependencies:

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.7(react@19.2.7)
+      recharts:
+        specifier: ^3.9.2
+        version: 3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1)
       swagger-ui-react:
         specifier: ^5.32.8
         version: 5.32.8(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -289,6 +292,17 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -392,6 +406,12 @@ packages:
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swagger-api/apidom-ast@1.11.2':
     resolution: {integrity: sha512-keG5q/AR0zIizKCcfcUKiDXDQscw27SyILFb0kFmVWlgv3JTP+8pdXjzCEFW+C8RKg/etap270jv2s8B6ghuXA==}
@@ -660,6 +680,33 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -898,6 +945,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   daisyui@5.6.6:
     resolution: {integrity: sha512-UFiuIZYucF7ylrnY3PT1SqwaEbVB10mqTZRyeRchZk0bud+HihYLLhXdxGDVmR/ftrM9G9YVr9FFPRVVIZJ5hA==}
 
@@ -909,6 +1000,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -970,6 +1064,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1030,6 +1127,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1184,6 +1284,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@11.1.11:
+    resolution: {integrity: sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==}
+
   immutable@3.8.3:
     resolution: {integrity: sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==}
     engines: {node: '>=0.10.0'}
@@ -1194,6 +1297,10 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -1593,10 +1700,23 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.9.2:
+    resolution: {integrity: sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redux-immutable@4.0.0:
     resolution: {integrity: sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg==}
     peerDependencies:
       immutable: ^3.8.1 || ^4.0.0-rc.1
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
 
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
@@ -1708,6 +1828,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -1797,6 +1920,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -2112,6 +2238,18 @@ snapshots:
     dependencies:
       playwright: 1.60.0
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.11
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 19.2.7
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -2166,6 +2304,10 @@ snapshots:
   '@rolldown/pluginutils@1.0.1': {}
 
   '@scarf/scarf@1.4.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swagger-api/apidom-ast@1.11.2':
     dependencies:
@@ -2727,6 +2869,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -2989,11 +3155,51 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   daisyui@5.6.6: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -3048,6 +3254,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
+
+  es-toolkit@1.49.0: {}
 
   escalade@3.2.0: {}
 
@@ -3133,6 +3341,8 @@ snapshots:
   estraverse@5.3.0: {}
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.4: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3273,11 +3483,15 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@11.1.11: {}
+
   immutable@3.8.3: {}
 
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
+
+  internmap@2.0.3: {}
 
   invariant@2.2.4:
     dependencies:
@@ -3607,9 +3821,33 @@ snapshots:
 
   react@19.2.7: {}
 
+  recharts@3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.49.0
+      eventemitter3: 5.0.4
+      immer: 11.1.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 16.13.1
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redux-immutable@4.0.0(immutable@3.8.3):
     dependencies:
       immutable: 3.8.3
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
 
   redux@5.0.1: {}
 
@@ -3774,6 +4012,8 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3868,6 +4108,23 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@8.0.16(@types/node@25.9.4)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:

--- a/ui/src/components/charts.tsx
+++ b/ui/src/components/charts.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from 'react'
+
+/** A single value in a chart series. */
+export interface Datum {
+  name: string
+  value: number
+}
+
+interface ChartCardProps {
+  title: string
+  subtitle?: string
+  height?: number
+  children: ReactNode
+}
+
+/** A DaisyUI card wrapper giving a chart a titled, sized surface. */
+export function ChartCard({ title, subtitle, height = 288, children }: ChartCardProps) {
+  return (
+    <div className="card bg-base-100 border border-base-300 shadow-sm">
+      <div className="card-body gap-1 p-4 sm:p-5">
+        <h3 className="card-title text-base">{title}</h3>
+        {subtitle ? <p className="text-sm text-base-content/60">{subtitle}</p> : null}
+        <div className="mt-2" style={{ width: '100%', height }}>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface TooltipEntry {
+  name?: string | number
+  value?: number | string
+  color?: string
+}
+
+interface ChartTooltipProps {
+  active?: boolean
+  payload?: TooltipEntry[]
+  label?: string | number
+}
+
+/** Theme-aware tooltip (Recharts' default is a hard-coded white box). */
+export function ChartTooltip({ active, payload, label }: ChartTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null
+  return (
+    <div className="rounded-box border border-base-300 bg-base-100 px-3 py-2 text-sm shadow-lg">
+      {label !== undefined && label !== '' ? (
+        <div className="mb-1 font-semibold break-all">{label}</div>
+      ) : null}
+      {payload.map((entry, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <span
+            className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+            style={{ backgroundColor: entry.color }}
+          />
+          <span className="text-base-content/70">{entry.name}</span>
+          <span className="ml-4 font-mono">
+            {typeof entry.value === 'number' ? entry.value.toLocaleString() : entry.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** Keep legend text in neutral ink instead of the (colored) series color. */
+export function legendFormatter(value: string): ReactNode {
+  return <span className="text-sm text-base-content/80">{value}</span>
+}
+
+const STABILITY_LABELS: Record<string, string> = {
+  stable: 'Stable',
+  release_candidate: 'Release Candidate',
+  development: 'Development',
+  alpha: 'Alpha',
+  beta: 'Beta',
+  deprecated: 'Deprecated',
+}
+
+export function stabilityLabel(key: string): string {
+  return STABILITY_LABELS[key] ?? key
+}

--- a/ui/src/hooks/useChartColors.ts
+++ b/ui/src/hooks/useChartColors.ts
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Theme-aware chart palette derived from DaisyUI CSS custom properties.
+ *
+ * Recharts needs concrete color strings (not `var(--x)` references, which don't
+ * resolve inside SVG presentation attributes), so we resolve the computed values
+ * off `document.documentElement` and re-read them whenever the `data-theme`
+ * attribute changes (the theme toggle in AppLayout sets it).
+ */
+export interface ChartColors {
+  primary: string
+  secondary: string
+  accent: string
+  info: string
+  success: string
+  warning: string
+  error: string
+  neutral: string
+  /** Neutral ink for axis labels / legend text. */
+  baseContent: string
+  /** The chart surface color (used for the gap ring between adjacent marks). */
+  base100: string
+  /** Recessive color for grid lines. */
+  grid: string
+  /** Fixed categorical order (identity) — never cycled; overflow folds into "Other". */
+  categorical: string[]
+  /** Status colors keyed by stability level (mirrors StabilityBadge). */
+  stability: Record<string, string>
+}
+
+function readVar(styles: CSSStyleDeclaration, name: string, fallback: string): string {
+  const value = styles.getPropertyValue(name).trim()
+  return value || fallback
+}
+
+function computeColors(): ChartColors {
+  const styles = getComputedStyle(document.documentElement)
+  const primary = readVar(styles, '--color-primary', '#570df8')
+  const secondary = readVar(styles, '--color-secondary', '#f000b8')
+  const accent = readVar(styles, '--color-accent', '#37cdbe')
+  const info = readVar(styles, '--color-info', '#3abff8')
+  const success = readVar(styles, '--color-success', '#36d399')
+  const warning = readVar(styles, '--color-warning', '#fbbd23')
+  const error = readVar(styles, '--color-error', '#f87272')
+  const neutral = readVar(styles, '--color-neutral', '#2a323c')
+  const baseContent = readVar(styles, '--color-base-content', '#1f2937')
+  const base100 = readVar(styles, '--color-base-100', '#ffffff')
+  const grid = readVar(styles, '--color-base-300', '#d1d5db')
+
+  return {
+    primary,
+    secondary,
+    accent,
+    info,
+    success,
+    warning,
+    error,
+    neutral,
+    baseContent,
+    base100,
+    grid,
+    // Distinct hues in a fixed order; excludes the reserved status colors.
+    categorical: [primary, secondary, accent, info, neutral],
+    stability: {
+      stable: success,
+      release_candidate: accent,
+      development: warning,
+      alpha: info,
+      beta: info,
+      deprecated: error,
+    },
+  }
+}
+
+export function useChartColors(): ChartColors {
+  const [colors, setColors] = useState<ChartColors>(computeColors)
+
+  useEffect(() => {
+    const update = () => setColors(computeColors())
+    update()
+    const observer = new MutationObserver(update)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    })
+    return () => observer.disconnect()
+  }, [])
+
+  return colors
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -45,18 +45,66 @@ async function fetchJSON<T>(url: string, options?: RequestInit): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-export interface RegistryStats {
-  registry_url: string;
-  counts: RegistryCounts;
+/** A breakdown map: label -> count. */
+export type Breakdown = Record<string, number>;
+
+/** Statistics shared by every signal type (metrics, spans, events, entities, attribute groups). */
+export interface CommonSignalStats {
+  count: number;
+  stability_breakdown: Breakdown;
+  deprecated_count: number;
+  total_with_note: number;
 }
 
-export interface RegistryCounts {
-  attributes: number;
-  metrics: number;
-  spans: number;
-  events: number;
-  entities: number;
-  attribute_groups: number;
+export interface AttributeStats {
+  attribute_count: number;
+  attribute_type_breakdown: Breakdown;
+  stability_breakdown: Breakdown;
+  deprecated_count: number;
+}
+
+export interface MetricStats {
+  common: CommonSignalStats;
+  metric_names: string[];
+  instrument_breakdown: Breakdown;
+  unit_breakdown: Breakdown;
+}
+
+export interface SpanStats {
+  common: CommonSignalStats;
+  span_kind_breakdown: Breakdown;
+}
+
+export interface EventStats {
+  common: CommonSignalStats;
+  event_names: string[];
+}
+
+export interface EntityStats {
+  common: CommonSignalStats;
+  entity_types: string[];
+  entity_identity_length_distribution: Breakdown;
+}
+
+export interface AttributeGroupStats {
+  common: CommonSignalStats;
+}
+
+export interface RegistryStatsDetail {
+  attributes: AttributeStats;
+  metrics: MetricStats;
+  spans: SpanStats;
+  events: EventStats;
+  entities: EntityStats;
+  attribute_groups: AttributeGroupStats;
+}
+
+/** Full registry statistics — the same data produced by `weaver registry stats`. */
+export interface RegistryStats {
+  schema_url: string;
+  version: string;
+  registry: RegistryStatsDetail;
+  refinements: Record<string, unknown>;
 }
 
 export interface AttributeResponse {

--- a/ui/src/routes/stats.tsx
+++ b/ui/src/routes/stats.tsx
@@ -1,7 +1,30 @@
 import { createRoute, Link } from '@tanstack/react-router'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  LabelList,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
 import { getRegistryStats } from '../lib/api'
-import type { RegistryStats } from '../lib/api'
+import type { Breakdown, CommonSignalStats, RegistryStats } from '../lib/api'
+import { useChartColors } from '../hooks/useChartColors'
+import type { ChartColors } from '../hooks/useChartColors'
+import {
+  ChartCard,
+  ChartTooltip,
+  legendFormatter,
+  stabilityLabel,
+  type Datum,
+} from '../components/charts'
 import { Route as RootRoute } from './__root'
 
 export const Route = createRoute({
@@ -10,104 +33,576 @@ export const Route = createRoute({
   component: Stats,
 })
 
+// --- data transforms -------------------------------------------------------
+
+/** Order stability segments deterministically, known levels first. */
+const STABILITY_ORDER = ['stable', 'release_candidate', 'development', 'alpha', 'beta']
+
+function sortedData(map: Breakdown): Datum[] {
+  return Object.entries(map)
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value || a.name.localeCompare(b.name))
+}
+
+function topN(data: Datum[], n: number): Datum[] {
+  if (data.length <= n) return data
+  const head = data.slice(0, n)
+  const rest = data.slice(n).reduce((sum, d) => sum + d.value, 0)
+  return rest > 0 ? [...head, { name: 'Other', value: rest }] : head
+}
+
+/** Collapse the many `enum(card:NNN)` buckets into a single `enum` bar. */
+function groupAttributeTypes(map: Breakdown): Datum[] {
+  const grouped: Record<string, number> = {}
+  for (const [key, value] of Object.entries(map)) {
+    const label = key.startsWith('enum(') ? 'enum' : key
+    grouped[label] = (grouped[label] ?? 0) + value
+  }
+  return sortedData(grouped)
+}
+
+/**
+ * Turn the `enum(card:NNN)` buckets into a cardinality distribution: how many
+ * enum attributes have a given number of members. Ordered by member count.
+ */
+function enumCardinalityDistribution(map: Breakdown): Datum[] {
+  return Object.entries(map)
+    .map(([key, value]) => {
+      const match = key.match(/^enum\(card:(\d+)\)$/)
+      return match ? { name: String(Number(match[1])), value } : null
+    })
+    .filter((datum): datum is Datum => datum !== null)
+    .sort((a, b) => Number(a.name) - Number(b.name))
+}
+
+interface StabilityRow {
+  name: string
+  [level: string]: string | number
+}
+
+// --- charts ----------------------------------------------------------------
+
+const axisTick = (colors: ChartColors) => ({ fill: colors.baseContent, fontSize: 12 })
+
+/** Horizontal stacked bar of stability composition across every signal type. */
+function StabilityChart({ rows, colors }: { rows: StabilityRow[]; colors: ChartColors }) {
+  const levels = useMemo(() => {
+    const present = new Set<string>()
+    for (const row of rows) {
+      for (const key of Object.keys(row)) {
+        if (key !== 'name') present.add(key)
+      }
+    }
+    return [...present].sort(
+      (a, b) => STABILITY_ORDER.indexOf(a) - STABILITY_ORDER.indexOf(b)
+    )
+  }, [rows])
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={rows} layout="vertical" margin={{ left: 8, right: 16, top: 4 }}>
+        <CartesianGrid horizontal={false} stroke={colors.grid} strokeDasharray="3 3" />
+        <XAxis type="number" allowDecimals={false} tick={axisTick(colors)} stroke={colors.grid} />
+        <YAxis
+          type="category"
+          dataKey="name"
+          width={72}
+          tick={axisTick(colors)}
+          stroke={colors.grid}
+        />
+        <Tooltip content={<ChartTooltip />} cursor={{ fill: colors.grid, opacity: 0.2 }} isAnimationActive={false} />
+        <Legend formatter={legendFormatter} />
+        {levels.map((level) => (
+          <Bar
+            key={level}
+            dataKey={level}
+            name={stabilityLabel(level)}
+            stackId="stability"
+            fill={colors.stability[level] ?? colors.neutral}
+            stroke={colors.base100}
+            strokeWidth={2}
+            radius={2}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+/** Horizontal magnitude bars, single hue, with value labels at the ends. */
+function HorizontalBars({
+  data,
+  colors,
+  color,
+  yWidth = 120,
+}: {
+  data: Datum[]
+  colors: ChartColors
+  color: string
+  yWidth?: number
+}) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} layout="vertical" margin={{ left: 8, right: 40, top: 4 }}>
+        <CartesianGrid horizontal={false} stroke={colors.grid} strokeDasharray="3 3" />
+        <XAxis type="number" allowDecimals={false} tick={axisTick(colors)} stroke={colors.grid} />
+        <YAxis
+          type="category"
+          dataKey="name"
+          width={yWidth}
+          tick={axisTick(colors)}
+          stroke={colors.grid}
+          interval={0}
+        />
+        <Tooltip content={<ChartTooltip />} cursor={{ fill: colors.grid, opacity: 0.2 }} isAnimationActive={false} />
+        <Bar dataKey="value" name="Count" fill={color} radius={[0, 4, 4, 0]}>
+          <LabelList
+            dataKey="value"
+            position="right"
+            style={{ fill: colors.baseContent, fontSize: 11 }}
+          />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+/** Vertical magnitude bars for a small distribution. */
+function VerticalBars({
+  data,
+  colors,
+  color,
+  xLabel,
+  showLabels = true,
+}: {
+  data: Datum[]
+  colors: ChartColors
+  color: string
+  xLabel?: string
+  showLabels?: boolean
+}) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} margin={{ left: 4, right: 8, top: 20, bottom: xLabel ? 20 : 4 }}>
+        <CartesianGrid vertical={false} stroke={colors.grid} strokeDasharray="3 3" />
+        <XAxis
+          dataKey="name"
+          tick={axisTick(colors)}
+          stroke={colors.grid}
+          label={
+            xLabel
+              ? {
+                  value: xLabel,
+                  position: 'insideBottom',
+                  offset: -8,
+                  fill: colors.baseContent,
+                  fontSize: 12,
+                }
+              : undefined
+          }
+        />
+        <YAxis allowDecimals={false} tick={axisTick(colors)} stroke={colors.grid} width={36} />
+        <Tooltip content={<ChartTooltip />} cursor={{ fill: colors.grid, opacity: 0.2 }} isAnimationActive={false} />
+        <Bar dataKey="value" name="Count" fill={color} radius={[4, 4, 0, 0]}>
+          {showLabels ? (
+            <LabelList
+              dataKey="value"
+              position="top"
+              style={{ fill: colors.baseContent, fontSize: 11 }}
+            />
+          ) : null}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+/** Donut for a categorical breakdown. */
+function DonutChart({ data, colors }: { data: Datum[]; colors: ChartColors }) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="value"
+          nameKey="name"
+          innerRadius="55%"
+          outerRadius="82%"
+          paddingAngle={2}
+          stroke={colors.base100}
+          strokeWidth={2}
+        >
+          {data.map((entry, index) => (
+            <Cell key={entry.name} fill={colors.categorical[index % colors.categorical.length]} />
+          ))}
+        </Pie>
+        <Tooltip content={<ChartTooltip />} isAnimationActive={false} />
+        <Legend formatter={legendFormatter} />
+      </PieChart>
+    </ResponsiveContainer>
+  )
+}
+
+interface CoverageRow {
+  name: string
+  documented: number
+  undocumented: number
+}
+
+/** Stacked documentation coverage (documented vs. undocumented) per signal type. */
+function CoverageChart({ rows, colors }: { rows: CoverageRow[]; colors: ChartColors }) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={rows} layout="vertical" margin={{ left: 8, right: 16, top: 4 }}>
+        <CartesianGrid horizontal={false} stroke={colors.grid} strokeDasharray="3 3" />
+        <XAxis type="number" allowDecimals={false} tick={axisTick(colors)} stroke={colors.grid} />
+        <YAxis
+          type="category"
+          dataKey="name"
+          width={72}
+          tick={axisTick(colors)}
+          stroke={colors.grid}
+        />
+        <Tooltip content={<ChartTooltip />} cursor={{ fill: colors.grid, opacity: 0.2 }} isAnimationActive={false} />
+        <Legend formatter={legendFormatter} />
+        <Bar
+          dataKey="documented"
+          name="Documented"
+          stackId="cov"
+          fill={colors.success}
+          stroke={colors.base100}
+          strokeWidth={2}
+          radius={2}
+        />
+        <Bar
+          dataKey="undocumented"
+          name="Undocumented"
+          stackId="cov"
+          fill={colors.warning}
+          stroke={colors.base100}
+          strokeWidth={2}
+          radius={2}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+function SummaryStat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-box bg-base-200/50 px-4 py-3">
+      <div className="text-xs uppercase tracking-wide text-base-content/60">{label}</div>
+      <div className="mt-1 font-mono text-2xl font-semibold">
+        {typeof value === 'number' ? value.toLocaleString() : value}
+      </div>
+    </div>
+  )
+}
+
+/** A compact key-figures panel that partners a chart for a signal type. */
+function SignalSummary({ title, common }: { title: string; common: CommonSignalStats }) {
+  const documentedPct = common.count
+    ? Math.round((common.total_with_note / common.count) * 100)
+    : 0
+  return (
+    <div className="card bg-base-100 border border-base-300 shadow-sm">
+      <div className="card-body justify-center gap-1 p-4 sm:p-5">
+        <h3 className="card-title text-base">{title}</h3>
+        <div className="mt-2 grid grid-cols-2 gap-3">
+          <SummaryStat label="Total" value={common.count} />
+          <SummaryStat label="Stable" value={common.stability_breakdown.stable ?? 0} />
+          <SummaryStat label="Deprecated" value={common.deprecated_count} />
+          <SummaryStat label="Documented" value={`${documentedPct}%`} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// --- page ------------------------------------------------------------------
+
 function Stats() {
   const [stats, setStats] = useState<RegistryStats | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const colors = useChartColors()
 
   useEffect(() => {
     let isMounted = true
-
     getRegistryStats()
       .then((data) => {
-        if (isMounted) {
-          setStats(data)
-        }
+        if (isMounted) setStats(data)
       })
       .catch((err: unknown) => {
-        if (isMounted) {
-          setError(err instanceof Error ? err.message : 'Unknown error')
-        }
+        if (isMounted) setError(err instanceof Error ? err.message : 'Unknown error')
       })
-
     return () => {
       isMounted = false
     }
   }, [])
 
-  const statItems = stats
-    ? [
-        {
-          label: 'Attributes',
-          value: stats.counts.attributes,
-          description: 'Semantic attributes',
-          type: 'attribute',
-        },
-        {
-          label: 'Metrics',
-          value: stats.counts.metrics,
-          description: 'Metric definitions',
-          type: 'metric',
-        },
-        {
-          label: 'Spans',
-          value: stats.counts.spans,
-          description: 'Span types',
-          type: 'span',
-        },
-        {
-          label: 'Events',
-          value: stats.counts.events,
-          description: 'Event definitions',
-          type: 'event',
-        },
-        {
-          label: 'Entities',
-          value: stats.counts.entities,
-          description: 'Entity types',
-          type: 'entity',
-        },
-      ]
-    : []
-
-  return (
-    <div className="space-y-6">
-      <h1 className="text-3xl font-bold">Registry Stats</h1>
-
-      {error ? (
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold">Registry Stats</h1>
         <div className="alert alert-error" role="alert">
           <span>Error loading registry stats: {error}</span>
         </div>
-      ) : !stats ? (
-        <div className="flex justify-center">
-          <span className="loading loading-spinner loading-lg"></span>
-        </div>
-      ) : (
-        <>
-          {stats.registry_url ? (
-            <p className="text-sm text-base-content/70">
-              Source:{' '}
-              <a href={stats.registry_url} target="_blank" className="link" rel="noreferrer">
-                {stats.registry_url}
-              </a>
-            </p>
-          ) : null}
+      </div>
+    )
+  }
 
-          <div className="stats stats-vertical lg:stats-horizontal shadow w-full">
-            {statItems.map((item) => (
-              <Link
-                key={item.type}
-                to="/search"
-                search={{ type: item.type }}
-                className="stat hover:bg-base-300 cursor-pointer transition-colors"
-              >
-                <div className="stat-title">{item.label}</div>
-                <div className="stat-value">{item.value}</div>
-                <div className="stat-desc">{item.description}</div>
-              </Link>
-            ))}
+  if (!stats) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold">Registry Stats</h1>
+        <div className="flex justify-center py-12">
+          <span className="loading loading-spinner loading-lg" aria-label="Loading" />
+        </div>
+      </div>
+    )
+  }
+
+  const r = stats.registry
+
+  const kpis = [
+    { label: 'Attributes', value: r.attributes.attribute_count, type: 'attribute' },
+    { label: 'Metrics', value: r.metrics.common.count, type: 'metric' },
+    { label: 'Spans', value: r.spans.common.count, type: 'span' },
+    { label: 'Events', value: r.events.common.count, type: 'event' },
+    { label: 'Entities', value: r.entities.common.count, type: 'entity' },
+  ]
+
+  // Only include signal types that actually have members, so empty rows/sections
+  // don't clutter the dashboard.
+  const signalBreakdowns = [
+    {
+      name: 'Attributes',
+      count: r.attributes.attribute_count,
+      stability: r.attributes.stability_breakdown,
+      deprecated: r.attributes.deprecated_count,
+    },
+    {
+      name: 'Metrics',
+      count: r.metrics.common.count,
+      stability: r.metrics.common.stability_breakdown,
+      deprecated: r.metrics.common.deprecated_count,
+    },
+    {
+      name: 'Spans',
+      count: r.spans.common.count,
+      stability: r.spans.common.stability_breakdown,
+      deprecated: r.spans.common.deprecated_count,
+    },
+    {
+      name: 'Events',
+      count: r.events.common.count,
+      stability: r.events.common.stability_breakdown,
+      deprecated: r.events.common.deprecated_count,
+    },
+    {
+      name: 'Entities',
+      count: r.entities.common.count,
+      stability: r.entities.common.stability_breakdown,
+      deprecated: r.entities.common.deprecated_count,
+    },
+  ].filter((signal) => signal.count > 0)
+
+  const stabilityRows: StabilityRow[] = signalBreakdowns.map((signal) => ({
+    name: signal.name,
+    ...signal.stability,
+  }))
+
+  const deprecatedData: Datum[] = signalBreakdowns.map((signal) => ({
+    name: signal.name,
+    value: signal.deprecated,
+  }))
+
+  const attributeTypeData = groupAttributeTypes(r.attributes.attribute_type_breakdown)
+  const enumCardinalityData = enumCardinalityDistribution(r.attributes.attribute_type_breakdown)
+  const instrumentData = sortedData(r.metrics.instrument_breakdown)
+  const unitData = topN(sortedData(r.metrics.unit_breakdown), 12)
+  const spanKindData = sortedData(r.spans.span_kind_breakdown)
+
+  const identityData = Object.entries(r.entities.entity_identity_length_distribution)
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => Number(a.name) - Number(b.name))
+
+  const coverageRows: CoverageRow[] = [
+    { name: 'Metrics', signal: r.metrics.common },
+    { name: 'Spans', signal: r.spans.common },
+    { name: 'Events', signal: r.events.common },
+    { name: 'Entities', signal: r.entities.common },
+  ]
+    .filter(({ signal }) => signal.count > 0)
+    .map(({ name, signal }) => ({
+      name,
+      documented: signal.total_with_note,
+      undocumented: Math.max(0, signal.count - signal.total_with_note),
+    }))
+
+  const totalDeprecated = deprecatedData.reduce((sum, d) => sum + d.value, 0)
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold">Registry Stats</h1>
+        {stats.schema_url ? (
+          <p className="text-sm text-base-content/70">
+            Source:{' '}
+            <a href={stats.schema_url} target="_blank" className="link" rel="noreferrer">
+              {stats.schema_url}
+            </a>
+          </p>
+        ) : null}
+      </div>
+
+      {/* KPI tiles */}
+      <div className="stats stats-vertical lg:stats-horizontal shadow w-full">
+        {kpis.map((kpi) => (
+          <Link
+            key={kpi.type}
+            to="/search"
+            search={{ type: kpi.type }}
+            className="stat hover:bg-base-300 cursor-pointer transition-colors"
+          >
+            <div className="stat-title">{kpi.label}</div>
+            <div className="stat-value">{kpi.value.toLocaleString()}</div>
+            <div className="stat-desc">Click to browse</div>
+          </Link>
+        ))}
+      </div>
+
+      {/* Stability & deprecation */}
+      {signalBreakdowns.length > 0 ? (
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Stability &amp; Deprecation</h2>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <ChartCard
+              title="Stability by signal type"
+              subtitle="Maturity composition across the registry"
+            >
+              <StabilityChart rows={stabilityRows} colors={colors} />
+            </ChartCard>
+            <ChartCard
+              title="Deprecated items"
+              subtitle={`${totalDeprecated.toLocaleString()} deprecated definitions in total`}
+            >
+              <HorizontalBars
+                data={deprecatedData}
+                colors={colors}
+                color={colors.error}
+                yWidth={72}
+              />
+            </ChartCard>
           </div>
-        </>
-      )}
+        </section>
+      ) : null}
+
+      {/* Attributes */}
+      {r.attributes.attribute_count > 0 ? (
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Attributes</h2>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <ChartCard
+              title="Attribute types"
+              subtitle="Enum variants are grouped into a single bucket"
+              height={320}
+            >
+              <HorizontalBars
+                data={attributeTypeData}
+                colors={colors}
+                color={colors.primary}
+                yWidth={140}
+              />
+            </ChartCard>
+            <ChartCard
+              title="Enum cardinality"
+              subtitle="Enum attributes grouped by number of members"
+              height={320}
+            >
+              {enumCardinalityData.length > 0 ? (
+                <VerticalBars
+                  data={enumCardinalityData}
+                  colors={colors}
+                  color={colors.secondary}
+                  xLabel="Members"
+                  showLabels={enumCardinalityData.length <= 12}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-sm text-base-content/60">
+                  No enum attributes
+                </div>
+              )}
+            </ChartCard>
+          </div>
+        </section>
+      ) : null}
+
+      {/* Metrics */}
+      {r.metrics.common.count > 0 ? (
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Metrics</h2>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <ChartCard title="Instruments" subtitle="Distribution of metric instrument kinds">
+              <DonutChart data={instrumentData} colors={colors} />
+            </ChartCard>
+            <SignalSummary title="Metric summary" common={r.metrics.common} />
+          </div>
+          <ChartCard
+            title="Top units"
+            subtitle="Most common metric units (rest grouped as Other)"
+          >
+            <HorizontalBars data={unitData} colors={colors} color={colors.secondary} yWidth={110} />
+          </ChartCard>
+        </section>
+      ) : null}
+
+      {/* Spans */}
+      {r.spans.common.count > 0 ? (
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Spans</h2>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <ChartCard title="Span kinds" subtitle="Distribution of span kinds">
+              <DonutChart data={spanKindData} colors={colors} />
+            </ChartCard>
+            <SignalSummary title="Span summary" common={r.spans.common} />
+          </div>
+        </section>
+      ) : null}
+
+      {/* Entities */}
+      {r.entities.common.count > 0 ? (
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Entities</h2>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <ChartCard
+              title="Entity identity size"
+              subtitle="Number of identifying attributes per entity"
+            >
+              <VerticalBars
+                data={identityData}
+                colors={colors}
+                color={colors.accent}
+                xLabel="Identity attributes"
+              />
+            </ChartCard>
+            <SignalSummary title="Entity summary" common={r.entities.common} />
+          </div>
+        </section>
+      ) : null}
+
+      {/* Documentation coverage */}
+      {coverageRows.length > 0 ? (
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Documentation Coverage</h2>
+          <ChartCard
+            title="Documented vs. undocumented"
+            subtitle="Signals carrying an explanatory note"
+          >
+            <CoverageChart rows={coverageRows} colors={colors} />
+          </ChartCard>
+        </section>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
Adds a rich stats page to the `serve` UI

`/api/v1/registry/stats` now returns the full `weaver registry stats` output, rendered as charts:

<img width="2940" height="6376" alt="image" src="https://github.com/user-attachments/assets/f0f07f4c-73e8-4356-b2e2-ce9ef302fec0" />