### PR TITLE
live-check: preserve instrumentation scope on signal samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 
 - Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
+- Live-check: preserve instrumentation scope through OTLP ingestion, expose it to Rego policies, and render it in standard output. ([#1605](https://github.com/open-telemetry/weaver/pull/1605) by @McGluut)
 
 # [0.25.1] - 2026-07-28
 

--- a/crates/weaver_infer/src/lib.rs
+++ b/crates/weaver_infer/src/lib.rs
@@ -1024,6 +1024,7 @@ mod tests {
             }],
             span_events: vec![],
             span_links: vec![],
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         };
@@ -1058,6 +1059,7 @@ mod tests {
                 live_check_result: None,
             }],
             span_links: vec![],
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         };
@@ -1135,6 +1137,7 @@ mod tests {
             attributes: vec![],
             span_events: vec![],
             span_links: vec![],
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         }));
@@ -1143,6 +1146,7 @@ mod tests {
             instrument: SampleInstrument::Supported(InstrumentSpec::Counter),
             unit: "{request}".to_owned(),
             data_points: None,
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         }));
@@ -1154,6 +1158,7 @@ mod tests {
             attributes: vec![],
             trace_id: None,
             span_id: None,
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         }));
@@ -1184,6 +1189,7 @@ mod tests {
             instrument: SampleInstrument::Unsupported("Summary".to_owned()),
             unit: String::new(),
             data_points: None,
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -1212,6 +1218,7 @@ mod tests {
                 exemplars: vec![],
                 live_check_result: None,
             }])),
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -1236,6 +1243,7 @@ mod tests {
                 exemplars: vec![],
                 live_check_result: None,
             }])),
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -1265,6 +1273,7 @@ mod tests {
                     live_check_result: None,
                 },
             ])),
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -1335,6 +1344,7 @@ mod tests {
             }],
             span_events: vec![],
             span_links: vec![],
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -1365,6 +1375,7 @@ mod tests {
             instrument: SampleInstrument::Supported(InstrumentSpec::Histogram),
             unit: "ms".to_owned(),
             data_points: None,
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         };
@@ -1390,6 +1401,7 @@ mod tests {
             instrument: SampleInstrument::Supported(InstrumentSpec::Counter),
             unit: String::new(), // Empty unit
             data_points: None,
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         };
@@ -1451,6 +1463,7 @@ mod tests {
                 live_check_result: None,
             }],
             span_links: vec![],
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -1575,6 +1588,7 @@ mod tests {
                 live_check_result: None,
             }],
             span_links: vec![],
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });

