### PR TITLE
Live-check: Add sample_name scoping to finding filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Live-check: (Fixes: [#1613](https://github.com/open-telemetry/weaver/issues/1613)) add `sample_names` to `[[live-check.finding_filters]]` to scope a filter to matching sample names, with glob wildcard support (also added to `exclude_samples`). ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @jerbly)
+- Live-check: (Fixes: [#1613](https://github.com/open-telemetry/weaver/issues/1613)) add `sample_names` to `[[live-check.finding_filters]]` to scope a filter to matching sample names, with glob wildcard support (also added to `exclude_samples`). ([#1619](https://github.com/open-telemetry/weaver/pull/1619) by @jerbly)
 - Add a tree view to the `serve` UI's search page, grouping results by namespace with expand/collapse controls, and a "Hide deprecated" toggle (on by default) for both the list and tree views. ([#1595](https://github.com/open-telemetry/weaver/pull/1595) by @jerbly)
 - Support signal refinements over a published dependency. ([#1587](https://github.com/open-telemetry/weaver/pull/1587) by @lmolkova)
 - 💥 BREAKING CHANGE 💥 Preserve per-attribute `requirement_level` on attribute refs of public attribute groups in the v2 resolved and materialized schemas. Each entry in an attribute group's `attributes` is now an object (`{ base, requirement_level }`) instead of a bare `attribute_catalog` index. ([#1584](https://github.com/open-telemetry/weaver/pull/1584) by @lmolkova)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Live-check: (Fixes: [#1613](https://github.com/open-telemetry/weaver/issues/1613)) add `sample_names` to `[[live-check.finding_filters]]` to scope a filter to matching sample names, with glob wildcard support (also added to `exclude_samples`). ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @jerbly)
 - Add a tree view to the `serve` UI's search page, grouping results by namespace with expand/collapse controls, and a "Hide deprecated" toggle (on by default) for both the list and tree views. ([#1595](https://github.com/open-telemetry/weaver/pull/1595) by @jerbly)
 - Support signal refinements over a published dependency. ([#1587](https://github.com/open-telemetry/weaver/pull/1587) by @lmolkova)
 - 💥 BREAKING CHANGE 💥 Preserve per-attribute `requirement_level` on attribute refs of public attribute groups in the v2 resolved and materialized schemas. Each entry in an attribute group's `attributes` is now an object (`{ base, requirement_level }`) instead of a bare `attribute_catalog` index. ([#1584](https://github.com/open-telemetry/weaver/pull/1584) by @lmolkova)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6393,6 +6393,7 @@ name = "weaver_live_check"
 version = "0.24.2"
 dependencies = [
  "assert_cmd",
+ "globset",
  "log",
  "miette",
  "opentelemetry",

--- a/crates/weaver_config/src/live_check.rs
+++ b/crates/weaver_config/src/live_check.rs
@@ -198,7 +198,8 @@ impl Default for LiveCheckEmitConfig {
 }
 
 /// A filter that drops findings by ID exclusion or minimum level.
-/// Optional `signal_type` scopes the filter to a specific signal type.
+/// Optional `signal_type` and `sample_names` scope the filter to a specific
+/// signal type and/or set of sample names.
 #[derive(Debug, Clone, Deserialize, PartialEq, JsonSchema)]
 pub struct FindingFilter {
     /// Drop findings with these IDs.
@@ -208,12 +209,18 @@ pub struct FindingFilter {
     /// Optional signal type scope. When set, this filter only applies to
     /// findings with a matching signal_type.
     pub signal_type: Option<String>,
-    /// Drop all findings for samples with these names.
+    /// Drop all findings for samples with these names (supports glob
+    /// wildcards, e.g. `"trace.*"`).
     /// For attribute samples, this matches the attribute key — e.g.
     /// `["trace.parent_id", "trace.span_id"]` suppresses all findings
     /// (e.g. `missing_attribute`) for those attribute keys.
     #[serde(default)]
     pub exclude_samples: Vec<String>,
+    /// Optional sample name scope (supports glob wildcards, e.g. `"http.*"`).
+    /// When set, this filter only applies to samples whose name matches one
+    /// of these patterns, in addition to any `signal_type` scope.
+    #[serde(default)]
+    pub sample_names: Vec<String>,
 }
 
 #[cfg(test)]
@@ -394,6 +401,50 @@ min_level = "violation"
         let config: WeaverConfig = toml::from_str(toml).expect("Failed to parse TOML");
         let lc = live_check(&config);
         assert!(lc.finding_filters[0].exclude_samples.is_empty());
+    }
+
+    #[test]
+    fn test_parse_sample_names() {
+        let toml = r#"
+[["live-check".finding_filters]]
+exclude = ["illegal_namespace"]
+sample_names = ["server.address", "server.port", "http.*"]
+
+[["live-check".finding_filters]]
+signal_type = "span"
+sample_names = ["custom.internal_id"]
+exclude = ["not_stable"]
+"#;
+        let config: WeaverConfig = toml::from_str(toml).expect("Failed to parse TOML");
+        let lc = live_check(&config);
+        assert_eq!(lc.finding_filters.len(), 2);
+
+        let f0 = &lc.finding_filters[0];
+        assert!(f0.signal_type.is_none());
+        assert_eq!(
+            f0.exclude.as_deref(),
+            Some(&["illegal_namespace".to_owned()][..])
+        );
+        assert_eq!(
+            f0.sample_names,
+            vec!["server.address", "server.port", "http.*"]
+        );
+
+        let f1 = &lc.finding_filters[1];
+        assert_eq!(f1.signal_type.as_deref(), Some("span"));
+        assert_eq!(f1.exclude.as_deref(), Some(&["not_stable".to_owned()][..]));
+        assert_eq!(f1.sample_names, vec!["custom.internal_id"]);
+    }
+
+    #[test]
+    fn test_parse_sample_names_defaults_to_empty() {
+        let toml = r#"
+[["live-check".finding_filters]]
+min_level = "violation"
+"#;
+        let config: WeaverConfig = toml::from_str(toml).expect("Failed to parse TOML");
+        let lc = live_check(&config);
+        assert!(lc.finding_filters[0].sample_names.is_empty());
     }
 
     #[test]

--- a/crates/weaver_live_check/Cargo.toml
+++ b/crates/weaver_live_check/Cargo.toml
@@ -28,6 +28,7 @@ opentelemetry-otlp.workspace = true
 opentelemetry-stdout.workspace = true
 tokio.workspace = true
 strum = { version = "0.27.2", features = ["derive"] }
+globset.workspace = true
 
 [dev-dependencies]
 weaver_test_support = { path = "../weaver_test_support" }

--- a/crates/weaver_live_check/README.md
+++ b/crates/weaver_live_check/README.md
@@ -202,7 +202,7 @@ Every key is optional: omit anything you want to leave at its default (or set on
 
 ### Finding filters
 
-Filters drop findings entirely. Use `exclude` to drop by ID, `min_level` to drop findings below a threshold, and `exclude_samples` to drop all findings for specific sample names. A filter without `signal_type` applies globally; one with `signal_type` applies only to that signal type.
+Filters drop findings entirely. Use `exclude` to drop by ID, `min_level` to drop findings below a threshold, and `exclude_samples` to drop all findings for specific sample names. A filter without `signal_type` applies globally; one with `signal_type` applies only to that signal type. `sample_names` further scopes a filter — like `signal_type`, but by sample name. Both `exclude_samples` and `sample_names` support glob wildcards (e.g. `"http.*"`).
 
 ```toml
 # Drop deprecated and missing_namespace findings, and anything below improvement
@@ -215,12 +215,18 @@ min_level = "improvement"
 signal_type = "span"
 exclude = ["not_stable"]
 
-# Suppress all findings for these attribute names
+# Suppress all findings for these attribute names (wildcards supported)
 [[live_check.finding_filters]]
 exclude_samples = ["trace.parent_id", "trace.span_id", "trace.trace_id"]
+
+# Drop illegal_namespace only for these specific attributes — the same
+# advice on any other attribute still surfaces as a finding
+[[live_check.finding_filters]]
+exclude = ["illegal_namespace"]
+sample_names = ["server.address", "server.port", "client.address", "client.port"]
 ```
 
-The `exclude_samples` filter matches by sample name: attribute key for attributes, span name for spans, metric name for metrics, event name for logs, and span event name for span events. It can be combined with other filter fields, for example scoping to a specific `signal_type`.
+The `exclude_samples` and `sample_names` fields match by sample name: attribute key for attributes, span name for spans, metric name for metrics, event name for logs, and span event name for span events. They can be combined with other filter fields, for example scoping to a specific `signal_type`.
 
 ## Output
 
@@ -436,24 +442,25 @@ advice_data = "schemas/**/*.json"
 Files are nested under `data` using their relative path inside the glob pattern base directory. Other file extensions are ignored.
 
 For example, if you run:
+
 ```sh
 weaver registry live-check --advice-data "schemas/**/*.json"
 ```
 
 And you have the file `schemas/user.json` with the following content:
+
 ```json
 {
-  "allowed_ids": [
-    "usr_123",
-    "usr_456"
-  ]
+  "allowed_ids": ["usr_123", "usr_456"]
 }
 ```
 
 It will be parsed and loaded into the OPA engine under the `data.user` path:
-* `data.user.allowed_ids` => `["usr_123", "usr_456"]`
+
+- `data.user.allowed_ids` => `["usr_123", "usr_456"]`
 
 You can then write a Rego rule to check whether the incoming telemetry attribute matches one of the allowed IDs:
+
 ```rego
 package live_check_advice
 
@@ -462,10 +469,10 @@ import rego.v1
 deny contains make_advice(advice_type, advice_level, advice_context, message) if {
     attr := input.sample.attribute
     attr.name == "user.id"
-    
+
     # Check if the incoming attribute value is not in the allowed list
     not attr.value in data.user.allowed_ids
-    
+
     advice_type := "invalid_user_id"
     advice_level := "violation"
     advice_context := {
@@ -476,5 +483,3 @@ deny contains make_advice(advice_type, advice_level, advice_context, message) if
     message := sprintf("User ID '%s' is not in the allowed list: %v", [attr.value, data.user.allowed_ids])
 }
 ```
-
-

--- a/crates/weaver_live_check/src/finding_modifier.rs
+++ b/crates/weaver_live_check/src/finding_modifier.rs
@@ -5,7 +5,8 @@
 //! Applies filters (ID exclusions, min-level, sample-name exclusions) to
 //! findings at creation time — before they are stored in `LiveCheckResult`.
 
-use crate::SampleRef;
+use crate::{Error, SampleRef};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use weaver_checker::PolicyFinding;
 use weaver_config::{FindingFilter, LiveCheckConfig};
 
@@ -13,34 +14,87 @@ use weaver_config::{FindingFilter, LiveCheckConfig};
 ///
 /// Used inline during `add_advice()` to drop findings before they are stored,
 /// avoiding collect-then-filter overhead.
+#[derive(Debug)]
 pub struct FindingModifier {
-    filters: Vec<FindingFilter>,
+    filters: Vec<CompiledFilter>,
 }
 
-/// Check whether a scope matches a finding's signal_type.
-/// A `None` scope matches all findings (global).
-fn scope_matches(scope: Option<&String>, signal_type: Option<&String>) -> bool {
-    scope.map_or(true, |s| signal_type == Some(s))
+/// A `FindingFilter` with its glob patterns precompiled once at construction
+/// time, so matching a finding never recompiles a pattern.
+#[derive(Debug)]
+struct CompiledFilter {
+    filter: FindingFilter,
+    /// Compiled `filter.sample_names` (scope), if non-empty.
+    sample_names_matcher: Option<GlobSet>,
+    /// Compiled `filter.exclude_samples` (exclusion condition), if non-empty.
+    exclude_samples_matcher: Option<GlobSet>,
+}
+
+/// Compile a list of glob patterns into a `GlobSet`. Returns `Ok(None)` when
+/// `patterns` is empty (nothing to match).
+fn compile_globset(patterns: &[String]) -> Result<Option<GlobSet>, Error> {
+    if patterns.is_empty() {
+        return Ok(None);
+    }
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        let glob = Glob::new(pattern).map_err(|e| Error::ConfigError {
+            error: format!("Invalid sample name pattern '{pattern}': {e}"),
+        })?;
+        _ = builder.add(glob);
+    }
+    let set = builder.build().map_err(|e| Error::ConfigError {
+        error: format!("Invalid sample name patterns {patterns:?}: {e}"),
+    })?;
+    Ok(Some(set))
+}
+
+/// Check whether a compiled filter's scope (`signal_type` and `sample_names`)
+/// matches a finding. Both scopes are optional and combine as AND; an unset
+/// scope matches everything.
+fn scope_matches(
+    compiled: &CompiledFilter,
+    finding: &PolicyFinding,
+    sample: &SampleRef<'_>,
+) -> bool {
+    let signal_type_ok = compiled
+        .filter
+        .signal_type
+        .as_ref()
+        .map_or(true, |s| finding.signal_type.as_deref() == Some(s.as_str()));
+    if !signal_type_ok {
+        return false;
+    }
+    match &compiled.sample_names_matcher {
+        None => true,
+        Some(matcher) => sample
+            .sample_name()
+            .is_some_and(|name| matcher.is_match(name)),
+    }
 }
 
 /// Check whether a finding should be excluded by a given filter.
-fn is_excluded_by(finding: &PolicyFinding, filter: &FindingFilter, sample: &SampleRef<'_>) -> bool {
+fn is_excluded_by(
+    finding: &PolicyFinding,
+    compiled: &CompiledFilter,
+    sample: &SampleRef<'_>,
+) -> bool {
     // Exclude by ID
-    if let Some(ref exclude_ids) = filter.exclude {
+    if let Some(ref exclude_ids) = compiled.filter.exclude {
         if exclude_ids.iter().any(|id| id == &finding.id) {
             return true;
         }
     }
     // Exclude by min_level
-    if let Some(min_level) = filter.min_level {
+    if let Some(min_level) = compiled.filter.min_level {
         if finding.level < min_level {
             return true;
         }
     }
     // Exclude by sample name
-    if !filter.exclude_samples.is_empty() {
+    if let Some(matcher) = &compiled.exclude_samples_matcher {
         if let Some(name) = sample.sample_name() {
-            if filter.exclude_samples.iter().any(|s| s == name) {
+            if matcher.is_match(name) {
                 return true;
             }
         }
@@ -51,22 +105,30 @@ fn is_excluded_by(finding: &PolicyFinding, filter: &FindingFilter, sample: &Samp
 impl FindingModifier {
     /// Create a new `FindingModifier` from finding filters.
     ///
-    /// Returns `None` if the filter list is empty.
-    #[must_use]
-    pub fn from_filters(filters: &[FindingFilter]) -> Option<Self> {
+    /// Returns `Ok(None)` if the filter list is empty. Returns `Err` if any
+    /// filter's `sample_names` or `exclude_samples` contains an invalid glob
+    /// pattern.
+    pub fn from_filters(filters: &[FindingFilter]) -> Result<Option<Self>, Error> {
         if filters.is_empty() {
-            return None;
+            return Ok(None);
         }
-        Some(Self {
-            filters: filters.to_vec(),
-        })
+        let filters = filters
+            .iter()
+            .map(|filter| {
+                Ok(CompiledFilter {
+                    sample_names_matcher: compile_globset(&filter.sample_names)?,
+                    exclude_samples_matcher: compile_globset(&filter.exclude_samples)?,
+                    filter: filter.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+        Ok(Some(Self { filters }))
     }
 
     /// Create a new `FindingModifier` from a `LiveCheckConfig`.
     ///
-    /// Returns `None` if the config has no filters.
-    #[must_use]
-    pub fn from_config(config: &LiveCheckConfig) -> Option<Self> {
+    /// Returns `Ok(None)` if the config has no filters.
+    pub fn from_config(config: &LiveCheckConfig) -> Result<Option<Self>, Error> {
         Self::from_filters(&config.finding_filters)
     }
 
@@ -76,17 +138,19 @@ impl FindingModifier {
     /// otherwise.
     ///
     /// `sample` is the sample that produced this finding. It is used by
-    /// `exclude_samples` filters to suppress findings by sample name (e.g.
-    /// attribute key for attribute samples).
+    /// `sample_names` to scope a filter to matching samples, and by
+    /// `exclude_samples` to suppress findings by sample name (e.g. attribute
+    /// key for attribute samples). Both support glob wildcards (e.g.
+    /// `"http.*"`).
     ///
-    /// A global filter (no `signal_type`) applies to all findings; a scoped
-    /// filter applies only when its `signal_type` matches the finding's
-    /// `signal_type`.
+    /// A global filter (no `signal_type` or `sample_names`) applies to all
+    /// findings; a scoped filter applies only when its `signal_type` and/or
+    /// `sample_names` match the finding's signal type and sample name.
     #[must_use]
     pub fn apply(&self, finding: PolicyFinding, sample: &SampleRef<'_>) -> Option<PolicyFinding> {
-        for filter in &self.filters {
-            if scope_matches(filter.signal_type.as_ref(), finding.signal_type.as_ref())
-                && is_excluded_by(&finding, filter, sample)
+        for compiled in &self.filters {
+            if scope_matches(compiled, &finding, sample)
+                && is_excluded_by(&finding, compiled, sample)
             {
                 return None;
             }
@@ -99,6 +163,7 @@ impl FindingModifier {
 mod tests {
     use super::*;
     use crate::sample_attribute::SampleAttribute;
+    use crate::sample_resource::SampleResource;
     use serde_json::json;
     use weaver_checker::FindingLevel;
 
@@ -122,25 +187,44 @@ mod tests {
         }
     }
 
+    fn make_filter(
+        exclude: Option<Vec<String>>,
+        min_level: Option<FindingLevel>,
+        signal_type: Option<String>,
+        exclude_samples: Vec<String>,
+        sample_names: Vec<String>,
+    ) -> FindingFilter {
+        FindingFilter {
+            exclude,
+            min_level,
+            signal_type,
+            exclude_samples,
+            sample_names,
+        }
+    }
+
     #[test]
     fn test_no_rules_passthrough() {
         let config = LiveCheckConfig::default();
-        let modifier = FindingModifier::from_config(&config);
+        let modifier = FindingModifier::from_config(&config).expect("valid config");
         assert!(modifier.is_none());
     }
 
     #[test]
     fn test_global_filter_exclude_by_id() {
         let config = LiveCheckConfig {
-            finding_filters: vec![FindingFilter {
-                exclude: Some(vec!["deprecated".to_owned()]),
-                min_level: None,
-                signal_type: None,
-                exclude_samples: vec![],
-            }],
+            finding_filters: vec![make_filter(
+                Some(vec!["deprecated".to_owned()]),
+                None,
+                None,
+                vec![],
+                vec![],
+            )],
             ..Default::default()
         };
-        let modifier = FindingModifier::from_config(&config).expect("modifier");
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
         let attr = make_attribute("some.attr");
         let sample = SampleRef::Attribute(&attr);
 
@@ -154,15 +238,18 @@ mod tests {
     #[test]
     fn test_global_filter_min_level() {
         let config = LiveCheckConfig {
-            finding_filters: vec![FindingFilter {
-                exclude: None,
-                min_level: Some(FindingLevel::Improvement),
-                signal_type: None,
-                exclude_samples: vec![],
-            }],
+            finding_filters: vec![make_filter(
+                None,
+                Some(FindingLevel::Improvement),
+                None,
+                vec![],
+                vec![],
+            )],
             ..Default::default()
         };
-        let modifier = FindingModifier::from_config(&config).expect("modifier");
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
         let attr = make_attribute("some.attr");
         let sample = SampleRef::Attribute(&attr);
 
@@ -179,15 +266,18 @@ mod tests {
     #[test]
     fn test_scoped_filter() {
         let config = LiveCheckConfig {
-            finding_filters: vec![FindingFilter {
-                exclude: Some(vec!["not_stable".to_owned()]),
-                min_level: None,
-                signal_type: Some("span".to_owned()),
-                exclude_samples: vec![],
-            }],
+            finding_filters: vec![make_filter(
+                Some(vec!["not_stable".to_owned()]),
+                None,
+                Some("span".to_owned()),
+                vec![],
+                vec![],
+            )],
             ..Default::default()
         };
-        let modifier = FindingModifier::from_config(&config).expect("modifier");
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
         let attr = make_attribute("some.attr");
         let sample = SampleRef::Attribute(&attr);
 
@@ -201,15 +291,18 @@ mod tests {
     #[test]
     fn test_exclude_samples_matches_attribute() {
         let config = LiveCheckConfig {
-            finding_filters: vec![FindingFilter {
-                exclude: None,
-                min_level: None,
-                signal_type: None,
-                exclude_samples: vec!["trace.parent_id".to_owned(), "trace.span_id".to_owned()],
-            }],
+            finding_filters: vec![make_filter(
+                None,
+                None,
+                None,
+                vec!["trace.parent_id".to_owned(), "trace.span_id".to_owned()],
+                vec![],
+            )],
             ..Default::default()
         };
-        let modifier = FindingModifier::from_config(&config).expect("modifier");
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
 
         // Matching attribute name — excluded
         let attr = make_attribute("trace.parent_id");
@@ -227,15 +320,18 @@ mod tests {
     #[test]
     fn test_exclude_samples_with_signal_type_scope() {
         let config = LiveCheckConfig {
-            finding_filters: vec![FindingFilter {
-                exclude: None,
-                min_level: None,
-                signal_type: Some("span".to_owned()),
-                exclude_samples: vec!["trace.parent_id".to_owned()],
-            }],
+            finding_filters: vec![make_filter(
+                None,
+                None,
+                Some("span".to_owned()),
+                vec!["trace.parent_id".to_owned()],
+                vec![],
+            )],
             ..Default::default()
         };
-        let modifier = FindingModifier::from_config(&config).expect("modifier");
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
         let attr = make_attribute("trace.parent_id");
         let sample = SampleRef::Attribute(&attr);
 
@@ -246,5 +342,166 @@ mod tests {
         // Non-matching signal_type — kept even though attribute matches
         let finding = make_finding("missing_attribute", FindingLevel::Violation, Some("metric"));
         assert!(modifier.apply(finding, &sample).is_some());
+    }
+
+    #[test]
+    fn test_exclude_samples_wildcard() {
+        let config = LiveCheckConfig {
+            finding_filters: vec![make_filter(
+                None,
+                None,
+                None,
+                vec!["trace.*".to_owned()],
+                vec![],
+            )],
+            ..Default::default()
+        };
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
+
+        let attr = make_attribute("trace.span_id");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding("missing_attribute", FindingLevel::Violation, None);
+        assert!(modifier.apply(finding, &sample).is_none());
+
+        let attr = make_attribute("http.method");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding("missing_attribute", FindingLevel::Violation, None);
+        assert!(modifier.apply(finding, &sample).is_some());
+    }
+
+    #[test]
+    fn test_sample_names_scopes_exclude_and_semantics() {
+        // exclude only applies where sample_names also matches (AND, not OR).
+        let config = LiveCheckConfig {
+            finding_filters: vec![make_filter(
+                Some(vec!["illegal_namespace".to_owned()]),
+                None,
+                None,
+                vec![],
+                vec!["server.address".to_owned(), "server.port".to_owned()],
+            )],
+            ..Default::default()
+        };
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
+
+        // Matching id + matching sample name — excluded
+        let attr = make_attribute("server.address");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding("illegal_namespace", FindingLevel::Violation, None);
+        assert!(modifier.apply(finding, &sample).is_none());
+
+        // Matching id but non-matching sample name — kept (this is the case
+        // exclude_samples/exclude alone could not express: the same advice on
+        // a different sample still surfaces).
+        let attr = make_attribute("db.statement");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding("illegal_namespace", FindingLevel::Violation, None);
+        assert!(modifier.apply(finding, &sample).is_some());
+    }
+
+    #[test]
+    fn test_sample_names_wildcard() {
+        let config = LiveCheckConfig {
+            finding_filters: vec![make_filter(
+                Some(vec!["illegal_namespace".to_owned()]),
+                None,
+                None,
+                vec![],
+                vec!["http.*".to_owned()],
+            )],
+            ..Default::default()
+        };
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
+
+        let attr = make_attribute("http.method");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding("illegal_namespace", FindingLevel::Violation, None);
+        assert!(modifier.apply(finding, &sample).is_none());
+
+        let attr = make_attribute("server.address");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding("illegal_namespace", FindingLevel::Violation, None);
+        assert!(modifier.apply(finding, &sample).is_some());
+    }
+
+    #[test]
+    fn test_sample_names_scopes_min_level_and_exclude_samples_too() {
+        // sample_names gates the whole filter block, same as signal_type.
+        let config = LiveCheckConfig {
+            finding_filters: vec![make_filter(
+                None,
+                Some(FindingLevel::Improvement),
+                None,
+                vec![],
+                vec!["http.*".to_owned()],
+            )],
+            ..Default::default()
+        };
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
+
+        let attr = make_attribute("http.method");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding("foo", FindingLevel::Information, None);
+        assert!(modifier.apply(finding, &sample).is_none());
+
+        let attr = make_attribute("server.address");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding("foo", FindingLevel::Information, None);
+        assert!(modifier.apply(finding, &sample).is_some());
+    }
+
+    #[test]
+    fn test_sample_names_scope_never_matches_nameless_sample() {
+        // Resources don't have a sample name, so a sample_names-scoped filter
+        // never applies to them.
+        let config = LiveCheckConfig {
+            finding_filters: vec![make_filter(
+                Some(vec!["foo".to_owned()]),
+                None,
+                None,
+                vec![],
+                vec!["*".to_owned()],
+            )],
+            ..Default::default()
+        };
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
+
+        let resource = SampleResource {
+            attributes: vec![],
+            live_check_result: None,
+        };
+        let sample = SampleRef::Resource(&resource);
+        let finding = make_finding("foo", FindingLevel::Violation, None);
+        assert!(modifier.apply(finding, &sample).is_some());
+    }
+
+    #[test]
+    fn test_invalid_sample_names_pattern_errors() {
+        let config = LiveCheckConfig {
+            finding_filters: vec![make_filter(None, None, None, vec![], vec!["[".to_owned()])],
+            ..Default::default()
+        };
+        let err = FindingModifier::from_config(&config).expect_err("invalid glob pattern");
+        assert!(matches!(err, Error::ConfigError { .. }));
+    }
+
+    #[test]
+    fn test_invalid_exclude_samples_pattern_errors() {
+        let config = LiveCheckConfig {
+            finding_filters: vec![make_filter(None, None, None, vec!["[".to_owned()], vec![])],
+            ..Default::default()
+        };
+        let err = FindingModifier::from_config(&config).expect_err("invalid glob pattern");
+        assert!(matches!(err, Error::ConfigError { .. }));
     }
 }

--- a/schemas/weaver-config.json
+++ b/schemas/weaver-config.json
@@ -559,7 +559,7 @@
       ]
     },
     "FindingFilter": {
-      "description": "A filter that drops findings by ID exclusion or minimum level.\nOptional `signal_type` scopes the filter to a specific signal type.",
+      "description": "A filter that drops findings by ID exclusion or minimum level.\nOptional `signal_type` and `sample_names` scope the filter to a specific\nsignal type and/or set of sample names.",
       "type": "object",
       "properties": {
         "exclude": {
@@ -573,7 +573,7 @@
           }
         },
         "exclude_samples": {
-          "description": "Drop all findings for samples with these names.\nFor attribute samples, this matches the attribute key — e.g.\n`[\"trace.parent_id\", \"trace.span_id\"]` suppresses all findings\n(e.g. `missing_attribute`) for those attribute keys.",
+          "description": "Drop all findings for samples with these names (supports glob\nwildcards, e.g. `\"trace.*\"`).\nFor attribute samples, this matches the attribute key — e.g.\n`[\"trace.parent_id\", \"trace.span_id\"]` suppresses all findings\n(e.g. `missing_attribute`) for those attribute keys.",
           "type": "array",
           "default": [],
           "items": {
@@ -590,6 +590,14 @@
               "type": "null"
             }
           ]
+        },
+        "sample_names": {
+          "description": "Optional sample name scope (supports glob wildcards, e.g. `\"http.*\"`).\nWhen set, this filter only applies to samples whose name matches one\nof these patterns, in addition to any `signal_type` scope.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
         },
         "signal_type": {
           "description": "Optional signal type scope. When set, this filter only applies to\nfindings with a matching signal_type.",

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -302,7 +302,7 @@ pub(crate) fn command(
     // Create the live checker with advisors
     let mut live_checker = LiveChecker::new(Arc::new(registry), default_advisors());
 
-    live_checker.finding_modifier = FindingModifier::from_filters(&config.finding_filters);
+    live_checker.finding_modifier = FindingModifier::from_filters(&config.finding_filters)?;
 
     let rego_advisor = RegoAdvisor::new(
         &live_checker,


### PR DESCRIPTION
Live-check: (Fixes: [#1613](https://github.com/open-telemetry/weaver/issues/1613)) add `sample_names` to `[[live-check.finding_filters]]` to scope a filter to matching sample names, with glob wildcard support (also added to `exclude_samples`).

Allows you to have config like so:

```toml
# What we could do in the current release:
[[live-check.finding_filters]]
exclude = ["invalid_format"]

# Now exclude missing_attribute findings but only for all aws samples and task.id
[[live-check.finding_filters]]
exclude = ["missing_attribute"]
sample_names = ["aws.*", "task.id"]

# Now only include violation level findings for samples starting with "Task"
[[live-check.finding_filters]]
min_level = "violation"
sample_names = ["Task*"]
```