### PR TITLE
Warn on invalid markdown snippet markers

### DIFF
--- a/crates/weaver_semconv_gen/src/lib.rs
+++ b/crates/weaver_semconv_gen/src/lib.rs
@@ -21,28 +21,25 @@ pub use v2::SnippetGenerator as SnipperGeneratorV2;
 
 use crate::parser::{GenerateMarkdownArgs, WeaverGenerateMarkdownArgs};
 
-/// A suspicious markdown snippet marker found in a markdown document.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InvalidSnippetMarker {
-    /// One-based line number.
-    pub line: usize,
-    /// The marker line.
-    pub marker: String,
-}
-
-/// Returns snippet-looking HTML comments that do not parse as supported markers.
+/// Returns warnings for snippet-looking HTML comments that do not parse as supported markers.
 #[must_use]
-pub fn invalid_snippet_markers(contents: &str) -> Vec<InvalidSnippetMarker> {
-    contents
+pub fn validate_markers(path: &str, contents: &str) -> DiagnosticMessages {
+    let marker_warnings = contents
         .lines()
         .enumerate()
         .filter_map(|(index, line)| {
-            parser::is_invalid_snippet_marker(line).then(|| InvalidSnippetMarker {
-                line: index + 1,
-                marker: line.to_owned(),
-            })
+            if parser::looks_like_snippet_marker(line) && !parser::is_valid_snippet_marker(line) {
+                Some(DiagnosticMessage::new(Error::InvalidSnippetMarker {
+                    path: path.to_owned(),
+                    line: index + 1,
+                    marker: line.to_owned(),
+                }))
+            } else {
+                None
+            }
         })
-        .collect()
+        .collect();
+    DiagnosticMessages::new(marker_warnings)
 }
 
 /// Errors emitted by this crate.
@@ -88,6 +85,18 @@ pub enum Error {
     InvalidSnippetHeader {
         /// Markdown snippet identifier <!-- semconv {header} -->
         header: String,
+    },
+
+    /// Thrown when a snippet-looking marker is not supported.
+    #[error("Suspicious markdown snippet marker in {path}:{line}: {marker}")]
+    #[diagnostic(severity(Warning))]
+    InvalidSnippetMarker {
+        /// Markdown file path.
+        path: String,
+        /// One-based line number.
+        line: usize,
+        /// The invalid marker line.
+        marker: String,
     },
 
     /// Thrown when a snippet lookup id is not valid.

--- a/crates/weaver_semconv_gen/src/lib.rs
+++ b/crates/weaver_semconv_gen/src/lib.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use std::{fmt, fs};
 use weaver_common::diagnostic::{DiagnosticMessage, DiagnosticMessages};
 use weaver_common::error::{format_errors, WeaverError};
+use weaver_common::result::WResult;
 use weaver_diff::diff_output;
 
 mod parser;
@@ -20,27 +21,6 @@ pub use v1::SnippetGenerator;
 pub use v2::SnippetGenerator as SnipperGeneratorV2;
 
 use crate::parser::{GenerateMarkdownArgs, WeaverGenerateMarkdownArgs};
-
-/// Returns warnings for snippet-looking HTML comments that do not parse as supported markers.
-#[must_use]
-pub fn validate_markers(path: &str, contents: &str) -> DiagnosticMessages {
-    let marker_warnings = contents
-        .lines()
-        .enumerate()
-        .filter_map(|(index, line)| {
-            if parser::looks_like_snippet_marker(line) && !parser::is_valid_snippet_marker(line) {
-                Some(DiagnosticMessage::new(Error::InvalidSnippetMarker {
-                    path: path.to_owned(),
-                    line: index + 1,
-                    marker: line.to_owned(),
-                }))
-            } else {
-                None
-            }
-        })
-        .collect();
-    DiagnosticMessages::new(marker_warnings)
-}
 
 /// Errors emitted by this crate.
 #[derive(thiserror::Error, Debug, Clone, Serialize, Diagnostic)]
@@ -152,14 +132,36 @@ pub trait MarkdownSnippetGenerator {
         dry_run: bool,
         attribute_registry_base_url: Option<&str>,
     ) -> Result<(), Error> {
-        let original_markdown = fs::read_to_string(file)
-            .map_err(|e| Error::StdIoError(e.to_string()))?
-            .replace("\r\n", "\n");
-        let updated_markdown =
-            self.update_markdown_contents(&original_markdown, attribute_registry_base_url)?;
-        if !dry_run {
-            fs::write(file, updated_markdown).map_err(|e| Error::StdIoError(e.to_string()))?;
-            Ok(())
+        match self.update_markdown_with_diagnostics(file, dry_run, attribute_registry_base_url) {
+            WResult::Ok(result) | WResult::OkWithNFEs(result, _) => Ok(result),
+            WResult::FatalErr(error) => Err(error),
+        }
+    }
+
+    /// Update a markdown file and return non-fatal marker diagnostics found while processing it.
+    fn update_markdown_with_diagnostics(
+        &self,
+        file: &str,
+        dry_run: bool,
+        attribute_registry_base_url: Option<&str>,
+    ) -> WResult<(), Error> {
+        let original_markdown = match fs::read_to_string(file) {
+            Ok(contents) => contents.replace("\r\n", "\n"),
+            Err(error) => return WResult::FatalErr(Error::StdIoError(error.to_string())),
+        };
+        let (updated_markdown, marker_warnings) = match self
+            .update_markdown_contents_with_diagnostics(
+                file,
+                &original_markdown,
+                attribute_registry_base_url,
+            )
+            .into_result_with_non_fatal()
+        {
+            Ok(result) => result,
+            Err(error) => return WResult::FatalErr(error),
+        };
+        let result = if !dry_run {
+            fs::write(file, updated_markdown).map_err(|e| Error::StdIoError(e.to_string()))
         } else if original_markdown != updated_markdown {
             Err(Error::MarkdownIsNotEqual {
                 original: original_markdown,
@@ -167,6 +169,10 @@ pub trait MarkdownSnippetGenerator {
             })
         } else {
             Ok(())
+        };
+        match result {
+            Ok(()) => WResult::with_non_fatal_errors((), marker_warnings),
+            Err(error) => WResult::FatalErr(error),
         }
     }
 
@@ -180,47 +186,80 @@ pub trait MarkdownSnippetGenerator {
         contents: &str,
         attribute_registry_base_url: Option<&str>,
     ) -> Result<String, Error> {
+        match self.update_markdown_contents_with_diagnostics(
+            "<memory>",
+            contents,
+            attribute_registry_base_url,
+        ) {
+            WResult::Ok(result) | WResult::OkWithNFEs(result, _) => Ok(result),
+            WResult::FatalErr(error) => Err(error),
+        }
+    }
+
+    /// Update markdown contents and return non-fatal marker diagnostics found in the same pass.
+    fn update_markdown_contents_with_diagnostics(
+        &self,
+        file: &str,
+        contents: &str,
+        attribute_registry_base_url: Option<&str>,
+    ) -> WResult<String, Error> {
         let mut result = String::new();
         let mut snippet_context: Option<SnippetType> = None;
-        for line in contents.lines() {
-            match snippet_context {
-                Some(SnippetType::Semconv) => {
-                    if parser::is_semconv_trailer(line) {
+        let mut marker_warnings = Vec::new();
+        let update_result = (|| {
+            for (index, line) in contents.lines().enumerate() {
+                if parser::looks_like_snippet_marker(line) && !parser::is_valid_snippet_marker(line)
+                {
+                    marker_warnings.push(Error::InvalidSnippetMarker {
+                        path: file.to_owned(),
+                        line: index + 1,
+                        marker: line.to_owned(),
+                    });
+                }
+                match snippet_context {
+                    Some(SnippetType::Semconv) => {
+                        if parser::is_semconv_trailer(line) {
+                            result.push_str(line);
+                            result.push('\n');
+                            snippet_context = None;
+                        }
+                    }
+                    Some(SnippetType::Weaver) => {
+                        if parser::is_weaver_trailer(line) {
+                            result.push_str(line);
+                            result.push('\n');
+                            snippet_context = None;
+                        }
+                    }
+                    None => {
+                        // Always push this line.
                         result.push_str(line);
                         result.push('\n');
-                        snippet_context = None;
-                    }
-                }
-                Some(SnippetType::Weaver) => {
-                    if parser::is_weaver_trailer(line) {
-                        result.push_str(line);
-                        result.push('\n');
-                        snippet_context = None;
-                    }
-                }
-                None => {
-                    // Always push this line.
-                    result.push_str(line);
-                    // TODO - don't do this on last line.
-                    result.push('\n');
-                    // Check to see if line matches snippet request.
-                    // If so, generate the snippet and continue.
-                    if parser::is_markdown_snippet_directive(line) {
-                        snippet_context = Some(SnippetType::Semconv);
-                        let arg = parser::parse_markdown_snippet_directive(line)?;
-                        let snippet =
-                            self.generate_markdown_snippet(arg, attribute_registry_base_url)?;
-                        result.push_str(&snippet);
-                    } else if parser::is_weaver_directive(line) {
-                        snippet_context = Some(SnippetType::Weaver);
-                        let arg = parser::parse_weaver_snippet_directive(line)?;
-                        let snippet = self.generate_weaver_snippet(arg)?;
-                        result.push_str(&snippet);
+                        // Check to see if line matches snippet request.
+                        // If so, generate the snippet and continue.
+                        if parser::is_markdown_snippet_directive(line) {
+                            snippet_context = Some(SnippetType::Semconv);
+                            let arg = parser::parse_markdown_snippet_directive(line)?;
+                            let snippet =
+                                self.generate_markdown_snippet(arg, attribute_registry_base_url)?;
+                            result.push_str(&snippet);
+                        } else if parser::is_weaver_directive(line) {
+                            snippet_context = Some(SnippetType::Weaver);
+                            let arg = parser::parse_weaver_snippet_directive(line)?;
+                            let snippet = self.generate_weaver_snippet(arg)?;
+                            result.push_str(&snippet);
+                        }
                     }
                 }
             }
+            Ok(result)
+        })();
+        match update_result {
+            Ok(updated_markdown) => {
+                WResult::with_non_fatal_errors(updated_markdown, marker_warnings)
+            }
+            Err(error) => WResult::FatalErr(error),
         }
-        Ok(result)
     }
 
     /// Generates a markdown snippet for a given parsed argument.

--- a/crates/weaver_semconv_gen/src/lib.rs
+++ b/crates/weaver_semconv_gen/src/lib.rs
@@ -21,6 +21,30 @@ pub use v2::SnippetGenerator as SnipperGeneratorV2;
 
 use crate::parser::{GenerateMarkdownArgs, WeaverGenerateMarkdownArgs};
 
+/// A suspicious markdown snippet marker found in a markdown document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidSnippetMarker {
+    /// One-based line number.
+    pub line: usize,
+    /// The marker line.
+    pub marker: String,
+}
+
+/// Returns snippet-looking HTML comments that do not parse as supported markers.
+#[must_use]
+pub fn invalid_snippet_markers(contents: &str) -> Vec<InvalidSnippetMarker> {
+    contents
+        .lines()
+        .enumerate()
+        .filter_map(|(index, line)| {
+            parser::is_invalid_snippet_marker(line).then(|| InvalidSnippetMarker {
+                line: index + 1,
+                marker: line.to_owned(),
+            })
+        })
+        .collect()
+}
+
 /// Errors emitted by this crate.
 #[derive(thiserror::Error, Debug, Clone, Serialize, Diagnostic)]
 #[non_exhaustive]

--- a/crates/weaver_semconv_gen/src/parser.rs
+++ b/crates/weaver_semconv_gen/src/parser.rs
@@ -10,7 +10,7 @@ use nom::multi::many0_count;
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    character::complete::{alpha1, alphanumeric1, multispace0},
+    character::complete::{alpha1, alphanumeric1, multispace0, multispace1},
     combinator::{opt, recognize, value},
     multi::separated_list0,
     sequence::pair,
@@ -159,7 +159,7 @@ fn parse_html_comment(input: &str) -> IResult<&str, &str> {
 fn parse_semconv_snippet_directive(input: &str) -> IResult<&str, GenerateMarkdownArgs> {
     let (input, _) = multispace0(input)?;
     let (input, _) = tag(SEMCONV_HEADER)(input)?;
-    let (input, _) = multispace0(input)?;
+    let (input, _) = multispace1(input)?;
     let (input, id) = parse_id(input)?;
     let (input, opt_args) = opt(parse_markdown_gen_parameters).parse(input)?;
     let (input, _) = multispace0(input)?;
@@ -176,7 +176,7 @@ fn parse_semconv_snippet_directive(input: &str) -> IResult<&str, GenerateMarkdow
 fn parse_weaver_snippet_args(input: &str) -> IResult<&str, WeaverGenerateMarkdownArgs> {
     let (input, _) = multispace0(input)?;
     let (input, _) = tag(WEAVER_HEADER)(input)?;
-    let (input, _) = multispace0(input)?;
+    let (input, _) = multispace1(input)?;
     // TODO - parse JQ expression and optional template to use.
     let (input, template) = opt(parse_weaver_template_directive).parse(input)?;
     let (input, _) = multispace0(input)?;
@@ -256,6 +256,29 @@ fn parse_semconv_trailer(input: &str) -> IResult<&str, ()> {
             ErrorKind::Not,
         )))
     }
+}
+
+/// Returns true if the line is an HTML comment that looks like a snippet marker,
+/// but does not parse as a supported marker.
+pub fn is_invalid_snippet_marker(line: &str) -> bool {
+    let Ok((rest, snippet)) = parse_html_comment(line) else {
+        return false;
+    };
+    if !rest.trim().is_empty() {
+        return false;
+    }
+
+    let snippet = snippet.trim();
+    let looks_like_snippet = snippet.starts_with(SEMCONV_HEADER)
+        || snippet.starts_with(SEMCONV_TRAILER)
+        || snippet.starts_with(WEAVER_HEADER)
+        || snippet.starts_with(WEAVER_TRAILER);
+
+    looks_like_snippet
+        && !is_markdown_snippet_directive(line)
+        && !is_semconv_trailer(line)
+        && !is_weaver_directive(line)
+        && !is_weaver_trailer(line)
 }
 
 /// Returns true if the line is the <!-- endsemconv --> marker for markdown snippets.
@@ -439,9 +462,9 @@ fn parse_refinement_lookup(input: &str) -> IResult<&str, RefinementLookup> {
 mod tests {
 
     use crate::parser::{
-        is_markdown_snippet_directive, is_semconv_trailer, is_weaver_trailer, parse_id_lookup_v2,
-        parse_weaver_snippet_directive, IdLookupV2, MarkdownGenParameters, RefinementLookup,
-        RegistryLookup,
+        is_invalid_snippet_marker, is_markdown_snippet_directive, is_semconv_trailer,
+        is_weaver_trailer, parse_id_lookup_v2, parse_weaver_snippet_directive, IdLookupV2,
+        MarkdownGenParameters, RefinementLookup, RegistryLookup,
     };
     use crate::Error;
 
@@ -539,6 +562,19 @@ mod tests {
     fn parse_weaver_trailer() {
         assert!(is_weaver_trailer("<!-- endweaver -->"));
         assert!(!is_weaver_trailer("<!-- endweaverded -->"));
+    }
+
+    #[test]
+    fn recognizes_invalid_snippet_markers() {
+        assert!(is_invalid_snippet_marker("<!-- semconvmetric.foo -->"));
+        assert!(is_invalid_snippet_marker(
+            "<!-- semconv metric.foo(bad) -->"
+        ));
+        assert!(is_invalid_snippet_marker("<!-- endsemconvded -->"));
+        assert!(!is_invalid_snippet_marker("<!-- semconv metric.foo-->"));
+        assert!(!is_invalid_snippet_marker("<!-- endsemconv-->"));
+        assert!(!is_invalid_snippet_marker("<!-- other semconv stuff -->"));
+        assert!(!is_invalid_snippet_marker("hello"));
     }
 
     #[test]

--- a/crates/weaver_semconv_gen/src/parser.rs
+++ b/crates/weaver_semconv_gen/src/parser.rs
@@ -10,7 +10,7 @@ use nom::multi::many0_count;
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    character::complete::{alpha1, alphanumeric1, multispace0, multispace1},
+    character::complete::{alpha1, alphanumeric1, multispace0},
     combinator::{opt, recognize, value},
     multi::separated_list0,
     sequence::pair,
@@ -159,7 +159,7 @@ fn parse_html_comment(input: &str) -> IResult<&str, &str> {
 fn parse_semconv_snippet_directive(input: &str) -> IResult<&str, GenerateMarkdownArgs> {
     let (input, _) = multispace0(input)?;
     let (input, _) = tag(SEMCONV_HEADER)(input)?;
-    let (input, _) = multispace1(input)?;
+    let (input, _) = multispace0(input)?;
     let (input, id) = parse_id(input)?;
     let (input, opt_args) = opt(parse_markdown_gen_parameters).parse(input)?;
     let (input, _) = multispace0(input)?;
@@ -176,7 +176,7 @@ fn parse_semconv_snippet_directive(input: &str) -> IResult<&str, GenerateMarkdow
 fn parse_weaver_snippet_args(input: &str) -> IResult<&str, WeaverGenerateMarkdownArgs> {
     let (input, _) = multispace0(input)?;
     let (input, _) = tag(WEAVER_HEADER)(input)?;
-    let (input, _) = multispace1(input)?;
+    let (input, _) = multispace0(input)?;
     // TODO - parse JQ expression and optional template to use.
     let (input, template) = opt(parse_weaver_template_directive).parse(input)?;
     let (input, _) = multispace0(input)?;
@@ -568,8 +568,7 @@ mod tests {
 
     #[test]
     fn recognizes_invalid_snippet_markers() {
-        assert!(looks_like_snippet_marker("<!-- semconvmetric.foo -->"));
-        assert!(!is_valid_snippet_marker("<!-- semconvmetric.foo -->"));
+        assert!(is_valid_snippet_marker("<!-- semconvmetric.foo -->"));
         assert!(looks_like_snippet_marker(
             "<!-- semconv metric.foo(bad) -->"
         ));

--- a/crates/weaver_semconv_gen/src/parser.rs
+++ b/crates/weaver_semconv_gen/src/parser.rs
@@ -258,9 +258,8 @@ fn parse_semconv_trailer(input: &str) -> IResult<&str, ()> {
     }
 }
 
-/// Returns true if the line is an HTML comment that looks like a snippet marker,
-/// but does not parse as a supported marker.
-pub fn is_invalid_snippet_marker(line: &str) -> bool {
+/// Returns true if the line is an HTML comment that looks like a snippet marker.
+pub fn looks_like_snippet_marker(line: &str) -> bool {
     let Ok((rest, snippet)) = parse_html_comment(line) else {
         return false;
     };
@@ -269,16 +268,18 @@ pub fn is_invalid_snippet_marker(line: &str) -> bool {
     }
 
     let snippet = snippet.trim();
-    let looks_like_snippet = snippet.starts_with(SEMCONV_HEADER)
+    snippet.starts_with(SEMCONV_HEADER)
         || snippet.starts_with(SEMCONV_TRAILER)
         || snippet.starts_with(WEAVER_HEADER)
-        || snippet.starts_with(WEAVER_TRAILER);
+        || snippet.starts_with(WEAVER_TRAILER)
+}
 
-    looks_like_snippet
-        && !is_markdown_snippet_directive(line)
-        && !is_semconv_trailer(line)
-        && !is_weaver_directive(line)
-        && !is_weaver_trailer(line)
+/// Returns true if the line is a supported markdown snippet marker.
+pub fn is_valid_snippet_marker(line: &str) -> bool {
+    is_markdown_snippet_directive(line)
+        || is_semconv_trailer(line)
+        || is_weaver_directive(line)
+        || is_weaver_trailer(line)
 }
 
 /// Returns true if the line is the <!-- endsemconv --> marker for markdown snippets.
@@ -462,9 +463,10 @@ fn parse_refinement_lookup(input: &str) -> IResult<&str, RefinementLookup> {
 mod tests {
 
     use crate::parser::{
-        is_invalid_snippet_marker, is_markdown_snippet_directive, is_semconv_trailer,
-        is_weaver_trailer, parse_id_lookup_v2, parse_weaver_snippet_directive, IdLookupV2,
-        MarkdownGenParameters, RefinementLookup, RegistryLookup,
+        is_markdown_snippet_directive, is_semconv_trailer, is_valid_snippet_marker,
+        is_weaver_trailer, looks_like_snippet_marker, parse_id_lookup_v2,
+        parse_weaver_snippet_directive, IdLookupV2, MarkdownGenParameters, RefinementLookup,
+        RegistryLookup,
     };
     use crate::Error;
 
@@ -566,15 +568,18 @@ mod tests {
 
     #[test]
     fn recognizes_invalid_snippet_markers() {
-        assert!(is_invalid_snippet_marker("<!-- semconvmetric.foo -->"));
-        assert!(is_invalid_snippet_marker(
+        assert!(looks_like_snippet_marker("<!-- semconvmetric.foo -->"));
+        assert!(!is_valid_snippet_marker("<!-- semconvmetric.foo -->"));
+        assert!(looks_like_snippet_marker(
             "<!-- semconv metric.foo(bad) -->"
         ));
-        assert!(is_invalid_snippet_marker("<!-- endsemconvded -->"));
-        assert!(!is_invalid_snippet_marker("<!-- semconv metric.foo-->"));
-        assert!(!is_invalid_snippet_marker("<!-- endsemconv-->"));
-        assert!(!is_invalid_snippet_marker("<!-- other semconv stuff -->"));
-        assert!(!is_invalid_snippet_marker("hello"));
+        assert!(!is_valid_snippet_marker("<!-- semconv metric.foo(bad) -->"));
+        assert!(looks_like_snippet_marker("<!-- endsemconvded -->"));
+        assert!(!is_valid_snippet_marker("<!-- endsemconvded -->"));
+        assert!(is_valid_snippet_marker("<!-- semconv metric.foo-->"));
+        assert!(is_valid_snippet_marker("<!-- endsemconv-->"));
+        assert!(!looks_like_snippet_marker("<!-- other semconv stuff -->"));
+        assert!(!looks_like_snippet_marker("hello"));
     }
 
     #[test]

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -10,7 +10,7 @@ use crate::{DiagnosticArgs, ExitDirectives};
 use clap::Args;
 use miette::Diagnostic;
 use serde_yaml::Value;
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 use weaver_common::diagnostic::{is_future_mode_enabled, DiagnosticMessage, DiagnosticMessages};
 use weaver_common::http_auth::HttpAuthResolver;
 use weaver_common::vdir::VirtualDirectory;
@@ -21,7 +21,9 @@ use weaver_forge::config::WeaverConfig;
 use weaver_forge::file_loader::FileSystemFileLoader;
 use weaver_forge::{OutputProcessor, OutputTarget};
 use weaver_macros::weaver_command;
-use weaver_semconv_gen::{MarkdownSnippetGenerator, SnipperGeneratorV2, SnippetGenerator};
+use weaver_semconv_gen::{
+    invalid_snippet_markers, MarkdownSnippetGenerator, SnipperGeneratorV2, SnippetGenerator,
+};
 
 #[derive(thiserror::Error, Debug, serde::Serialize, Diagnostic)]
 enum UpdateMarkdownError {
@@ -32,6 +34,21 @@ enum UpdateMarkdownError {
     /// The update-markdown command ran into a fatal error.
     #[error("weaver registry update-markdown failed.")]
     MarkdownUpdateFailed,
+}
+
+#[derive(thiserror::Error, Debug, serde::Serialize, Diagnostic)]
+enum UpdateMarkdownWarning {
+    /// A markdown file contains a snippet-looking marker that could not be parsed.
+    #[error("Suspicious markdown snippet marker in {path}:{line}: {marker}")]
+    #[diagnostic(severity(Warning))]
+    InvalidSnippetMarker {
+        /// Markdown file path.
+        path: String,
+        /// One-based line number.
+        line: usize,
+        /// The marker line.
+        marker: String,
+    },
 }
 
 /// Update Jinja-marker sections inside Markdown files from a resolved registry.
@@ -171,6 +188,7 @@ pub(crate) fn command(
     log_success("Registry resolved successfully");
     let operation = if dry_run { "Validating" } else { "Updating" };
     let mut has_error = false;
+    let mut marker_warnings = DiagnosticMessages::empty();
     for entry in walkdir::WalkDir::new(&markdown_dir)
         .into_iter()
         .filter_map(|e| match e {
@@ -179,11 +197,21 @@ pub(crate) fn command(
         })
     {
         log_info(format!("{}: ${}", operation, entry.path().display()));
-        if let Err(error) = generator.update_markdown(
-            &entry.path().display().to_string(),
-            dry_run,
-            attribute_registry_base_url.as_deref(),
-        ) {
+        let path = entry.path().display().to_string();
+        if let Ok(contents) = fs::read_to_string(entry.path()) {
+            for marker in invalid_snippet_markers(&contents) {
+                marker_warnings.extend_from_vec(vec![DiagnosticMessage::new(
+                    UpdateMarkdownWarning::InvalidSnippetMarker {
+                        path: path.clone(),
+                        line: marker.line,
+                        marker: marker.marker,
+                    },
+                )]);
+            }
+        }
+        if let Err(error) =
+            generator.update_markdown(&path, dry_run, attribute_registry_base_url.as_deref())
+        {
             has_error = true;
             log_error(error);
         }
@@ -203,7 +231,7 @@ pub(crate) fn command(
 
     Ok(ExitDirectives {
         exit_code: 0,
-        warnings: None,
+        warnings: (!marker_warnings.is_empty()).then_some(marker_warnings),
     })
 }
 
@@ -311,6 +339,82 @@ mod tests {
         let exit_directive = run_command(&cli);
         // The command should succeed.
         assert_eq!(exit_directive.exit_code, 0);
+    }
+
+    #[test]
+    fn test_registry_update_markdown_warns_on_invalid_snippet_marker() {
+        let temp_dir = tempfile::TempDir::new().expect("failed to create temp dir");
+        let markdown_dir = temp_dir.path().join("markdown");
+        let registry_dir = temp_dir.path().join("registry");
+        std::fs::create_dir_all(&markdown_dir).expect("failed to create markdown dir");
+        std::fs::create_dir_all(&registry_dir).expect("failed to create registry dir");
+        std::fs::write(
+            registry_dir.join("test.yaml"),
+            r#"
+groups:
+  - id: trace.test
+    type: span
+    span_kind: client
+    brief: Test span
+    stability: stable
+    attributes:
+      - id: my.name
+        brief: Test attribute.
+        type: string
+        stability: stable
+        examples: ["test"]
+"#,
+        )
+        .expect("failed to write test registry");
+
+        let markdown_path = markdown_dir.join("test.md");
+        let mut markdown =
+            std::fs::read_to_string("tests/markdown_update_dryrun/current_output/test.md")
+                .expect("failed to read test markdown");
+        markdown.push_str("\n<!-- semconvmetric.test -->\n");
+        std::fs::write(&markdown_path, markdown).expect("failed to write test markdown");
+
+        let cli = Cli {
+            debug: 0,
+            quiet: false,
+            future: false,
+            allow_git_credentials: false,
+            config: None,
+            command: Some(Commands::Registry(RegistryCommand {
+                command: RegistrySubCommand::UpdateMarkdown(RegistryUpdateMarkdownArgs {
+                    markdown_dir: Some(
+                        markdown_dir
+                            .to_str()
+                            .expect("markdown dir path is valid UTF-8")
+                            .to_owned(),
+                    ),
+                    registry: RegistryArgs {
+                        registry: Some(VirtualDirectoryPath::LocalFolder {
+                            path: registry_dir
+                                .to_str()
+                                .expect("registry dir path is valid UTF-8")
+                                .to_owned(),
+                        }),
+                        ..Default::default()
+                    },
+                    dry_run: Some(false),
+                    attribute_registry_base_url: None,
+                    templates: Some("tests/markdown_update_dryrun/templates".to_owned()),
+                    diagnostic: Default::default(),
+                    target: Some("markdown".to_owned()),
+                    param: None,
+                    params: None,
+                }),
+            })),
+        };
+
+        let exit_directive = run_command(&cli);
+        assert_eq!(exit_directive.exit_code, 0);
+        let warnings = exit_directive
+            .warnings
+            .expect("invalid marker should be reported as a warning");
+        assert_eq!(warnings.len(), 1);
+        assert!(!warnings.has_error());
     }
 
     #[test]

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -22,7 +22,7 @@ use weaver_forge::file_loader::FileSystemFileLoader;
 use weaver_forge::{OutputProcessor, OutputTarget};
 use weaver_macros::weaver_command;
 use weaver_semconv_gen::{
-    invalid_snippet_markers, MarkdownSnippetGenerator, SnipperGeneratorV2, SnippetGenerator,
+    validate_markers, MarkdownSnippetGenerator, SnipperGeneratorV2, SnippetGenerator,
 };
 
 #[derive(thiserror::Error, Debug, serde::Serialize, Diagnostic)]
@@ -34,21 +34,6 @@ enum UpdateMarkdownError {
     /// The update-markdown command ran into a fatal error.
     #[error("weaver registry update-markdown failed.")]
     MarkdownUpdateFailed,
-}
-
-#[derive(thiserror::Error, Debug, serde::Serialize, Diagnostic)]
-enum UpdateMarkdownWarning {
-    /// A markdown file contains a snippet-looking marker that could not be parsed.
-    #[error("Suspicious markdown snippet marker in {path}:{line}: {marker}")]
-    #[diagnostic(severity(Warning))]
-    InvalidSnippetMarker {
-        /// Markdown file path.
-        path: String,
-        /// One-based line number.
-        line: usize,
-        /// The marker line.
-        marker: String,
-    },
 }
 
 /// Update Jinja-marker sections inside Markdown files from a resolved registry.
@@ -199,15 +184,7 @@ pub(crate) fn command(
         log_info(format!("{}: ${}", operation, entry.path().display()));
         let path = entry.path().display().to_string();
         if let Ok(contents) = fs::read_to_string(entry.path()) {
-            for marker in invalid_snippet_markers(&contents) {
-                marker_warnings.extend_from_vec(vec![DiagnosticMessage::new(
-                    UpdateMarkdownWarning::InvalidSnippetMarker {
-                        path: path.clone(),
-                        line: marker.line,
-                        marker: marker.marker,
-                    },
-                )]);
-            }
+            marker_warnings.extend(validate_markers(&path, &contents));
         }
         if let Err(error) =
             generator.update_markdown(&path, dry_run, attribute_registry_base_url.as_deref())

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -10,7 +10,7 @@ use crate::{DiagnosticArgs, ExitDirectives};
 use clap::Args;
 use miette::Diagnostic;
 use serde_yaml::Value;
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 use weaver_common::diagnostic::{is_future_mode_enabled, DiagnosticMessage, DiagnosticMessages};
 use weaver_common::http_auth::HttpAuthResolver;
 use weaver_common::vdir::VirtualDirectory;
@@ -21,9 +21,7 @@ use weaver_forge::config::WeaverConfig;
 use weaver_forge::file_loader::FileSystemFileLoader;
 use weaver_forge::{OutputProcessor, OutputTarget};
 use weaver_macros::weaver_command;
-use weaver_semconv_gen::{
-    validate_markers, MarkdownSnippetGenerator, SnipperGeneratorV2, SnippetGenerator,
-};
+use weaver_semconv_gen::{MarkdownSnippetGenerator, SnipperGeneratorV2, SnippetGenerator};
 
 #[derive(thiserror::Error, Debug, serde::Serialize, Diagnostic)]
 enum UpdateMarkdownError {
@@ -183,11 +181,13 @@ pub(crate) fn command(
     {
         log_info(format!("{}: ${}", operation, entry.path().display()));
         let path = entry.path().display().to_string();
-        if let Ok(contents) = fs::read_to_string(entry.path()) {
-            marker_warnings.extend(validate_markers(&path, &contents));
-        }
-        if let Err(error) =
-            generator.update_markdown(&path, dry_run, attribute_registry_base_url.as_deref())
+        if let Err(error) = generator
+            .update_markdown_with_diagnostics(
+                &path,
+                dry_run,
+                attribute_registry_base_url.as_deref(),
+            )
+            .capture_non_fatal_errors(&mut marker_warnings)
         {
             has_error = true;
             log_error(error);
@@ -348,7 +348,7 @@ groups:
         let mut markdown =
             std::fs::read_to_string("tests/markdown_update_dryrun/current_output/test.md")
                 .expect("failed to read test markdown");
-        markdown.push_str("\n<!-- semconvmetric.test -->\n");
+        markdown.push_str("\n<!-- semconv metric.test(bad) -->\n");
         std::fs::write(&markdown_path, markdown).expect("failed to write test markdown");
 
         let cli = Cli {


### PR DESCRIPTION
Refs #501

This warns when `registry update-markdown` sees an HTML comment that looks like a semconv/weaver snippet marker but does not parse as one.

Marker validation now runs during the generator's existing line-by-line Markdown update pass and returns warnings as non-fatal `WResult` diagnostics, avoiding a second file read and parse. Existing whitespace-tolerant marker parsing remains unchanged.

Tests:
- `cargo fmt --all --check`
- `cargo test -p weaver_semconv_gen recognizes_invalid_snippet_markers`
- `cargo test -p weaver test_registry_update_markdown_warns_on_invalid_snippet_marker`
- `cargo clippy -p weaver_semconv_gen --all-targets --no-deps`
