### PR TITLE
Align MSRV settings with CI

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.81.0"  # MSRV
+msrv = "1.88.0"  # MSRV
 warn-on-all-wildcard-imports = true
 allow-expect-in-tests = true
 allow-unwrap-in-tests = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ edition = "2021"
 repository = "https://github.com/open-telemetry/weaver"
 license = "Apache-2.0"
 publish = false
-rust-version = "1.81.0"
+rust-version = "1.88.0"
 
 [workspace.dependencies]
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/crates/weaver_live_check/src/finding_modifier.rs
+++ b/crates/weaver_live_check/src/finding_modifier.rs
@@ -61,7 +61,7 @@ fn scope_matches(
         .filter
         .signal_type
         .as_ref()
-        .map_or(true, |s| finding.signal_type.as_deref() == Some(s.as_str()));
+        .is_none_or(|s| finding.signal_type.as_deref() == Some(s.as_str()));
     if !signal_type_ok {
         return false;
     }

--- a/crates/weaver_live_check/src/finding_modifier.rs
+++ b/crates/weaver_live_check/src/finding_modifier.rs
@@ -20,7 +20,7 @@ pub struct FindingModifier {
 /// Check whether a scope matches a finding's signal_type.
 /// A `None` scope matches all findings (global).
 fn scope_matches(scope: Option<&String>, signal_type: Option<&String>) -> bool {
-    scope.map_or(true, |s| signal_type == Some(s))
+    scope.is_none_or(|s| signal_type == Some(s))
 }
 
 /// Check whether a finding should be excluded by a given filter.


### PR DESCRIPTION
CI is checking against MSRV 1.88 - config in cargo.toml and clippy.toml was still on 1.81. This meant linting (and other things) was misaligned with our minimum.

(Spotted this because I wanted to use [is_none_or](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none_or) which is in 1.82)