### PR TITLE
Fix live-check HTTP response delivery during shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6388,6 +6388,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/weaver_live_check/Cargo.toml
+++ b/crates/weaver_live_check/Cargo.toml
@@ -37,6 +37,7 @@ serde_yaml.workspace = true
 serial_test = "3.4.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 ureq.workspace = true
+reqwest = { version = "0.13.3", default-features = false, features = ["http2"] }
 
 [lints]
 workspace = true

--- a/crates/weaver_live_check/tests/livecheck_emit.rs
+++ b/crates/weaver_live_check/tests/livecheck_emit.rs
@@ -10,6 +10,8 @@ use std::thread::sleep;
 use std::time::Duration;
 use weaver_test_support::reserve_test_port;
 
+const RESPONSE_PADDING_SIZE: usize = 2 * 1024 * 1024;
+
 /// Guard that kills the child process on drop (e.g., on panic) to prevent orphaned processes.
 struct ChildGuard(Option<Child>);
 
@@ -59,13 +61,22 @@ fn wait_for_health(port: u16) {
     }
 }
 
-/// POST /stop and return the response body.
-fn stop_and_collect_report(port: u16) -> String {
+/// POST /stop over HTTP/2 and return the response body.
+async fn stop_and_collect_report(port: u16) -> String {
     let url = format!("http://127.0.0.1:{port}/stop");
-    let response = ureq::post(&url).send("").expect("POST /stop failed");
+    let response = reqwest::Client::builder()
+        .http2_prior_knowledge()
+        .build()
+        .expect("Failed to build HTTP/2 client")
+        .post(url)
+        .send()
+        .await
+        .expect("POST /stop failed");
+    // Leave the response body unread long enough to expose premature process shutdown.
+    tokio::time::sleep(Duration::from_millis(500)).await;
     response
-        .into_body()
-        .read_to_string()
+        .text()
+        .await
         .expect("Failed to read /stop response body")
 }
 
@@ -242,7 +253,8 @@ async fn test_livecheck_emit_roundtrip() {
             json!({
                 "attribute_key": "db.system",
                 "attribute_value": "postgresql",
-                "expected": "postgres"
+                "expected": "postgres",
+                "padding": "x".repeat(RESPONSE_PADDING_SIZE)
             }),
         );
         emitter.emit_finding(&finding, &sample_ref, &parent);
@@ -336,7 +348,11 @@ async fn test_livecheck_emit_roundtrip() {
     sleep(Duration::from_millis(500));
 
     // 6. Collect report via POST /stop
-    let report_body = stop_and_collect_report(admin_port);
+    let report_body = stop_and_collect_report(admin_port).await;
+    assert!(
+        report_body.len() > RESPONSE_PADDING_SIZE,
+        "Expected a report large enough to exercise asynchronous response delivery"
+    );
 
     // 7. Wait for weaver to exit
     //    Exit code may be non-zero if there are violations — we check that separately below.

--- a/crates/weaver_live_check/tests/livecheck_emit.rs
+++ b/crates/weaver_live_check/tests/livecheck_emit.rs
@@ -66,12 +66,15 @@ async fn stop_and_collect_report(port: u16) -> String {
     let url = format!("http://127.0.0.1:{port}/stop");
     let response = reqwest::Client::builder()
         .http2_prior_knowledge()
+        .timeout(Duration::from_secs(65))
         .build()
         .expect("Failed to build HTTP/2 client")
         .post(url)
         .send()
         .await
-        .expect("POST /stop failed");
+        .expect("POST /stop failed")
+        .error_for_status()
+        .expect("POST /stop returned an error status");
     // Leave the response body unread long enough to expose premature process shutdown.
     tokio::time::sleep(Duration::from_millis(500)).await;
     response

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -470,6 +470,7 @@ pub(crate) fn command(
                     .take()
                 {
                     let _ = sender.send((content_type, body));
+                    report.wait_for_server_shutdown();
                 }
             }
         } else {

--- a/src/registry/otlp/mod.rs
+++ b/src/registry/otlp/mod.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 use std::fmt::{Display, Formatter};
 use std::net::{AddrParseError, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot, watch};
@@ -39,6 +39,8 @@ use tonic::codegen::tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 use weaver_common::diagnostic::{DiagnosticMessage, DiagnosticMessages};
+
+const ADMIN_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Channel for sending the formatted report back to the /stop HTTP handler.
 ///
@@ -50,6 +52,22 @@ pub struct AdminReportSender {
     pub sender: Arc<Mutex<Option<oneshot::Sender<(String, String)>>>>,
     /// Set to `true` to have `/stop` wait and return the report as its response body.
     pub expect_report: Arc<AtomicBool>,
+    server_shutdown: Arc<(Mutex<bool>, Condvar)>,
+}
+
+impl AdminReportSender {
+    /// Wait until the admin server has finished its graceful shutdown or times out.
+    pub fn wait_for_server_shutdown(&self) {
+        let (shutdown_lock, shutdown_complete) = &*self.server_shutdown;
+        let is_shutdown = shutdown_lock
+            .lock()
+            .expect("Admin server shutdown lock poisoned");
+        let _ = shutdown_complete
+            .wait_timeout_while(is_shutdown, ADMIN_REQUEST_TIMEOUT, |is_shutdown| {
+                !*is_shutdown
+            })
+            .expect("Admin server shutdown lock poisoned");
+    }
 }
 
 /// Expose the OTLP gRPC services.
@@ -223,6 +241,7 @@ pub fn listen_otlp_requests(
     let report_sender = AdminReportSender {
         sender: Arc::new(Mutex::new(None)),
         expect_report: Arc::new(AtomicBool::new(false)),
+        server_shutdown: Arc::new((Mutex::new(false), Condvar::new())),
     };
     let logs_service = LogsServiceImpl {
         tx: tx.clone(),
@@ -378,7 +397,7 @@ async fn stop_handler(State(state): State<AdminState>) -> impl IntoResponse {
             .send(OtlpRequest::Stop(StopSignal::AdminStop))
             .await;
 
-        let response = match tokio::time::timeout(Duration::from_secs(60), rx).await {
+        let response = match tokio::time::timeout(ADMIN_REQUEST_TIMEOUT, rx).await {
             Ok(Ok((content_type, body))) => {
                 (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], body).into_response()
             }
@@ -455,6 +474,7 @@ async fn spawn_http_admin_handler(
                 expect_report: report_sender.expect_report.clone(),
                 shutdown_tx: Arc::new(Mutex::new(Some(shutdown_tx))),
             };
+            let server_shutdown = report_sender.server_shutdown.clone();
 
             let app = Router::new()
                 .route("/health", get(health_handler))
@@ -467,6 +487,11 @@ async fn spawn_http_admin_handler(
                         let _ = shutdown_rx.await;
                     })
                     .await;
+                let (shutdown_lock, shutdown_complete) = &*server_shutdown;
+                *shutdown_lock
+                    .lock()
+                    .expect("Admin server shutdown lock poisoned") = true;
+                shutdown_complete.notify_all();
             });
         }
         Err(e) => {


### PR DESCRIPTION
When `weaver registry live-check --output http` receives `POST /stop`, the live-check command can exit after sending the report to the admin handler but before the detached Axum server finishes writing the response. With HTTP/2, terminating the process during that window resets the connection and leaves the client without the promised report.

This change coordinates shutdown between the live-check command and the admin server. After handing the report to `/stop`, the command now waits for Axum's graceful shutdown to complete, bounded by the existing 60-second admin request timeout.

The regression test uses HTTP/2, produces a response larger than typical socket buffers, and pauses after receiving the response headers before consuming the body. Without the lifecycle wait, the test fails while decoding the body with `ConnectionReset`; with the fix, the complete report is delivered and Weaver exits normally.

This was observed downstream in the OpenTelemetry Java instrumentation JMX tests: https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/29557928989/job/87829898889

## Testing

- `cargo fmt --check`
- `cargo test --bin weaver registry::otlp::tests::test_http_stop_endpoint_with_report -- --nocapture`
- `cargo test -p weaver_live_check --test livecheck_emit test_livecheck_emit_roundtrip -- --nocapture`
- `cargo clippy --bin weaver --no-deps`
- `cargo clippy -p weaver_live_check --test livecheck_emit --no-deps`