--- a/crates/weaver_infer/src/lib.rs
+++ b/crates/weaver_infer/src/lib.rs
@@ -101,6 +101,9 @@ impl AccumulatedSamples {
             Sample::Metric(metric) => self.add_metric(metric),
             Sample::Log(log) => self.add_event(log.event_name, log.attributes),
             Sample::Attribute(attr) => accumulate_attribute(&mut self.resources, attr),
+            Sample::InstrumentationScope(_) => {
+                // Scope metadata is not part of the inferred resource or signal schema.
+            }
             other => {
                 // This shouldn't happen since we control when add_sample is called.
                 // Adding anyway just in case.

--- a/crates/weaver_live_check/README.md
+++ b/crates/weaver_live_check/README.md
@@ -153,6 +153,10 @@ make_finding(id, level, context, message) := {
 
 `input.sample` contains the sample entity for assessment wrapped in a type e.g. `input.sample.attribute` or `input.sample.span`.
 
+`input.resource` contains the resource associated with the signal being assessed, or `null` when no resource is available.
+
+`input.instrumentation_scope` contains the instrumentation scope associated with the signal being assessed, or `null` when no scope is available. When present, it includes `name`, `version`, `schema_url`, `attributes`, and `dropped_attributes_count`.
+
 `input.registry_attribute`, when present, contains the matching attribute definition from the supplied registry.
 
 `input.registry_group`, when present, contains the matching group definition from the supplied registry.

--- a/crates/weaver_live_check/docs/finding.md
+++ b/crates/weaver_live_check/docs/finding.md
@@ -189,6 +189,7 @@ the telemetry pipeline generated the issue.
 | `span_event` | ![Development](https://img.shields.io/badge/-development-blue) | An event attached to a span |
 | `span_link` | ![Development](https://img.shields.io/badge/-development-blue) | A link between spans |
 | `resource` | ![Development](https://img.shields.io/badge/-development-blue) | A resource describing the telemetry source |
+| `instrumentation_scope` | ![Development](https://img.shields.io/badge/-development-blue) | An instrumentation scope that produced telemetry signals |
 | `metric` | ![Development](https://img.shields.io/badge/-development-blue) | A metric measurement |
 | `number_data_point` | ![Development](https://img.shields.io/badge/-development-blue) | A numeric data point within a metric |
 | `histogram_data_point` | ![Development](https://img.shields.io/badge/-development-blue) | A histogram data point within a metric |

--- a/crates/weaver_live_check/model/live_check.yaml
+++ b/crates/weaver_live_check/model/live_check.yaml
@@ -192,6 +192,10 @@ attributes:
           value: "resource"
           brief: "A resource describing the telemetry source"
           stability: development
+        - id: instrumentation_scope
+          value: "instrumentation_scope"
+          brief: "An instrumentation scope that produced telemetry signals"
+          stability: development
         - id: metric
           value: "metric"
           brief: "A metric measurement"

--- a/crates/weaver_live_check/src/advice/rego_advisor.rs
+++ b/crates/weaver_live_check/src/advice/rego_advisor.rs
@@ -9,9 +9,10 @@ use weaver_forge::jq;
 
 use super::{emit_findings, Advisor};
 use crate::{
-    live_checker::LiveChecker, otlp_logger::OtlpEmitter, Error, Sample, SampleRef,
-    VersionedAttribute, VersionedSignal, DEFAULT_LIVE_CHECK_JQ, DEFAULT_LIVE_CHECK_REGO,
-    DEFAULT_LIVE_CHECK_REGO_POLICY_PATH,
+    live_checker::LiveChecker, otlp_logger::OtlpEmitter,
+    sample_instrumentation_scope::SampleInstrumentationScope, sample_resource::SampleResource,
+    Error, Sample, SampleRef, VersionedAttribute, VersionedSignal, DEFAULT_LIVE_CHECK_JQ,
+    DEFAULT_LIVE_CHECK_REGO, DEFAULT_LIVE_CHECK_REGO_POLICY_PATH,
 };
 
 /// An advisor which runs a rego policy on the attribute
@@ -104,6 +105,8 @@ impl RegoAdvisor {
 #[derive(Serialize)]
 struct RegoInput<'a> {
     sample: SampleRef<'a>,
+    resource: Option<&'a SampleResource>,
+    instrumentation_scope: Option<&'a SampleInstrumentationScope>,
     registry_attribute: Option<Rc<VersionedAttribute>>,
     registry_group: Option<Rc<VersionedSignal>>,
 }
@@ -120,6 +123,8 @@ impl Advisor for RegoAdvisor {
         let mut findings = self.check(RegoInput {
             sample: sample.clone(),
             registry_attribute,
+            resource: signal.resource(),
+            instrumentation_scope: signal.instrumentation_scope(),
             registry_group,
         })?;
 

--- a/crates/weaver_live_check/src/advice/type_advisor.rs
+++ b/crates/weaver_live_check/src/advice/type_advisor.rs
@@ -714,6 +714,7 @@ mod tests {
             unit: "".to_owned(),
             data_points: None,
             instrument: SampleInstrument::Supported(weaver_semconv::group::InstrumentSpec::Counter),
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -783,6 +784,7 @@ mod tests {
             unit: "".to_owned(),
             data_points: None,
             instrument: SampleInstrument::Supported(weaver_semconv::group::InstrumentSpec::Counter),
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -826,6 +828,7 @@ mod tests {
             unit: "".to_owned(),
             data_points: None,
             instrument: SampleInstrument::Supported(weaver_semconv::group::InstrumentSpec::Counter),
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });

--- a/crates/weaver_live_check/src/generated/attributes.rs
+++ b/crates/weaver_live_check/src/generated/attributes.rs
@@ -173,6 +173,8 @@ pub enum SampleType {
     SpanLink,
     /// A resource describing the telemetry source
     Resource,
+    /// An instrumentation scope that produced telemetry signals
+    InstrumentationScope,
     /// A metric measurement
     Metric,
     /// A numeric data point within a metric

--- a/crates/weaver_live_check/src/lib.rs
+++ b/crates/weaver_live_check/src/lib.rs
@@ -44,6 +44,8 @@ pub mod live_checker;
 pub mod otlp_logger;
 /// The intermediary format for attributes
 pub mod sample_attribute;
+/// An intermediary format for instrumentation scope metadata.
+pub mod sample_instrumentation_scope;
 /// The intermediary format for logs
 pub mod sample_log;
 /// The intermediary format for metrics

--- a/crates/weaver_live_check/src/lib.rs
+++ b/crates/weaver_live_check/src/lib.rs
@@ -8,6 +8,7 @@ use finding_modifier::FindingModifier;
 use live_checker::LiveChecker;
 use miette::Diagnostic;
 use sample_attribute::SampleAttribute;
+use sample_instrumentation_scope::SampleInstrumentationScope;
 use sample_log::SampleLog;
 use sample_metric::{
     SampleExemplar, SampleExponentialHistogramDataPoint, SampleHistogramDataPoint, SampleMetric,
@@ -387,6 +388,17 @@ impl Sample {
             Sample::Span(s) => s.resource.as_deref(),
             Sample::Metric(m) => m.resource.as_deref(),
             Sample::Log(l) => l.resource.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Returns the instrumentation scope that produced the signal, if available.
+    #[must_use]
+    pub fn instrumentation_scope(&self) -> Option<&SampleInstrumentationScope> {
+        match self {
+            Sample::Span(s) => s.instrumentation_scope.as_deref(),
+            Sample::Metric(m) => m.instrumentation_scope.as_deref(),
+            Sample::Log(l) => l.instrumentation_scope.as_deref(),
             _ => None,
         }
     }

--- a/crates/weaver_live_check/src/lib.rs
+++ b/crates/weaver_live_check/src/lib.rs
@@ -291,6 +291,8 @@ pub enum Sample {
     SpanLink(SampleSpanLink),
     /// A sample resource
     Resource(SampleResource),
+    /// An instrumentation scope that produced telemetry signals
+    InstrumentationScope(SampleInstrumentationScope),
     /// A sample metric
     Metric(SampleMetric),
     /// A sample log
@@ -312,6 +314,8 @@ pub enum SampleRef<'a> {
     SpanLink(&'a SampleSpanLink),
     /// A sample resource
     Resource(&'a SampleResource),
+    /// An instrumentation scope that produced telemetry signals
+    InstrumentationScope(&'a SampleInstrumentationScope),
     /// A sample metric
     Metric(&'a SampleMetric),
     /// A sample number data point
@@ -329,15 +333,17 @@ pub enum SampleRef<'a> {
 impl SampleRef<'_> {
     /// Returns the sample name, if available for this sample type.
     ///
-    /// For attributes this is the attribute key, for spans/metrics/events
-    /// it is the signal name. Sub-signal types (data points, exemplars,
-    /// span links, resources) do not carry a name.
+    /// For attributes this is the attribute key, for instrumentation scopes
+    /// it is the scope name, and for spans/metrics/events it is the signal
+    /// name. Sub-signal types (data points, exemplars, span links, resources)
+    /// do not carry a name.
     #[must_use]
     pub fn sample_name(&self) -> Option<&str> {
         match self {
             SampleRef::Attribute(attr) => Some(&attr.name),
             SampleRef::Span(span) => Some(&span.name),
             SampleRef::SpanEvent(event) => Some(&event.name),
+            SampleRef::InstrumentationScope(scope) => Some(&scope.name),
             SampleRef::Metric(metric) => Some(&metric.name),
             SampleRef::Log(log) => Some(&log.event_name),
             _ => None,
@@ -353,6 +359,7 @@ impl SampleRef<'_> {
             SampleRef::SpanEvent(_) => SampleType::SpanEvent,
             SampleRef::SpanLink(_) => SampleType::SpanLink,
             SampleRef::Resource(_) => SampleType::Resource,
+            SampleRef::InstrumentationScope(_) => SampleType::InstrumentationScope,
             SampleRef::Metric(_) => SampleType::Metric,
             SampleRef::NumberDataPoint(_) => SampleType::NumberDataPoint,
             SampleRef::HistogramDataPoint(_) => SampleType::HistogramDataPoint,
@@ -376,6 +383,7 @@ impl Sample {
             Sample::SpanEvent(_) => None,
             Sample::SpanLink(_) => None,
             Sample::Resource(_) => Some(SignalType::Resource.to_string()),
+            Sample::InstrumentationScope(_) => None,
             Sample::Metric(_) => Some(SignalType::Metric.to_string()),
             Sample::Log(_) => Some(SignalType::Log.to_string()),
         }
@@ -413,6 +421,7 @@ impl Sample {
             Sample::SpanEvent(_) => None,
             Sample::SpanLink(_) => None,
             Sample::Resource(_) => None,
+            Sample::InstrumentationScope(_) => None,
             Sample::Metric(metric) => Some(metric.name.clone()),
             Sample::Log(log) => Some(log.event_name.clone()),
         }
@@ -443,6 +452,9 @@ impl LiveCheckRunner for Sample {
             }
             Sample::Resource(resource) => {
                 resource.run_live_check(live_checker, stats, parent_group, parent_signal)
+            }
+            Sample::InstrumentationScope(scope) => {
+                scope.run_live_check(live_checker, stats, parent_group, parent_signal)
             }
             Sample::Metric(metric) => {
                 metric.run_live_check(live_checker, stats, parent_group, parent_signal)

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -190,10 +190,12 @@ mod tests {
     use crate::{
         advice::{DeprecatedAdvisor, EnumAdvisor, RegoAdvisor, StabilityAdvisor, TypeAdvisor},
         sample_attribute::SampleAttribute,
+        sample_instrumentation_scope::SampleInstrumentationScope,
         sample_metric::{
             DataPoints, SampleExemplar, SampleExponentialHistogramDataPoint, SampleInstrument,
             SampleMetric, SampleNumberDataPoint,
         },
+        sample_span::SampleSpan,
         LiveCheckRunner, LiveCheckStatistics, Sample,
     };
 
@@ -1951,6 +1953,7 @@ mod tests {
                     exemplars: vec![],
                 },
             ])),
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -2028,6 +2031,7 @@ mod tests {
                     live_check_result: None,
                 }],
             }])),
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -2078,6 +2082,7 @@ mod tests {
                 instrument: SampleInstrument::Unsupported("Summary".to_owned()),
                 unit: "By".to_owned(),
                 data_points: None,
+                instrumentation_scope: None,
                 live_check_result: None,
                 resource: None,
             }),
@@ -2086,6 +2091,7 @@ mod tests {
                 instrument: SampleInstrument::Unsupported("Unspecified".to_owned()),
                 unit: "By".to_owned(),
                 data_points: None,
+                instrumentation_scope: None,
                 live_check_result: None,
                 resource: None,
             }),
@@ -2418,6 +2424,7 @@ mod tests {
             attributes: vec![],
             trace_id: None,
             span_id: None,
+            instrumentation_scope: None,
             live_check_result: None,
             resource: Some(resource),
         })
@@ -2572,6 +2579,7 @@ mod tests {
             attributes: vec![],
             trace_id: None,
             span_id: None,
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         });
@@ -2610,6 +2618,95 @@ mod tests {
                 .iter()
                 .any(|a| a.id == "entity_conditionally_required_attribute_not_present"),
             "conditionally required entity attribute finding expected even without resource"
+        );
+    }
+
+    #[test]
+    fn test_custom_rego_can_inspect_span_instrumentation_scope() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let policy_path = temp_dir.path().join("scope.rego");
+        let rego_content = r#"
+            package live_check_advice
+
+            import rego.v1
+
+            make_advice(advice_type, advice_level, advice_context, message) := {
+                "type": "advice",
+                "advice_type": advice_type,
+                "advice_level": advice_level,
+                "advice_context": advice_context,
+                "message": message,
+            }
+
+            deny contains make_advice(advice_type, advice_level, advice_context, message) if {
+                input.sample.span.instrumentation_scope.name == "framework"
+                input.sample.span.instrumentation_scope.version == "1.2.3"
+                input.sample.span.instrumentation_scope.schema_url == "https://opentelemetry.io/schemas/1.32.0"
+                input.sample.span.instrumentation_scope.attributes[0].name == "scope.environment"
+                input.sample.span.instrumentation_scope.dropped_attributes_count == 2
+                advice_type := "instrumentation_scope_seen"
+                advice_level := "information"
+                advice_context := {"scope_name": "framework"}
+                message := "Instrumentation scope is policy-visible"
+            }
+        "#;
+        std::fs::write(&policy_path, rego_content).expect("Failed to write custom policy");
+
+        let registry = make_registry(false);
+        let mut live_checker = LiveChecker::new(Arc::new(registry), vec![]);
+        let rego_advisor = RegoAdvisor::new(
+            &live_checker,
+            &Some(temp_dir.path().to_path_buf()),
+            &None,
+            &None,
+        )
+        .expect("Failed to create Rego advisor");
+        live_checker.add_advisor(Box::new(rego_advisor));
+
+        let mut sample = Sample::Span(SampleSpan {
+            name: "operation".to_owned(),
+            kind: SpanKindSpec::Internal,
+            status: None,
+            attributes: vec![],
+            span_events: vec![],
+            span_links: vec![],
+            instrumentation_scope: Some(SampleInstrumentationScope {
+                name: "framework".to_owned(),
+                version: "1.2.3".to_owned(),
+                schema_url: "https://opentelemetry.io/schemas/1.32.0".to_owned(),
+                attributes: vec![SampleAttribute {
+                    name: "scope.environment".to_owned(),
+                    value: Some(json!("test")),
+                    r#type: None,
+                    live_check_result: None,
+                }],
+                dropped_attributes_count: 2,
+            }),
+            live_check_result: None,
+            resource: None,
+        });
+        let mut stats =
+            LiveCheckStatistics::Cumulative(CumulativeStatistics::new(&live_checker.registry));
+
+        sample
+            .run_live_check(&mut live_checker, &mut stats, None, &sample.clone())
+            .expect("live check should not error");
+
+        let advice = match &sample {
+            Sample::Span(span) => {
+                &span
+                    .live_check_result
+                    .as_ref()
+                    .expect("span should contain a live check result")
+                    .all_advice
+            }
+            _ => unreachable!("test constructs a span"),
+        };
+        assert!(
+            advice
+                .iter()
+                .any(|finding| finding.id == "instrumentation_scope_seen"),
+            "expected custom policy to inspect instrumentation scope: {advice:?}"
         );
     }
 
@@ -3101,6 +3198,7 @@ mod tests {
                     exemplars: vec![],
                     live_check_result: None,
                 }])),
+                instrumentation_scope: None,
                 live_check_result: None,
                 resource: Some(resource),
             })

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -2691,6 +2691,7 @@ mod tests {
                     live_check_result: None,
                 }],
                 dropped_attributes_count: 2,
+                live_check_result: None,
             })),
             live_check_result: None,
             resource: Some(Rc::new(SampleResource {

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -195,6 +195,7 @@ mod tests {
             DataPoints, SampleExemplar, SampleExponentialHistogramDataPoint, SampleInstrument,
             SampleMetric, SampleNumberDataPoint,
         },
+        sample_resource::SampleResource,
         sample_span::SampleSpan,
         LiveCheckRunner, LiveCheckStatistics, Sample,
     };
@@ -2639,15 +2640,24 @@ mod tests {
             }
 
             deny contains make_advice(advice_type, advice_level, advice_context, message) if {
-                input.sample.span.instrumentation_scope.name == "framework"
-                input.sample.span.instrumentation_scope.version == "1.2.3"
-                input.sample.span.instrumentation_scope.schema_url == "https://opentelemetry.io/schemas/1.32.0"
-                input.sample.span.instrumentation_scope.attributes[0].name == "scope.environment"
-                input.sample.span.instrumentation_scope.dropped_attributes_count == 2
+                input.instrumentation_scope.name == "framework"
+                input.instrumentation_scope.version == "1.2.3"
+                input.instrumentation_scope.schema_url == "https://opentelemetry.io/schemas/1.32.0"
+                input.instrumentation_scope.attributes[0].name == "scope.environment"
+                input.instrumentation_scope.dropped_attributes_count == 2
+                input.resource != null
                 advice_type := "instrumentation_scope_seen"
                 advice_level := "information"
                 advice_context := {"scope_name": "framework"}
                 message := "Instrumentation scope is policy-visible"
+            }
+
+            deny contains make_advice(advice_type, advice_level, advice_context, message) if {
+                input.instrumentation_scope == null
+                advice_type := "instrumentation_scope_absent"
+                advice_level := "information"
+                advice_context := {"scope_name": null}
+                message := "Missing instrumentation scope is explicitly null"
             }
         "#;
         std::fs::write(&policy_path, rego_content).expect("Failed to write custom policy");
@@ -2670,7 +2680,7 @@ mod tests {
             attributes: vec![],
             span_events: vec![],
             span_links: vec![],
-            instrumentation_scope: Some(SampleInstrumentationScope {
+            instrumentation_scope: Some(Rc::new(SampleInstrumentationScope {
                 name: "framework".to_owned(),
                 version: "1.2.3".to_owned(),
                 schema_url: "https://opentelemetry.io/schemas/1.32.0".to_owned(),
@@ -2681,9 +2691,12 @@ mod tests {
                     live_check_result: None,
                 }],
                 dropped_attributes_count: 2,
-            }),
+            })),
             live_check_result: None,
-            resource: None,
+            resource: Some(Rc::new(SampleResource {
+                attributes: vec![],
+                live_check_result: None,
+            })),
         });
         let mut stats =
             LiveCheckStatistics::Cumulative(CumulativeStatistics::new(&live_checker.registry));
@@ -2707,6 +2720,33 @@ mod tests {
                 .iter()
                 .any(|finding| finding.id == "instrumentation_scope_seen"),
             "expected custom policy to inspect instrumentation scope: {advice:?}"
+        );
+
+        let mut unscoped_sample = sample.clone();
+        match &mut unscoped_sample {
+            Sample::Span(span) => {
+                span.instrumentation_scope = None;
+                span.live_check_result = None;
+            }
+            _ => unreachable!("test constructs a span"),
+        }
+        unscoped_sample
+            .run_live_check(
+                &mut live_checker,
+                &mut stats,
+                None,
+                &unscoped_sample.clone(),
+            )
+            .expect("unscoped live check should not error");
+        let unscoped_advice = match &unscoped_sample {
+            Sample::Span(span) => &span.live_check_result.as_ref().unwrap().all_advice,
+            _ => unreachable!("test constructs a span"),
+        };
+        assert!(
+            unscoped_advice
+                .iter()
+                .any(|finding| finding.id == "instrumentation_scope_absent"),
+            "expected missing scope to be explicitly null for Rego: {unscoped_advice:?}"
         );
     }
 

--- a/crates/weaver_live_check/src/otlp_logger.rs
+++ b/crates/weaver_live_check/src/otlp_logger.rs
@@ -293,6 +293,7 @@ mod tests {
             attributes: vec![],
             span_events: vec![],
             span_links: vec![],
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         }
@@ -305,6 +306,7 @@ mod tests {
             instrument: SampleInstrument::Supported(InstrumentSpec::Gauge),
             unit: "ms".to_owned(),
             data_points: None,
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         }

