### PR TITLE
Fix broken Main Commands links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,17 +102,17 @@ Further reading:
 
 ## Main Commands
 
-| Command                                                                   | Description                                                                                               |
-| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| [weaver registry check](docs/usage.md#registry-check)                     | Validates a semantic convention registry                                                                  |
-| [weaver registry resolve](docs/usage.md#registry-resolve)                 | Resolves a semantic convention registry                                                                   |
-| [weaver registry diff](docs/usage.md#registry-diff)                       | Generate a diff between two versions of a semantic convention registry                                    |
-| [weaver registry generate](docs/usage.md#registry-generate)               | Generates artifacts from a semantic convention registry                                                   |
-| [weaver registry update-markdown](docs/usage.md#registry-update-markdown) | Update markdown files that contain markers indicating the templates used to update the specified sections |
-| [weaver registry live-check](docs/usage.md#registry-live-check)           | Check the conformance level of an OTLP stream against a semantic convention registry                      |
-| [weaver registry emit](docs/usage.md#registry-emit)                       | Emits a semantic convention registry as example signals to your OTLP receiver                             |
-| [weaver registry mcp](docs/mcp-server.md)                                 | Run an MCP server for LLM integration                                                                     |
-| [weaver completion](docs/usage.md#completion)                             | Generate shell completions                                                                                |
+| Command                                                                          | Description                                                                                               |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [weaver registry check](docs/usage.md#weaver-registry-check)                     | Validates a semantic convention registry                                                                  |
+| [weaver registry resolve](docs/usage.md#weaver-registry-resolve)                 | Resolves a semantic convention registry                                                                   |
+| [weaver registry diff](docs/usage.md#weaver-registry-diff)                       | Generate a diff between two versions of a semantic convention registry                                    |
+| [weaver registry generate](docs/usage.md#weaver-registry-generate)               | Generates artifacts from a semantic convention registry                                                   |
+| [weaver registry update-markdown](docs/usage.md#weaver-registry-update-markdown) | Update markdown files that contain markers indicating the templates used to update the specified sections |
+| [weaver registry live-check](docs/usage.md#weaver-registry-live-check)           | Check the conformance level of an OTLP stream against a semantic convention registry                      |
+| [weaver registry emit](docs/usage.md#weaver-registry-emit)                       | Emits a semantic convention registry as example signals to your OTLP receiver                             |
+| [weaver registry mcp](docs/usage.md#weaver-registry-mcp)                         | Run an MCP server for LLM integration                                                                     |
+| [weaver completion](docs/usage.md#weaver-completion)                             | Generate shell completions                                                                                |
 
 ## Getting Help
 


### PR DESCRIPTION
## Summary
- The README Main Commands table linked `weaver registry mcp` to `docs/mcp-server.md`, which does not exist
- The other command links used short anchors (`#registry-check`, etc.) that also do not match `docs/usage.md`
- Point every table link at the matching TOC heading ID (`#weaver-registry-check`, …, `#weaver-completion`)

## Test plan
- [ ] Open the README on GitHub and click each Main Commands link
- [ ] Confirm each lands on the matching section in `docs/usage.md`