--- a/crates/weaver_live_check/src/sample_instrumentation_scope.rs
+++ b/crates/weaver_live_check/src/sample_instrumentation_scope.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Intermediary format for instrumentation scope metadata.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::sample_attribute::SampleAttribute;
+
+/// Identifies the instrumentation scope that produced a telemetry signal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SampleInstrumentationScope {
+    /// Instrumentation scope name.
+    #[serde(default)]
+    pub name: String,
+    /// Instrumentation scope version.
+    #[serde(default)]
+    pub version: String,
+    /// Schema URL declared by the OTLP scope container.
+    #[serde(default)]
+    pub schema_url: String,
+    /// Instrumentation scope attributes.
+    #[serde(default)]
+    pub attributes: Vec<SampleAttribute>,
+    /// Number of scope attributes dropped before export.
+    #[serde(default)]
+    pub dropped_attributes_count: u32,
+}

--- a/crates/weaver_live_check/src/sample_instrumentation_scope.rs
+++ b/crates/weaver_live_check/src/sample_instrumentation_scope.rs
@@ -2,10 +2,15 @@
 
 //! Intermediary format for instrumentation scope metadata.
 
+use std::rc::Rc;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::sample_attribute::SampleAttribute;
+use crate::{
+    live_checker::LiveChecker, sample_attribute::SampleAttribute, Advisable, Error,
+    LiveCheckResult, LiveCheckRunner, LiveCheckStatistics, Sample, SampleRef, VersionedSignal,
+};
 
 /// Identifies the instrumentation scope that produced a telemetry signal.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -25,4 +30,31 @@ pub struct SampleInstrumentationScope {
     /// Number of scope attributes dropped before export.
     #[serde(default)]
     pub dropped_attributes_count: u32,
+    /// Live check result.
+    pub live_check_result: Option<LiveCheckResult>,
+}
+
+impl Advisable for SampleInstrumentationScope {
+    fn as_sample_ref(&self) -> SampleRef<'_> {
+        SampleRef::InstrumentationScope(self)
+    }
+
+    fn entity_type(&self) -> &str {
+        "instrumentation_scope"
+    }
+}
+
+impl LiveCheckRunner for SampleInstrumentationScope {
+    fn run_live_check(
+        &mut self,
+        live_checker: &mut LiveChecker,
+        stats: &mut LiveCheckStatistics,
+        parent_group: Option<Rc<VersionedSignal>>,
+        parent_signal: &Sample,
+    ) -> Result<(), Error> {
+        self.live_check_result =
+            Some(self.run_advisors(live_checker, stats, parent_group.clone(), parent_signal)?);
+        self.attributes
+            .run_live_check(live_checker, stats, parent_group, parent_signal)
+    }
 }

--- a/crates/weaver_live_check/src/sample_log.rs
+++ b/crates/weaver_live_check/src/sample_log.rs
@@ -13,6 +13,7 @@ use crate::{
     advice::{check_entity_associations, emit_findings, FindingBuilder},
     live_checker::LiveChecker,
     sample_attribute::SampleAttribute,
+    sample_instrumentation_scope::SampleInstrumentationScope,
     sample_resource::SampleResource,
     Error, FindingId, LiveCheckResult, LiveCheckRunner, LiveCheckStatistics, Sample, SampleRef,
     VersionedSignal,
@@ -36,6 +37,9 @@ pub struct SampleLog {
     pub trace_id: Option<String>,
     /// Span ID if the event is correlated with a span
     pub span_id: Option<String>,
+    /// Instrumentation scope that produced this log record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instrumentation_scope: Option<SampleInstrumentationScope>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
     /// Reference to the parent resource (not serialized)

--- a/crates/weaver_live_check/src/sample_log.rs
+++ b/crates/weaver_live_check/src/sample_log.rs
@@ -37,9 +37,9 @@ pub struct SampleLog {
     pub trace_id: Option<String>,
     /// Span ID if the event is correlated with a span
     pub span_id: Option<String>,
-    /// Instrumentation scope that produced this log record.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub instrumentation_scope: Option<SampleInstrumentationScope>,
+    /// Shared instrumentation scope that produced this log record (not serialized).
+    #[serde(skip)]
+    pub instrumentation_scope: Option<Rc<SampleInstrumentationScope>>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
     /// Reference to the parent resource (not serialized)

--- a/crates/weaver_live_check/src/sample_metric.rs
+++ b/crates/weaver_live_check/src/sample_metric.rs
@@ -15,6 +15,7 @@ use crate::{
     advice::{check_entity_associations, emit_findings, FindingBuilder},
     live_checker::LiveChecker,
     sample_attribute::SampleAttribute,
+    sample_instrumentation_scope::SampleInstrumentationScope,
     sample_resource::SampleResource,
     Advisable, Error, FindingId, LiveCheckResult, LiveCheckRunner, LiveCheckStatistics, Sample,
     SampleRef, VersionedSignal,
@@ -288,6 +289,9 @@ pub struct SampleMetric {
     pub unit: String,
     /// Data points of the metric.
     pub data_points: Option<DataPoints>,
+    /// Instrumentation scope that produced this metric.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instrumentation_scope: Option<SampleInstrumentationScope>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
     /// Reference to the parent resource (not serialized)

--- a/crates/weaver_live_check/src/sample_metric.rs
+++ b/crates/weaver_live_check/src/sample_metric.rs
@@ -289,9 +289,9 @@ pub struct SampleMetric {
     pub unit: String,
     /// Data points of the metric.
     pub data_points: Option<DataPoints>,
-    /// Instrumentation scope that produced this metric.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub instrumentation_scope: Option<SampleInstrumentationScope>,
+    /// Shared instrumentation scope that produced this metric (not serialized).
+    #[serde(skip)]
+    pub instrumentation_scope: Option<Rc<SampleInstrumentationScope>>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
     /// Reference to the parent resource (not serialized)

--- a/crates/weaver_live_check/src/sample_span.rs
+++ b/crates/weaver_live_check/src/sample_span.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 use weaver_semconv::group::SpanKindSpec;
 
 use crate::{
-    live_checker::LiveChecker, sample_attribute::SampleAttribute, sample_resource::SampleResource,
+    live_checker::LiveChecker, sample_attribute::SampleAttribute,
+    sample_instrumentation_scope::SampleInstrumentationScope, sample_resource::SampleResource,
     Advisable, Error, LiveCheckResult, LiveCheckRunner, LiveCheckStatistics, Sample, SampleRef,
     VersionedSignal,
 };
@@ -53,6 +54,9 @@ pub struct SampleSpan {
     /// SpanLinks
     #[serde(default)]
     pub span_links: Vec<SampleSpanLink>,
+    /// Instrumentation scope that produced this span.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instrumentation_scope: Option<SampleInstrumentationScope>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
     /// Reference to the parent resource (not serialized)

--- a/crates/weaver_live_check/src/sample_span.rs
+++ b/crates/weaver_live_check/src/sample_span.rs
@@ -54,9 +54,9 @@ pub struct SampleSpan {
     /// SpanLinks
     #[serde(default)]
     pub span_links: Vec<SampleSpanLink>,
-    /// Instrumentation scope that produced this span.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub instrumentation_scope: Option<SampleInstrumentationScope>,
+    /// Shared instrumentation scope that produced this span (not serialized).
+    #[serde(skip)]
+    pub instrumentation_scope: Option<Rc<SampleInstrumentationScope>>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
     /// Reference to the parent resource (not serialized)

--- a/crates/weaver_live_check/tests/instrumentation_scope.rs
+++ b/crates/weaver_live_check/tests/instrumentation_scope.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compatibility tests for instrumentation scope metadata on live-check signals.
+
+use serde_json::{json, Value};
+use weaver_live_check::{sample_instrumentation_scope::SampleInstrumentationScope, Sample};
+
+fn scope_json(name: &str) -> Value {
+    json!({
+        "name": name,
+        "version": "1.2.3",
+        "schema_url": "https://opentelemetry.io/schemas/1.32.0",
+        "attributes": [{"name": "scope.environment", "value": "test"}],
+        "dropped_attributes_count": 2
+    })
+}
+
+#[test]
+fn legacy_signal_json_without_scope_remains_valid_and_omits_the_field() {
+    let inputs = [
+        json!({"span": {"name": "operation", "kind": "internal"}}),
+        json!({"metric": {"name": "requests", "instrument": "counter", "unit": "1"}}),
+        json!({"log": {"event_name": "request.completed"}}),
+    ];
+
+    for input in inputs {
+        let sample: Sample = serde_json::from_value(input).expect("legacy JSON must deserialize");
+        let output = serde_json::to_value(sample).expect("sample must serialize");
+        let signal = output
+            .as_object()
+            .and_then(|root| root.values().next())
+            .and_then(Value::as_object)
+            .expect("sample must contain one signal object");
+        assert!(!signal.contains_key("instrumentation_scope"));
+    }
+}
+
+#[test]
+fn scope_metadata_round_trips_for_every_signal_type() {
+    let inputs = [
+        json!({"span": {
+            "name": "operation",
+            "kind": "internal",
+            "instrumentation_scope": scope_json("trace-library")
+        }}),
+        json!({"metric": {
+            "name": "requests",
+            "instrument": "counter",
+            "unit": "1",
+            "instrumentation_scope": scope_json("metric-library")
+        }}),
+        json!({"log": {
+            "event_name": "request.completed",
+            "instrumentation_scope": scope_json("log-library")
+        }}),
+    ];
+
+    for input in inputs {
+        let sample: Sample =
+            serde_json::from_value(input.clone()).expect("scoped JSON must deserialize");
+        let scope: &SampleInstrumentationScope = match &sample {
+            Sample::Span(span) => span.instrumentation_scope.as_ref(),
+            Sample::Metric(metric) => metric.instrumentation_scope.as_ref(),
+            Sample::Log(log) => log.instrumentation_scope.as_ref(),
+            _ => unreachable!("test only supplies whole signals"),
+        }
+        .expect("scope metadata must be attached to the signal");
+
+        assert_eq!(scope.version, "1.2.3");
+        assert_eq!(scope.schema_url, "https://opentelemetry.io/schemas/1.32.0");
+        assert_eq!(scope.attributes.len(), 1);
+        assert_eq!(scope.dropped_attributes_count, 2);
+
+        let expected_scope = serde_json::to_value(scope).expect("scope must serialize");
+        let output = serde_json::to_value(sample).expect("sample must serialize");
+        let output_scope = output
+            .as_object()
+            .and_then(|root| root.values().next())
+            .and_then(|signal| signal.get("instrumentation_scope"))
+            .expect("serialized signal must contain scope metadata");
+        assert_eq!(output_scope, &expected_scope);
+    }
+}

--- a/crates/weaver_live_check/tests/instrumentation_scope.rs
+++ b/crates/weaver_live_check/tests/instrumentation_scope.rs
@@ -1,17 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! Compatibility tests for instrumentation scope metadata on live-check signals.
+//! Context-carrier tests for instrumentation scope metadata on live-check signals.
+
+use std::rc::Rc;
 
 use serde_json::{json, Value};
-use weaver_live_check::{sample_instrumentation_scope::SampleInstrumentationScope, Sample};
+use weaver_live_check::{
+    sample_attribute::SampleAttribute, sample_instrumentation_scope::SampleInstrumentationScope,
+    Sample,
+};
 
-fn scope_json(name: &str) -> Value {
-    json!({
-        "name": name,
-        "version": "1.2.3",
-        "schema_url": "https://opentelemetry.io/schemas/1.32.0",
-        "attributes": [{"name": "scope.environment", "value": "test"}],
-        "dropped_attributes_count": 2
+fn scope(name: &str) -> Rc<SampleInstrumentationScope> {
+    Rc::new(SampleInstrumentationScope {
+        name: name.to_owned(),
+        version: "1.2.3".to_owned(),
+        schema_url: "https://opentelemetry.io/schemas/1.32.0".to_owned(),
+        attributes: vec![SampleAttribute {
+            name: "scope.environment".to_owned(),
+            value: Some(json!("test")),
+            r#type: None,
+            live_check_result: None,
+        }],
+        dropped_attributes_count: 2,
     })
 }
 
@@ -36,48 +46,42 @@ fn legacy_signal_json_without_scope_remains_valid_and_omits_the_field() {
 }
 
 #[test]
-fn scope_metadata_round_trips_for_every_signal_type() {
+fn scope_metadata_is_not_serialized_on_every_signal() {
     let inputs = [
-        json!({"span": {
-            "name": "operation",
-            "kind": "internal",
-            "instrumentation_scope": scope_json("trace-library")
-        }}),
-        json!({"metric": {
-            "name": "requests",
-            "instrument": "counter",
-            "unit": "1",
-            "instrumentation_scope": scope_json("metric-library")
-        }}),
-        json!({"log": {
-            "event_name": "request.completed",
-            "instrumentation_scope": scope_json("log-library")
-        }}),
+        (
+            json!({"span": {"name": "operation", "kind": "internal"}}),
+            "trace-library",
+        ),
+        (
+            json!({"metric": {"name": "requests", "instrument": "counter", "unit": "1"}}),
+            "metric-library",
+        ),
+        (
+            json!({"log": {"event_name": "request.completed"}}),
+            "log-library",
+        ),
     ];
 
-    for input in inputs {
-        let sample: Sample =
-            serde_json::from_value(input.clone()).expect("scoped JSON must deserialize");
-        let scope: &SampleInstrumentationScope = match &sample {
-            Sample::Span(span) => span.instrumentation_scope.as_ref(),
-            Sample::Metric(metric) => metric.instrumentation_scope.as_ref(),
-            Sample::Log(log) => log.instrumentation_scope.as_ref(),
+    for (input, scope_name) in inputs {
+        let mut sample: Sample =
+            serde_json::from_value(input).expect("sample JSON must deserialize");
+        let instrumentation_scope = scope(scope_name);
+        match &mut sample {
+            Sample::Span(span) => span.instrumentation_scope = Some(instrumentation_scope),
+            Sample::Metric(metric) => metric.instrumentation_scope = Some(instrumentation_scope),
+            Sample::Log(log) => log.instrumentation_scope = Some(instrumentation_scope),
             _ => unreachable!("test only supplies whole signals"),
         }
-        .expect("scope metadata must be attached to the signal");
 
-        assert_eq!(scope.version, "1.2.3");
-        assert_eq!(scope.schema_url, "https://opentelemetry.io/schemas/1.32.0");
-        assert_eq!(scope.attributes.len(), 1);
-        assert_eq!(scope.dropped_attributes_count, 2);
-
-        let expected_scope = serde_json::to_value(scope).expect("scope must serialize");
         let output = serde_json::to_value(sample).expect("sample must serialize");
-        let output_scope = output
+        let signal = output
             .as_object()
             .and_then(|root| root.values().next())
-            .and_then(|signal| signal.get("instrumentation_scope"))
-            .expect("serialized signal must contain scope metadata");
-        assert_eq!(output_scope, &expected_scope);
+            .and_then(Value::as_object)
+            .expect("sample must contain one signal object");
+        assert!(
+            !signal.contains_key("instrumentation_scope"),
+            "shared scope context must not be repeated in serialized signals: {output}"
+        );
     }
 }

--- a/crates/weaver_live_check/tests/instrumentation_scope.rs
+++ b/crates/weaver_live_check/tests/instrumentation_scope.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use serde_json::{json, Value};
 use weaver_live_check::{
     sample_attribute::SampleAttribute, sample_instrumentation_scope::SampleInstrumentationScope,
-    Sample,
+    Sample, SampleRef, SampleType,
 };
 
 fn scope(name: &str) -> Rc<SampleInstrumentationScope> {
@@ -22,7 +22,32 @@ fn scope(name: &str) -> Rc<SampleInstrumentationScope> {
             live_check_result: None,
         }],
         dropped_attributes_count: 2,
+        live_check_result: None,
     })
+}
+
+#[test]
+fn instrumentation_scope_serializes_as_a_root_sample_carrier() {
+    let instrumentation_scope = scope("library");
+    let sample = Sample::InstrumentationScope((*instrumentation_scope).clone());
+    assert!(
+        sample.instrumentation_scope().is_none(),
+        "the root scope is input.sample context, not its own adjacent signal context"
+    );
+    let value = serde_json::to_value(sample).expect("scope sample serializes");
+
+    assert_eq!(value["instrumentation_scope"]["name"], "library");
+    assert_eq!(
+        value["instrumentation_scope"]["schema_url"],
+        "https://opentelemetry.io/schemas/1.32.0"
+    );
+    assert_eq!(
+        value["instrumentation_scope"]["attributes"][0]["name"],
+        "scope.environment"
+    );
+    let sample_ref = SampleRef::InstrumentationScope(instrumentation_scope.as_ref());
+    assert_eq!(sample_ref.sample_type(), SampleType::InstrumentationScope);
+    assert_eq!(sample_ref.sample_name(), Some("library"));
 }
 
 #[test]
@@ -72,6 +97,13 @@ fn scope_metadata_is_not_serialized_on_every_signal() {
             Sample::Log(log) => log.instrumentation_scope = Some(instrumentation_scope),
             _ => unreachable!("test only supplies whole signals"),
         }
+        assert_eq!(
+            sample
+                .instrumentation_scope()
+                .expect("signal keeps adjacent scope context")
+                .name,
+            scope_name
+        );
 
         let output = serde_json::to_value(sample).expect("sample must serialize");
         let signal = output

--- a/crates/weaver_live_check/tests/livecheck_emit.rs
+++ b/crates/weaver_live_check/tests/livecheck_emit.rs
@@ -207,6 +207,7 @@ async fn test_livecheck_emit_roundtrip() {
             attributes: vec![],
             span_events: vec![],
             span_links: vec![],
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         };
@@ -230,6 +231,7 @@ async fn test_livecheck_emit_roundtrip() {
             instrument: SampleInstrument::Supported(InstrumentSpec::Histogram),
             unit: "s".to_owned(),
             data_points: None,
+            instrumentation_scope: None,
             live_check_result: None,
             resource: None,
         };
@@ -310,6 +312,7 @@ async fn test_livecheck_emit_roundtrip() {
             attributes: vec![],
             span_events: vec![],
             span_links: vec![],
+            instrumentation_scope: None,
             live_check_result: None,
             resource: Some(Rc::new(resource)),
         };
@@ -345,6 +348,7 @@ async fn test_livecheck_emit_roundtrip() {
             attributes: vec![],
             trace_id: None,
             span_id: None,
+            instrumentation_scope: None,
             live_check_result: None,
             resource: Some(Rc::new(resource)),
         };

--- a/crates/weaver_mcp/src/service.rs
+++ b/crates/weaver_mcp/src/service.rs
@@ -185,6 +185,18 @@ fn collect_compact_findings(samples: &[Sample]) -> Vec<serde_json::Value> {
                     out.push(json!({"type": "resource", "attribute_findings": parts}));
                 }
             }
+            Sample::InstrumentationScope(scope) => {
+                let findings = extract_findings(&scope.live_check_result);
+                let attr_findings = extract_attr_findings(&scope.attributes);
+                if !findings.is_empty() || !attr_findings.is_empty() {
+                    out.push(json!({
+                        "name": scope.name,
+                        "type": "instrumentation_scope",
+                        "findings": findings,
+                        "attribute_findings": attr_findings,
+                    }));
+                }
+            }
             Sample::Metric(m) => {
                 let findings = extract_findings(&m.live_check_result);
                 if !findings.is_empty() {

--- a/defaults/live_check_templates/ansi/live_check_macros.j2
+++ b/defaults/live_check_templates/ansi/live_check_macros.j2
@@ -78,6 +78,19 @@
 {%- endfor %}
 {% endmacro %}
 
+{% macro display_instrumentation_scope(scope, indent=0) %}
+{{ " " * indent }}{{ ("Instrumentation scope") | ansi_bright_cyan | ansi_bold }} {{ scope.name }}{% if scope.version %} `{{ scope.version }}`{% endif %}
+{% if scope.schema_url %}
+{{ " " * indent }}  schema URL: {{ scope.schema_url }}
+{% endif %}
+{% if scope.dropped_attributes_count %}
+{{ " " * indent }}  dropped attributes: {{ scope.dropped_attributes_count }}
+{% endif %}
+{%- for attribute in scope.attributes %}
+{{ " " * (indent + 4) }}- {{ attribute.name }}{% if attribute.value %} = {{ attribute.value }}{% endif %}
+{%- endfor %}
+{% endmacro %}
+
 {% macro summarize_data_point_value(data_point) %}
 {%- if data_point.value is defined -%}
 {{ data_point.value }}
@@ -105,17 +118,23 @@ count={{ data_point.count }}, sum={{ data_point.sum }}, min={{ data_point.min }}
 {%- endfor %}
 {% endmacro %}
 
-{% macro display_metric(metric, indent=0) %}
+{% macro display_metric(metric, instrumentation_scope, indent=0) %}
 {{ " " * indent }}{{ ("Metric") | ansi_bright_cyan | ansi_bold }} {{ display_sample_header(metric.live_check_result.highest_advice_level, metric.name) }} `{{ metric.instrument }}`, `{{ metric.unit }}`
 {{ display_advice(metric.live_check_result.all_advice, indent) }}
+{% if instrumentation_scope %}
+{{ display_instrumentation_scope(instrumentation_scope, indent + 4) }}
+{%- endif %}
 {%- for data_point in metric.data_points %}
 {{ display_data_point(data_point, indent + 4) }}
 {%- endfor %}
 {%- endmacro %}
 
-{% macro display_log(log, indent=0) %}
+{% macro display_log(log, instrumentation_scope, indent=0) %}
 {{ " " * indent }}{% if log.event_name %}{{ ("Log Event") | ansi_bright_cyan | ansi_bold }}{% else %}{{ ("Log") | ansi_bright_cyan | ansi_bold }}{% endif %} {{ display_sample_header(log.live_check_result.highest_advice_level, log.event_name) }}
 {{ display_advice(log.live_check_result.all_advice, indent) }}
+{% if instrumentation_scope %}
+{{ display_instrumentation_scope(instrumentation_scope, indent + 4) }}
+{%- endif %}
 {%- for attribute in log.attributes %}
 {{ display_attribute(attribute, indent + 4) }}
 {%- endfor %}
@@ -125,6 +144,9 @@ count={{ data_point.count }}, sum={{ data_point.sum }}, min={{ data_point.min }}
 {%- if sample.span is defined -%}
 {{ " " * indent }}{{ ("Span") | ansi_bright_cyan | ansi_bold }} {{ display_sample_header(sample.span.live_check_result.highest_advice_level, sample.span.name) }} `{{ sample.span.kind }}`
 {{ display_advice(sample.span.live_check_result.all_advice, indent) }}
+{% if sample.instrumentation_scope %}
+{{ display_instrumentation_scope(sample.instrumentation_scope, indent + 4) }}
+{%- endif %}
 {%- for attribute in sample.span.attributes %}
 {{ display_attribute(attribute, indent + 4) }}
 {%- endfor %}
@@ -143,9 +165,9 @@ count={{ data_point.count }}, sum={{ data_point.sum }}, min={{ data_point.min }}
 {%- elif sample.resource is defined -%}
 {{ display_resource(sample.resource, indent) }}
 {%- elif sample.metric is defined -%}
-{{ display_metric(sample.metric, indent) }}
+{{ display_metric(sample.metric, sample.instrumentation_scope, indent) }}
 {%- elif sample.log is defined -%}
-{{ display_log(sample.log, indent) }}
+{{ display_log(sample.log, sample.instrumentation_scope, indent) }}
 {%- endif -%}
 {%- endmacro -%}
 

--- a/defaults/live_check_templates/ansi/live_check_macros.j2
+++ b/defaults/live_check_templates/ansi/live_check_macros.j2
@@ -80,6 +80,7 @@
 
 {% macro display_instrumentation_scope(scope, indent=0) %}
 {{ " " * indent }}{{ ("Instrumentation scope") | ansi_bright_cyan | ansi_bold }} {{ scope.name }}{% if scope.version %} `{{ scope.version }}`{% endif %}
+{{ display_advice(scope.live_check_result.all_advice, indent) }}
 {% if scope.schema_url %}
 {{ " " * indent }}  schema URL: {{ scope.schema_url }}
 {% endif %}
@@ -87,7 +88,7 @@
 {{ " " * indent }}  dropped attributes: {{ scope.dropped_attributes_count }}
 {% endif %}
 {%- for attribute in scope.attributes %}
-{{ " " * (indent + 4) }}- {{ attribute.name }}{% if attribute.value %} = {{ attribute.value }}{% endif %}
+{{ display_attribute(attribute, indent + 4) }}
 {%- endfor %}
 {% endmacro %}
 
@@ -118,23 +119,17 @@ count={{ data_point.count }}, sum={{ data_point.sum }}, min={{ data_point.min }}
 {%- endfor %}
 {% endmacro %}
 
-{% macro display_metric(metric, instrumentation_scope, indent=0) %}
+{% macro display_metric(metric, indent=0) %}
 {{ " " * indent }}{{ ("Metric") | ansi_bright_cyan | ansi_bold }} {{ display_sample_header(metric.live_check_result.highest_advice_level, metric.name) }} `{{ metric.instrument }}`, `{{ metric.unit }}`
 {{ display_advice(metric.live_check_result.all_advice, indent) }}
-{% if instrumentation_scope %}
-{{ display_instrumentation_scope(instrumentation_scope, indent + 4) }}
-{%- endif %}
 {%- for data_point in metric.data_points %}
 {{ display_data_point(data_point, indent + 4) }}
 {%- endfor %}
 {%- endmacro %}
 
-{% macro display_log(log, instrumentation_scope, indent=0) %}
+{% macro display_log(log, indent=0) %}
 {{ " " * indent }}{% if log.event_name %}{{ ("Log Event") | ansi_bright_cyan | ansi_bold }}{% else %}{{ ("Log") | ansi_bright_cyan | ansi_bold }}{% endif %} {{ display_sample_header(log.live_check_result.highest_advice_level, log.event_name) }}
 {{ display_advice(log.live_check_result.all_advice, indent) }}
-{% if instrumentation_scope %}
-{{ display_instrumentation_scope(instrumentation_scope, indent + 4) }}
-{%- endif %}
 {%- for attribute in log.attributes %}
 {{ display_attribute(attribute, indent + 4) }}
 {%- endfor %}
@@ -144,9 +139,6 @@ count={{ data_point.count }}, sum={{ data_point.sum }}, min={{ data_point.min }}
 {%- if sample.span is defined -%}
 {{ " " * indent }}{{ ("Span") | ansi_bright_cyan | ansi_bold }} {{ display_sample_header(sample.span.live_check_result.highest_advice_level, sample.span.name) }} `{{ sample.span.kind }}`
 {{ display_advice(sample.span.live_check_result.all_advice, indent) }}
-{% if sample.instrumentation_scope %}
-{{ display_instrumentation_scope(sample.instrumentation_scope, indent + 4) }}
-{%- endif %}
 {%- for attribute in sample.span.attributes %}
 {{ display_attribute(attribute, indent + 4) }}
 {%- endfor %}
@@ -164,10 +156,12 @@ count={{ data_point.count }}, sum={{ data_point.sum }}, min={{ data_point.min }}
 {{ display_span_link(sample.span_link, indent) }}
 {%- elif sample.resource is defined -%}
 {{ display_resource(sample.resource, indent) }}
+{%- elif sample.instrumentation_scope is defined -%}
+{{ display_instrumentation_scope(sample.instrumentation_scope, indent) }}
 {%- elif sample.metric is defined -%}
-{{ display_metric(sample.metric, sample.instrumentation_scope, indent) }}
+{{ display_metric(sample.metric, indent) }}
 {%- elif sample.log is defined -%}
-{{ display_log(sample.log, sample.instrumentation_scope, indent) }}
+{{ display_log(sample.log, indent) }}
 {%- endif -%}
 {%- endmacro -%}
 

--- a/defaults/live_check_templates/ansi/live_check_macros.j2
+++ b/defaults/live_check_templates/ansi/live_check_macros.j2
@@ -79,7 +79,7 @@
 {% endmacro %}
 
 {% macro display_instrumentation_scope(scope, indent=0) %}
-{{ " " * indent }}{{ ("Instrumentation scope") | ansi_bright_cyan | ansi_bold }} {{ scope.name }}{% if scope.version %} `{{ scope.version }}`{% endif %}
+{{ " " * indent }}{{ ("Instrumentation scope") | ansi_bright_cyan | ansi_bold }} {{ display_sample_header(scope.live_check_result.highest_advice_level, scope.name) }}{% if scope.version %} `{{ scope.version }}`{% endif %}
 {{ display_advice(scope.live_check_result.all_advice, indent) }}
 {% if scope.schema_url %}
 {{ " " * indent }}  schema URL: {{ scope.schema_url }}

--- a/src/registry/infer.rs
+++ b/src/registry/infer.rs
@@ -121,6 +121,7 @@ fn process_otlp_request(request: OtlpRequest, accumulator: &mut AccumulatedSampl
                             attributes: Vec::new(),
                             span_events: Vec::new(),
                             span_links: Vec::new(),
+                            instrumentation_scope: None,
                             live_check_result: None,
                             resource: None,
                         };

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -546,7 +546,10 @@ mod tests {
             1,
             "{rendered}"
         );
-        assert!(rendered.contains("scope-name"), "{rendered}");
+        assert!(
+            rendered.contains("\x1b[92mscope-name\x1b[0m"),
+            "scope name should use the finding-level sample header colour: {rendered}"
+        );
         assert!(rendered.contains("1.2.3"), "{rendered}");
         assert!(
             rendered.contains("https://example.test/schema"),

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -11,7 +11,6 @@ use clap::Args;
 use include_dir::{include_dir, Dir};
 
 use log::info;
-use serde::Serialize;
 use weaver_common::diagnostic::DiagnosticMessages;
 use weaver_common::http_auth::HttpAuthResolver;
 use weaver_common::{log_success, log_warn};
@@ -27,9 +26,8 @@ use weaver_live_check::live_checker::LiveChecker;
 use weaver_live_check::text_file_ingester::TextFileIngester;
 use weaver_live_check::text_stdin_ingester::TextStdinIngester;
 use weaver_live_check::{
-    sample_instrumentation_scope::SampleInstrumentationScope, sample_resource::SampleResource,
-    CumulativeStatistics, DisabledStatistics, Error, Ingester, LiveCheckReport, LiveCheckRunner,
-    LiveCheckStatistics, Sample, VersionedRegistry,
+    sample_resource::SampleResource, CumulativeStatistics, DisabledStatistics, Error, Ingester,
+    LiveCheckReport, LiveCheckRunner, LiveCheckStatistics, Sample, VersionedRegistry,
 };
 use weaver_macros::weaver_command;
 
@@ -206,55 +204,7 @@ fn default_advisors() -> Vec<Box<dyn Advisor>> {
     ]
 }
 
-/// Template-only view that keeps shared signal context adjacent to the sample.
-#[derive(Serialize)]
-struct TemplateSample<'a> {
-    #[serde(flatten)]
-    sample: &'a Sample,
-    instrumentation_scope: Option<&'a SampleInstrumentationScope>,
-}
-
-impl<'a> From<&'a Sample> for TemplateSample<'a> {
-    fn from(sample: &'a Sample) -> Self {
-        Self {
-            sample,
-            instrumentation_scope: sample.instrumentation_scope(),
-        }
-    }
-}
-
-/// Template-only report view for the standard text renderer.
-#[derive(Serialize)]
-struct TemplateLiveCheckReport<'a> {
-    statistics: &'a LiveCheckStatistics,
-    samples: Vec<TemplateSample<'a>>,
-}
-
-impl<'a> TemplateLiveCheckReport<'a> {
-    fn new(samples: &'a [Sample], statistics: &'a LiveCheckStatistics) -> Self {
-        Self {
-            statistics,
-            samples: samples.iter().map(TemplateSample::from).collect(),
-        }
-    }
-}
-
-fn uses_template_context(output: &OutputProcessor) -> bool {
-    output.content_type() == "text/plain"
-}
-
-fn generate_sample(
-    output: &mut OutputProcessor,
-    sample: &Sample,
-) -> Result<(), weaver_forge::error::Error> {
-    if uses_template_context(output) {
-        output.generate(&TemplateSample::from(sample))
-    } else {
-        output.generate(sample)
-    }
-}
-
-/// Generate output for a complete report - handles line-oriented special case.
+/// Generate output for a complete report - handles line-oriented special case
 fn generate_report(
     output: &mut OutputProcessor,
     samples: Vec<Sample>,
@@ -269,8 +219,6 @@ fn generate_report(
             LiveCheckStatistics::Cumulative(_) => output.generate(&stats),
             LiveCheckStatistics::Disabled(_) => Ok(()),
         }
-    } else if uses_template_context(output) {
-        output.generate(&TemplateLiveCheckReport::new(&samples, &stats))
     } else {
         let report = LiveCheckReport {
             statistics: stats,
@@ -458,7 +406,7 @@ pub(crate) fn command(
             samples.push(sample);
         } else {
             // Output this sample immediately (streaming mode)
-            generate_sample(&mut output, &sample).map_err(DiagnosticMessages::from)?;
+            output.generate(&sample).map_err(DiagnosticMessages::from)?;
         }
     }
 
@@ -501,10 +449,6 @@ pub(crate) fn command(
                     LiveCheckStatistics::Disabled(_) => {}
                 }
                 lines.join("\n")
-            } else if uses_template_context(&output) {
-                output
-                    .generate_to_string(&TemplateLiveCheckReport::new(&samples, &stats))
-                    .map_err(DiagnosticMessages::from)?
             } else {
                 let report = LiveCheckReport {
                     statistics: stats,
@@ -553,8 +497,6 @@ pub(crate) fn command(
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
     use serde_json::json;
     use weaver_forge::{OutputProcessor, OutputTarget};
     use weaver_live_check::{
@@ -562,7 +504,7 @@ mod tests {
         sample_instrumentation_scope::SampleInstrumentationScope, LiveCheckResult, Sample,
     };
 
-    use super::{RegistryLiveCheckArgs, TemplateSample, DEFAULT_LIVE_CHECK_TEMPLATES};
+    use super::{RegistryLiveCheckArgs, DEFAULT_LIVE_CHECK_TEMPLATES};
     use crate::registry::tests::assert_config_cli_consistency;
 
     #[test]
@@ -571,12 +513,7 @@ mod tests {
     }
 
     #[test]
-    fn ansi_output_displays_shared_instrumentation_scope() {
-        let inputs = [
-            json!({"span": {"name": "operation", "kind": "internal"}}),
-            json!({"metric": {"name": "requests", "instrument": "counter", "unit": "1"}}),
-            json!({"log": {"event_name": "request.completed"}}),
-        ];
+    fn ansi_output_displays_instrumentation_scope_through_the_normal_sample_path() {
         let output = OutputProcessor::new(
             "ansi",
             "live_check",
@@ -586,53 +523,35 @@ mod tests {
         )
         .expect("ANSI output processor should load");
 
-        for input in inputs {
-            let mut sample: Sample =
-                serde_json::from_value(input).expect("signal sample should deserialize");
-            let instrumentation_scope = Rc::new(SampleInstrumentationScope {
-                name: "scope-name".to_owned(),
-                version: "1.2.3".to_owned(),
-                schema_url: "https://example.test/schema".to_owned(),
-                attributes: vec![SampleAttribute {
-                    name: "scope.environment".to_owned(),
-                    value: Some(json!("test")),
-                    r#type: None,
-                    live_check_result: None,
-                }],
-                dropped_attributes_count: 2,
-            });
-            match &mut sample {
-                Sample::Span(span) => {
-                    span.instrumentation_scope = Some(Rc::clone(&instrumentation_scope));
-                    span.live_check_result = Some(LiveCheckResult::new());
-                }
-                Sample::Metric(metric) => {
-                    metric.instrumentation_scope = Some(Rc::clone(&instrumentation_scope));
-                    metric.live_check_result = Some(LiveCheckResult::new());
-                }
-                Sample::Log(log) => {
-                    log.instrumentation_scope = Some(Rc::clone(&instrumentation_scope));
-                    log.live_check_result = Some(LiveCheckResult::new());
-                }
-                _ => unreachable!("test only supplies whole signals"),
-            }
+        let sample = Sample::InstrumentationScope(SampleInstrumentationScope {
+            name: "scope-name".to_owned(),
+            version: "1.2.3".to_owned(),
+            schema_url: "https://example.test/schema".to_owned(),
+            attributes: vec![SampleAttribute {
+                name: "scope.environment".to_owned(),
+                value: Some(json!("test")),
+                r#type: None,
+                live_check_result: Some(LiveCheckResult::new()),
+            }],
+            dropped_attributes_count: 2,
+            live_check_result: Some(LiveCheckResult::new()),
+        });
 
-            let rendered = output
-                .generate_to_string(&TemplateSample::from(&sample))
-                .expect("ANSI sample should render");
+        let rendered = output
+            .generate_to_string(&sample)
+            .expect("ANSI sample should render");
 
-            assert_eq!(
-                rendered.matches("Instrumentation scope").count(),
-                1,
-                "{rendered}"
-            );
-            assert!(rendered.contains("scope-name"), "{rendered}");
-            assert!(rendered.contains("1.2.3"), "{rendered}");
-            assert!(
-                rendered.contains("https://example.test/schema"),
-                "{rendered}"
-            );
-            assert!(rendered.contains("scope.environment"), "{rendered}");
-        }
+        assert_eq!(
+            rendered.matches("Instrumentation scope").count(),
+            1,
+            "{rendered}"
+        );
+        assert!(rendered.contains("scope-name"), "{rendered}");
+        assert!(rendered.contains("1.2.3"), "{rendered}");
+        assert!(
+            rendered.contains("https://example.test/schema"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("scope.environment"), "{rendered}");
     }
 }

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -11,6 +11,7 @@ use clap::Args;
 use include_dir::{include_dir, Dir};
 
 use log::info;
+use serde::Serialize;
 use weaver_common::diagnostic::DiagnosticMessages;
 use weaver_common::http_auth::HttpAuthResolver;
 use weaver_common::{log_success, log_warn};
@@ -26,8 +27,9 @@ use weaver_live_check::live_checker::LiveChecker;
 use weaver_live_check::text_file_ingester::TextFileIngester;
 use weaver_live_check::text_stdin_ingester::TextStdinIngester;
 use weaver_live_check::{
-    sample_resource::SampleResource, CumulativeStatistics, DisabledStatistics, Error, Ingester,
-    LiveCheckReport, LiveCheckRunner, LiveCheckStatistics, Sample, VersionedRegistry,
+    sample_instrumentation_scope::SampleInstrumentationScope, sample_resource::SampleResource,
+    CumulativeStatistics, DisabledStatistics, Error, Ingester, LiveCheckReport, LiveCheckRunner,
+    LiveCheckStatistics, Sample, VersionedRegistry,
 };
 use weaver_macros::weaver_command;
 
@@ -204,7 +206,55 @@ fn default_advisors() -> Vec<Box<dyn Advisor>> {
     ]
 }
 
-/// Generate output for a complete report - handles line-oriented special case
+/// Template-only view that keeps shared signal context adjacent to the sample.
+#[derive(Serialize)]
+struct TemplateSample<'a> {
+    #[serde(flatten)]
+    sample: &'a Sample,
+    instrumentation_scope: Option<&'a SampleInstrumentationScope>,
+}
+
+impl<'a> From<&'a Sample> for TemplateSample<'a> {
+    fn from(sample: &'a Sample) -> Self {
+        Self {
+            sample,
+            instrumentation_scope: sample.instrumentation_scope(),
+        }
+    }
+}
+
+/// Template-only report view for the standard text renderer.
+#[derive(Serialize)]
+struct TemplateLiveCheckReport<'a> {
+    statistics: &'a LiveCheckStatistics,
+    samples: Vec<TemplateSample<'a>>,
+}
+
+impl<'a> TemplateLiveCheckReport<'a> {
+    fn new(samples: &'a [Sample], statistics: &'a LiveCheckStatistics) -> Self {
+        Self {
+            statistics,
+            samples: samples.iter().map(TemplateSample::from).collect(),
+        }
+    }
+}
+
+fn uses_template_context(output: &OutputProcessor) -> bool {
+    output.content_type() == "text/plain"
+}
+
+fn generate_sample(
+    output: &mut OutputProcessor,
+    sample: &Sample,
+) -> Result<(), weaver_forge::error::Error> {
+    if uses_template_context(output) {
+        output.generate(&TemplateSample::from(sample))
+    } else {
+        output.generate(sample)
+    }
+}
+
+/// Generate output for a complete report - handles line-oriented special case.
 fn generate_report(
     output: &mut OutputProcessor,
     samples: Vec<Sample>,
@@ -219,6 +269,8 @@ fn generate_report(
             LiveCheckStatistics::Cumulative(_) => output.generate(&stats),
             LiveCheckStatistics::Disabled(_) => Ok(()),
         }
+    } else if uses_template_context(output) {
+        output.generate(&TemplateLiveCheckReport::new(&samples, &stats))
     } else {
         let report = LiveCheckReport {
             statistics: stats,
@@ -406,7 +458,7 @@ pub(crate) fn command(
             samples.push(sample);
         } else {
             // Output this sample immediately (streaming mode)
-            output.generate(&sample).map_err(DiagnosticMessages::from)?;
+            generate_sample(&mut output, &sample).map_err(DiagnosticMessages::from)?;
         }
     }
 
@@ -449,6 +501,10 @@ pub(crate) fn command(
                     LiveCheckStatistics::Disabled(_) => {}
                 }
                 lines.join("\n")
+            } else if uses_template_context(&output) {
+                output
+                    .generate_to_string(&TemplateLiveCheckReport::new(&samples, &stats))
+                    .map_err(DiagnosticMessages::from)?
             } else {
                 let report = LiveCheckReport {
                     statistics: stats,
@@ -497,11 +553,86 @@ pub(crate) fn command(
 
 #[cfg(test)]
 mod tests {
-    use super::RegistryLiveCheckArgs;
+    use std::rc::Rc;
+
+    use serde_json::json;
+    use weaver_forge::{OutputProcessor, OutputTarget};
+    use weaver_live_check::{
+        sample_attribute::SampleAttribute,
+        sample_instrumentation_scope::SampleInstrumentationScope, LiveCheckResult, Sample,
+    };
+
+    use super::{RegistryLiveCheckArgs, TemplateSample, DEFAULT_LIVE_CHECK_TEMPLATES};
     use crate::registry::tests::assert_config_cli_consistency;
 
     #[test]
     fn config_fields_match_cli_args() {
         assert_config_cli_consistency::<RegistryLiveCheckArgs>();
+    }
+
+    #[test]
+    fn ansi_output_displays_shared_instrumentation_scope() {
+        let inputs = [
+            json!({"span": {"name": "operation", "kind": "internal"}}),
+            json!({"metric": {"name": "requests", "instrument": "counter", "unit": "1"}}),
+            json!({"log": {"event_name": "request.completed"}}),
+        ];
+        let output = OutputProcessor::new(
+            "ansi",
+            "live_check",
+            Some(&DEFAULT_LIVE_CHECK_TEMPLATES),
+            None,
+            OutputTarget::Stdout,
+        )
+        .expect("ANSI output processor should load");
+
+        for input in inputs {
+            let mut sample: Sample =
+                serde_json::from_value(input).expect("signal sample should deserialize");
+            let instrumentation_scope = Rc::new(SampleInstrumentationScope {
+                name: "scope-name".to_owned(),
+                version: "1.2.3".to_owned(),
+                schema_url: "https://example.test/schema".to_owned(),
+                attributes: vec![SampleAttribute {
+                    name: "scope.environment".to_owned(),
+                    value: Some(json!("test")),
+                    r#type: None,
+                    live_check_result: None,
+                }],
+                dropped_attributes_count: 2,
+            });
+            match &mut sample {
+                Sample::Span(span) => {
+                    span.instrumentation_scope = Some(Rc::clone(&instrumentation_scope));
+                    span.live_check_result = Some(LiveCheckResult::new());
+                }
+                Sample::Metric(metric) => {
+                    metric.instrumentation_scope = Some(Rc::clone(&instrumentation_scope));
+                    metric.live_check_result = Some(LiveCheckResult::new());
+                }
+                Sample::Log(log) => {
+                    log.instrumentation_scope = Some(Rc::clone(&instrumentation_scope));
+                    log.live_check_result = Some(LiveCheckResult::new());
+                }
+                _ => unreachable!("test only supplies whole signals"),
+            }
+
+            let rendered = output
+                .generate_to_string(&TemplateSample::from(&sample))
+                .expect("ANSI sample should render");
+
+            assert_eq!(
+                rendered.matches("Instrumentation scope").count(),
+                1,
+                "{rendered}"
+            );
+            assert!(rendered.contains("scope-name"), "{rendered}");
+            assert!(rendered.contains("1.2.3"), "{rendered}");
+            assert!(
+                rendered.contains("https://example.test/schema"),
+                "{rendered}"
+            );
+            assert!(rendered.contains("scope.environment"), "{rendered}");
+        }
     }
 }

--- a/src/registry/otlp/conversion.rs
+++ b/src/registry/otlp/conversion.rs
@@ -6,6 +6,7 @@ use chrono::{TimeZone, Utc};
 use serde_json::{json, Value};
 use weaver_live_check::{
     sample_attribute::SampleAttribute,
+    sample_instrumentation_scope::SampleInstrumentationScope,
     sample_log::SampleLog,
     sample_metric::{DataPoints, SampleInstrument, SampleMetric},
     sample_span::{Status, StatusCode},
@@ -14,11 +15,39 @@ use weaver_semconv::group::{InstrumentSpec, SpanKindSpec};
 
 use super::grpc_stubs::proto::trace::v1::status::StatusCode as OtlpStatusCode;
 use super::grpc_stubs::proto::{
-    common::v1::{AnyValue, KeyValue},
+    common::v1::{AnyValue, InstrumentationScope, KeyValue},
     logs::v1::LogRecord,
     metrics::v1::{metric::Data, HistogramDataPoint, Metric, NumberDataPoint},
     trace::v1::span::SpanKind,
 };
+
+/// Converts OTLP instrumentation scope metadata and its containing schema URL.
+///
+/// A missing scope with an empty schema URL carries no ownership metadata and
+/// remains absent. A non-empty schema URL is preserved even when the OTLP scope
+/// message itself is missing.
+pub fn otlp_instrumentation_scope_to_sample(
+    scope: Option<&InstrumentationScope>,
+    schema_url: &str,
+) -> Option<SampleInstrumentationScope> {
+    if scope.is_none() && schema_url.is_empty() {
+        return None;
+    }
+
+    Some(SampleInstrumentationScope {
+        name: scope.map_or_else(String::new, |scope| scope.name.clone()),
+        version: scope.map_or_else(String::new, |scope| scope.version.clone()),
+        schema_url: schema_url.to_owned(),
+        attributes: scope.map_or_else(Vec::new, |scope| {
+            scope
+                .attributes
+                .iter()
+                .map(sample_attribute_from_key_value)
+                .collect()
+        }),
+        dropped_attributes_count: scope.map_or(0, |scope| scope.dropped_attributes_count),
+    })
+}
 
 fn maybe_to_json(value: Option<AnyValue>) -> Option<Value> {
     if let Some(value) = value {
@@ -99,6 +128,7 @@ pub fn otlp_metric_to_sample(otlp_metric: Metric) -> SampleMetric {
         instrument: otlp_data_to_instrument(&otlp_metric.data),
         unit: otlp_metric.unit,
         data_points: otlp_data_to_data_points(&otlp_metric.data),
+        instrumentation_scope: None,
         live_check_result: None,
         resource: None,
     }
@@ -356,6 +386,7 @@ pub fn otlp_log_record_to_sample_log(log_record: &LogRecord) -> SampleLog {
                 Some(span_id)
             }
         },
+        instrumentation_scope: None,
         live_check_result: None,
         resource: None,
     }

--- a/src/registry/otlp/conversion.rs
+++ b/src/registry/otlp/conversion.rs
@@ -46,6 +46,7 @@ pub fn otlp_instrumentation_scope_to_sample(
                 .collect()
         }),
         dropped_attributes_count: scope.map_or(0, |scope| scope.dropped_attributes_count),
+        live_check_result: None,
     })
 }
 

--- a/src/registry/otlp/otlp_ingester.rs
+++ b/src/registry/otlp/otlp_ingester.rs
@@ -14,8 +14,8 @@ use weaver_live_check::{
 
 use super::{
     conversion::{
-        otlp_log_record_to_sample_log, otlp_metric_to_sample, sample_attribute_from_key_value,
-        span_kind_from_otlp_kind, status_from_otlp_status,
+        otlp_instrumentation_scope_to_sample, otlp_log_record_to_sample_log, otlp_metric_to_sample,
+        sample_attribute_from_key_value, span_kind_from_otlp_kind, status_from_otlp_status,
     },
     listen_otlp_requests, OtlpRequest, ShutdownCoordinator,
 };
@@ -68,16 +68,21 @@ impl OtlpIterator {
                     };
 
                     for scope_log in resource_log.scope_logs {
-                        if let Some(scope) = scope_log.scope {
-                            for attribute in scope.attributes {
+                        let instrumentation_scope = otlp_instrumentation_scope_to_sample(
+                            scope_log.scope.as_ref(),
+                            &scope_log.schema_url,
+                        );
+                        if let Some(scope) = scope_log.scope.as_ref() {
+                            for attribute in &scope.attributes {
                                 self.buffer.push(Sample::Attribute(
-                                    sample_attribute_from_key_value(&attribute),
+                                    sample_attribute_from_key_value(attribute),
                                 ));
                             }
                         }
 
                         for log_record in scope_log.log_records {
                             let mut sample_log = otlp_log_record_to_sample_log(&log_record);
+                            sample_log.instrumentation_scope = instrumentation_scope.clone();
                             sample_log.resource = rc_resource.clone();
                             self.buffer.push(Sample::Log(sample_log));
                         }
@@ -105,17 +110,21 @@ impl OtlpIterator {
                     };
 
                     for scope_metric in resource_metric.scope_metrics {
-                        if let Some(scope) = scope_metric.scope {
-                            // TODO SampleInstrumentationScope?
-                            for attribute in scope.attributes {
+                        let instrumentation_scope = otlp_instrumentation_scope_to_sample(
+                            scope_metric.scope.as_ref(),
+                            &scope_metric.schema_url,
+                        );
+                        if let Some(scope) = scope_metric.scope.as_ref() {
+                            for attribute in &scope.attributes {
                                 self.buffer.push(Sample::Attribute(
-                                    sample_attribute_from_key_value(&attribute),
+                                    sample_attribute_from_key_value(attribute),
                                 ));
                             }
                         }
 
                         for metric in scope_metric.metrics {
                             let mut sample_metric = otlp_metric_to_sample(metric);
+                            sample_metric.instrumentation_scope = instrumentation_scope.clone();
                             sample_metric.resource = rc_resource.clone();
                             self.buffer.push(Sample::Metric(sample_metric));
                         }
@@ -143,11 +152,14 @@ impl OtlpIterator {
                     };
 
                     for scope_span in resource_span.scope_spans {
-                        if let Some(scope) = scope_span.scope {
-                            // TODO SampleInstrumentationScope?
-                            for attribute in scope.attributes {
+                        let instrumentation_scope = otlp_instrumentation_scope_to_sample(
+                            scope_span.scope.as_ref(),
+                            &scope_span.schema_url,
+                        );
+                        if let Some(scope) = scope_span.scope.as_ref() {
+                            for attribute in &scope.attributes {
                                 self.buffer.push(Sample::Attribute(
-                                    sample_attribute_from_key_value(&attribute),
+                                    sample_attribute_from_key_value(attribute),
                                 ));
                             }
                         }
@@ -161,6 +173,7 @@ impl OtlpIterator {
                                 attributes: Vec::new(),
                                 span_events: Vec::new(),
                                 span_links: Vec::new(),
+                                instrumentation_scope: instrumentation_scope.clone(),
                                 live_check_result: None,
                                 resource: rc_resource.clone(),
                             };
@@ -272,5 +285,240 @@ impl Ingester for OtlpIngester {
     fn ingest(&self) -> Result<Box<dyn Iterator<Item = Sample>>, Error> {
         let (iterator, _coordinator) = self.ingest_otlp()?;
         Ok(iterator)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::otlp::grpc_stubs::proto::{
+        collector::{
+            logs::v1::ExportLogsServiceRequest, metrics::v1::ExportMetricsServiceRequest,
+            trace::v1::ExportTraceServiceRequest,
+        },
+        common::v1::{any_value, AnyValue, InstrumentationScope, KeyValue},
+        logs::v1::{LogRecord, ResourceLogs, ScopeLogs},
+        metrics::v1::{Metric, ResourceMetrics, ScopeMetrics},
+        resource::v1::Resource,
+        trace::v1::{ResourceSpans, ScopeSpans, Span},
+    };
+
+    fn string_attribute(name: &str, value: &str) -> KeyValue {
+        KeyValue {
+            key: name.to_owned(),
+            value: Some(AnyValue {
+                value: Some(any_value::Value::StringValue(value.to_owned())),
+            }),
+        }
+    }
+
+    fn scope(name: &str) -> InstrumentationScope {
+        InstrumentationScope {
+            name: name.to_owned(),
+            version: "1.2.3".to_owned(),
+            attributes: vec![string_attribute("scope.environment", "test")],
+            dropped_attributes_count: 2,
+        }
+    }
+
+    fn collect(requests: Vec<OtlpRequest>) -> Vec<Sample> {
+        OtlpIterator::new(Box::new(requests.into_iter())).collect()
+    }
+
+    #[test]
+    fn same_named_spans_keep_distinct_instrumentation_scopes() {
+        let request = OtlpRequest::Traces(ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![
+                    ScopeSpans {
+                        scope: Some(scope("library-a")),
+                        spans: vec![Span {
+                            name: "shared-operation".to_owned(),
+                            ..Default::default()
+                        }],
+                        schema_url: "https://example.test/schema/a".to_owned(),
+                    },
+                    ScopeSpans {
+                        scope: Some(scope("library-b")),
+                        spans: vec![Span {
+                            name: "shared-operation".to_owned(),
+                            ..Default::default()
+                        }],
+                        schema_url: "https://example.test/schema/b".to_owned(),
+                    },
+                ],
+                ..Default::default()
+            }],
+        });
+
+        let scopes: Vec<_> = collect(vec![request])
+            .into_iter()
+            .filter_map(|sample| match sample {
+                Sample::Span(span) => span.instrumentation_scope,
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(scopes.len(), 2);
+        assert_eq!(scopes[0].name, "library-a");
+        assert_eq!(scopes[0].schema_url, "https://example.test/schema/a");
+        assert_eq!(scopes[1].name, "library-b");
+        assert_eq!(scopes[1].schema_url, "https://example.test/schema/b");
+    }
+
+    #[test]
+    fn instrumentation_scope_reaches_spans_metrics_and_logs() {
+        let requests = vec![
+            OtlpRequest::Traces(ExportTraceServiceRequest {
+                resource_spans: vec![ResourceSpans {
+                    scope_spans: vec![ScopeSpans {
+                        scope: Some(scope("trace-library")),
+                        spans: vec![Span {
+                            name: "operation".to_owned(),
+                            ..Default::default()
+                        }],
+                        schema_url: "https://example.test/trace".to_owned(),
+                    }],
+                    ..Default::default()
+                }],
+            }),
+            OtlpRequest::Metrics(ExportMetricsServiceRequest {
+                resource_metrics: vec![ResourceMetrics {
+                    scope_metrics: vec![ScopeMetrics {
+                        scope: Some(scope("metric-library")),
+                        metrics: vec![Metric {
+                            name: "requests".to_owned(),
+                            ..Default::default()
+                        }],
+                        schema_url: "https://example.test/metric".to_owned(),
+                    }],
+                    ..Default::default()
+                }],
+            }),
+            OtlpRequest::Logs(ExportLogsServiceRequest {
+                resource_logs: vec![ResourceLogs {
+                    scope_logs: vec![ScopeLogs {
+                        scope: Some(scope("log-library")),
+                        log_records: vec![LogRecord {
+                            event_name: "request.completed".to_owned(),
+                            ..Default::default()
+                        }],
+                        schema_url: "https://example.test/log".to_owned(),
+                    }],
+                    ..Default::default()
+                }],
+            }),
+        ];
+
+        let samples = collect(requests);
+        let span_scope = samples.iter().find_map(|sample| match sample {
+            Sample::Span(span) => span.instrumentation_scope.as_ref(),
+            _ => None,
+        });
+        let metric_scope = samples.iter().find_map(|sample| match sample {
+            Sample::Metric(metric) => metric.instrumentation_scope.as_ref(),
+            _ => None,
+        });
+        let log_scope = samples.iter().find_map(|sample| match sample {
+            Sample::Log(log) => log.instrumentation_scope.as_ref(),
+            _ => None,
+        });
+
+        assert_eq!(span_scope.expect("span scope").name, "trace-library");
+        assert_eq!(metric_scope.expect("metric scope").name, "metric-library");
+        assert_eq!(log_scope.expect("log scope").name, "log-library");
+    }
+
+    #[test]
+    fn missing_scope_stays_absent_but_schema_only_scope_is_preserved() {
+        let request = OtlpRequest::Traces(ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![
+                    ScopeSpans {
+                        scope: None,
+                        spans: vec![Span {
+                            name: "unknown-owner".to_owned(),
+                            ..Default::default()
+                        }],
+                        schema_url: String::new(),
+                    },
+                    ScopeSpans {
+                        scope: None,
+                        spans: vec![Span {
+                            name: "schema-owned".to_owned(),
+                            ..Default::default()
+                        }],
+                        schema_url: "https://example.test/schema-only".to_owned(),
+                    },
+                ],
+                ..Default::default()
+            }],
+        });
+
+        let spans: Vec<_> = collect(vec![request])
+            .into_iter()
+            .filter_map(|sample| match sample {
+                Sample::Span(span) => Some(span),
+                _ => None,
+            })
+            .collect();
+
+        assert!(spans[0].instrumentation_scope.is_none());
+        let schema_only = spans[1]
+            .instrumentation_scope
+            .as_ref()
+            .expect("schema URL is ownership metadata even when scope is absent");
+        assert_eq!(schema_only.name, "");
+        assert_eq!(schema_only.schema_url, "https://example.test/schema-only");
+    }
+
+    #[test]
+    fn scope_attributes_are_attached_and_emitted_for_checking_exactly_once() {
+        let request = OtlpRequest::Traces(ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![string_attribute("service.name", "checkout")],
+                    ..Default::default()
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: Some(scope("trace-library")),
+                    spans: vec![Span {
+                        name: "operation".to_owned(),
+                        ..Default::default()
+                    }],
+                    schema_url: "https://example.test/trace".to_owned(),
+                }],
+                ..Default::default()
+            }],
+        });
+
+        let samples = collect(vec![request]);
+        let checked_scope_attributes = samples
+            .iter()
+            .filter(|sample| {
+                matches!(sample, Sample::Attribute(attribute) if attribute.name == "scope.environment")
+            })
+            .count();
+        assert_eq!(checked_scope_attributes, 1);
+
+        let span = samples
+            .iter()
+            .find_map(|sample| match sample {
+                Sample::Span(span) => Some(span),
+                _ => None,
+            })
+            .expect("span sample");
+        assert_eq!(
+            span.resource.as_ref().expect("resource").attributes[0].name,
+            "service.name"
+        );
+        assert_eq!(
+            span.instrumentation_scope
+                .as_ref()
+                .expect("scope")
+                .attributes[0]
+                .name,
+            "scope.environment"
+        );
     }
 }

--- a/src/registry/otlp/otlp_ingester.rs
+++ b/src/registry/otlp/otlp_ingester.rs
@@ -73,12 +73,9 @@ impl OtlpIterator {
                             &scope_log.schema_url,
                         )
                         .map(Rc::new);
-                        if let Some(scope) = scope_log.scope.as_ref() {
-                            for attribute in &scope.attributes {
-                                self.buffer.push(Sample::Attribute(
-                                    sample_attribute_from_key_value(attribute),
-                                ));
-                            }
+                        if let Some(scope) = &instrumentation_scope {
+                            self.buffer
+                                .push(Sample::InstrumentationScope((**scope).clone()));
                         }
 
                         for log_record in scope_log.log_records {
@@ -116,12 +113,9 @@ impl OtlpIterator {
                             &scope_metric.schema_url,
                         )
                         .map(Rc::new);
-                        if let Some(scope) = scope_metric.scope.as_ref() {
-                            for attribute in &scope.attributes {
-                                self.buffer.push(Sample::Attribute(
-                                    sample_attribute_from_key_value(attribute),
-                                ));
-                            }
+                        if let Some(scope) = &instrumentation_scope {
+                            self.buffer
+                                .push(Sample::InstrumentationScope((**scope).clone()));
                         }
 
                         for metric in scope_metric.metrics {
@@ -159,12 +153,9 @@ impl OtlpIterator {
                             &scope_span.schema_url,
                         )
                         .map(Rc::new);
-                        if let Some(scope) = scope_span.scope.as_ref() {
-                            for attribute in &scope.attributes {
-                                self.buffer.push(Sample::Attribute(
-                                    sample_attribute_from_key_value(attribute),
-                                ));
-                            }
+                        if let Some(scope) = &instrumentation_scope {
+                            self.buffer
+                                .push(Sample::InstrumentationScope((**scope).clone()));
                         }
 
                         for span in scope_span.spans {
@@ -463,10 +454,21 @@ mod tests {
             Sample::Log(log) => log.instrumentation_scope.as_ref(),
             _ => None,
         });
+        let emitted_scope_names: Vec<_> = samples
+            .iter()
+            .filter_map(|sample| match sample {
+                Sample::InstrumentationScope(scope) => Some(scope.name.as_str()),
+                _ => None,
+            })
+            .collect();
 
         assert_eq!(span_scope.expect("span scope").name, "trace-library");
         assert_eq!(metric_scope.expect("metric scope").name, "metric-library");
         assert_eq!(log_scope.expect("log scope").name, "log-library");
+        assert_eq!(
+            emitted_scope_names,
+            ["trace-library", "metric-library", "log-library"]
+        );
     }
 
     #[test]
@@ -495,10 +497,18 @@ mod tests {
             }],
         });
 
-        let spans: Vec<_> = collect(vec![request])
-            .into_iter()
+        let samples = collect(vec![request]);
+        let spans: Vec<_> = samples
+            .iter()
             .filter_map(|sample| match sample {
                 Sample::Span(span) => Some(span),
+                _ => None,
+            })
+            .collect();
+        let emitted_scopes: Vec<_> = samples
+            .iter()
+            .filter_map(|sample| match sample {
+                Sample::InstrumentationScope(scope) => Some(scope),
                 _ => None,
             })
             .collect();
@@ -510,10 +520,15 @@ mod tests {
             .expect("schema URL is ownership metadata even when scope is absent");
         assert_eq!(schema_only.name, "");
         assert_eq!(schema_only.schema_url, "https://example.test/schema-only");
+        assert_eq!(emitted_scopes.len(), 1);
+        assert_eq!(
+            emitted_scopes[0].schema_url,
+            "https://example.test/schema-only"
+        );
     }
 
     #[test]
-    fn scope_attributes_are_attached_and_emitted_for_checking_exactly_once() {
+    fn instrumentation_scope_is_emitted_once_and_attached_to_its_signal() {
         let request = OtlpRequest::Traces(ExportTraceServiceRequest {
             resource_spans: vec![ResourceSpans {
                 resource: Some(Resource {
@@ -533,13 +548,39 @@ mod tests {
         });
 
         let samples = collect(vec![request]);
-        let checked_scope_attributes = samples
+        let emitted_scopes: Vec<_> = samples
             .iter()
-            .filter(|sample| {
-                matches!(sample, Sample::Attribute(attribute) if attribute.name == "scope.environment")
+            .filter_map(|sample| {
+                let value = serde_json::to_value(sample).expect("sample serializes");
+                value.get("instrumentation_scope").cloned()
             })
-            .count();
-        assert_eq!(checked_scope_attributes, 1);
+            .collect();
+        assert_eq!(emitted_scopes.len(), 1);
+        assert_eq!(emitted_scopes[0]["name"], "trace-library");
+        assert_eq!(
+            emitted_scopes[0]["attributes"][0]["name"],
+            "scope.environment"
+        );
+        assert!(
+            samples.iter().all(
+                |sample| !matches!(sample, Sample::Attribute(attribute) if attribute.name == "scope.environment")
+            ),
+            "scope attributes should be grouped under the scope sample"
+        );
+        let resource_position = samples
+            .iter()
+            .position(|sample| matches!(sample, Sample::Resource(_)))
+            .expect("resource sample");
+        let scope_position = samples
+            .iter()
+            .position(|sample| matches!(sample, Sample::InstrumentationScope(_)))
+            .expect("instrumentation scope sample");
+        let span_position = samples
+            .iter()
+            .position(|sample| matches!(sample, Sample::Span(_)))
+            .expect("span sample");
+        assert!(resource_position < scope_position);
+        assert!(scope_position < span_position);
 
         let span = samples
             .iter()

--- a/src/registry/otlp/otlp_ingester.rs
+++ b/src/registry/otlp/otlp_ingester.rs
@@ -71,7 +71,8 @@ impl OtlpIterator {
                         let instrumentation_scope = otlp_instrumentation_scope_to_sample(
                             scope_log.scope.as_ref(),
                             &scope_log.schema_url,
-                        );
+                        )
+                        .map(Rc::new);
                         if let Some(scope) = scope_log.scope.as_ref() {
                             for attribute in &scope.attributes {
                                 self.buffer.push(Sample::Attribute(
@@ -113,7 +114,8 @@ impl OtlpIterator {
                         let instrumentation_scope = otlp_instrumentation_scope_to_sample(
                             scope_metric.scope.as_ref(),
                             &scope_metric.schema_url,
-                        );
+                        )
+                        .map(Rc::new);
                         if let Some(scope) = scope_metric.scope.as_ref() {
                             for attribute in &scope.attributes {
                                 self.buffer.push(Sample::Attribute(
@@ -155,7 +157,8 @@ impl OtlpIterator {
                         let instrumentation_scope = otlp_instrumentation_scope_to_sample(
                             scope_span.scope.as_ref(),
                             &scope_span.schema_url,
-                        );
+                        )
+                        .map(Rc::new);
                         if let Some(scope) = scope_span.scope.as_ref() {
                             for attribute in &scope.attributes {
                                 self.buffer.push(Sample::Attribute(
@@ -364,6 +367,43 @@ mod tests {
         assert_eq!(scopes[0].schema_url, "https://example.test/schema/a");
         assert_eq!(scopes[1].name, "library-b");
         assert_eq!(scopes[1].schema_url, "https://example.test/schema/b");
+    }
+
+    #[test]
+    fn spans_from_the_same_otlp_scope_share_context() {
+        let request = OtlpRequest::Traces(ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![ScopeSpans {
+                    scope: Some(scope("shared-library")),
+                    spans: vec![
+                        Span {
+                            name: "first-operation".to_owned(),
+                            ..Default::default()
+                        },
+                        Span {
+                            name: "second-operation".to_owned(),
+                            ..Default::default()
+                        },
+                    ],
+                    schema_url: "https://example.test/schema".to_owned(),
+                }],
+                ..Default::default()
+            }],
+        });
+
+        let scopes: Vec<_> = collect(vec![request])
+            .into_iter()
+            .filter_map(|sample| match sample {
+                Sample::Span(span) => span.instrumentation_scope,
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(scopes.len(), 2);
+        assert!(
+            Rc::ptr_eq(&scopes[0], &scopes[1]),
+            "signals in one OTLP scope must reuse the same context allocation"
+        );
     }
 
     #[test]

--- a/tests/registry_emit.rs
+++ b/tests/registry_emit.rs
@@ -129,9 +129,11 @@ fn run_emit_with_live_check_test(use_v2: bool) {
         .as_f64()
         .expect("Failed to get registry_coverage as f64");
 
-    assert_eq!(no_advice_count, 59);
+    // The emitted traces, metrics, and logs each add one instrumentation-scope
+    // carrier, and all three complete without advice.
+    assert_eq!(no_advice_count, 62);
     assert_eq!(total_advisories, 14);
-    assert_eq!(total_entities, 73);
+    assert_eq!(total_entities, 76);
     assert!(registry_coverage > 0.7);
 
     // The temporary directory will be automatically cleaned up when temp_dir goes out of scope


### PR DESCRIPTION
## Summary

- preserve OTLP instrumentation-scope name, version, schema URL, attributes, and dropped-attribute count on live-check span, metric, and log samples through one shared `Rc`
- emit each instrumentation scope once as a normal root `Sample::InstrumentationScope`, ordered after its resource and before its child signals
- expose both `resource` and `instrumentation_scope` beside `sample` to custom Rego policies, while keeping the shared context out of each signal's serialized shape
- render instrumentation scope through the ordinary output/template path and document the custom-advisor input contract

## Why

Live-check currently loses the instrumentation scope that owns a signal. That makes same-named operations from different libraries indistinguishable and prevents custom policies from inspecting the scope schema URL or other scope metadata.

The OTLP container already supplies this information. This change preserves the ownership context without flattening it into resource metadata or repeating it on every signal. The root scope sample gives output and validation one normal carrier, matching the existing resource pattern.

## Compatibility

- legacy signal JSON without `instrumentation_scope` remains valid and retains its serialized shape
- shared resource and instrumentation-scope context remains skipped on individual signal serialization
- a missing scope plus an empty schema URL remains absent
- a schema URL is preserved and emitted once even when the OTLP scope message is absent
- scope attributes are validated exactly once under the root scope sample instead of being emitted as separate root attribute samples
- resource and instrumentation scope remain distinct; no positional scope association is added to JSON input

## Validation

Focused tests cover:

- one root scope carrier per OTLP scope, ordered `Resource -> InstrumentationScope -> signals`
- shared `Rc` identity for signals in one scope
- span, metric, and log propagation
- true absence versus schema-URL-only scope
- grouped scope-attribute validation without standalone duplication
- ordinary-path ANSI rendering
- root-versus-adjacent Rego context and scoped/unscoped `null` behavior
- legacy signal JSON compatibility

Local source gates on commit `721aaad`:

- Rust formatting check
- Cargo workspace metadata resolution
- YAML parse
- Git diff hygiene
- independent source/contract review

Fresh local Rust linking is unavailable in this Windows environment because the MSVC `link.exe`/import-library toolchain is not installed. GitHub Actions on the pushed commit are therefore the executable cross-platform gate.

## Review scope

This PR intentionally covers spans, metrics, and logs together because all three use the same OTLP resource/scope container semantics. The latest refactor follows review feedback by modeling scope as a normal sample carrier rather than adding output-specific template context.

Refs #1360