### PR TITLE
make deprecated.note optional on renamed deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Make `deprecated.note` optional for `{reason: renamed}` - inferred from `renamed_to`. ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @lmolkova)
 - Add a tree view to the `serve` UI's search page, grouping results by namespace with expand/collapse controls, and a "Hide deprecated" toggle (on by default) for both the list and tree views. ([#1595](https://github.com/open-telemetry/weaver/pull/1595) by @jerbly)
 - Support signal refinements over a published dependency. ([#1587](https://github.com/open-telemetry/weaver/pull/1587) by @lmolkova)
 - 💥 BREAKING CHANGE 💥 Preserve per-attribute `requirement_level` on attribute refs of public attribute groups in the v2 resolved and materialized schemas. Each entry in an attribute group's `attributes` is now an object (`{ base, requirement_level }`) instead of a bare `attribute_catalog` index. ([#1584](https://github.com/open-telemetry/weaver/pull/1584) by @lmolkova)

--- a/crates/weaver_forge/src/extensions/otel.rs
+++ b/crates/weaver_forge/src/extensions/otel.rs
@@ -946,7 +946,7 @@ mod tests {
             stability: None,
             deprecated: Some(Deprecated::Renamed {
                 renamed_to: "new_name".to_owned(),
-                note: "".to_owned(),
+                note: None,
             }),
             tags: None,
             value: None,

--- a/crates/weaver_resolved_schema/src/lib.rs
+++ b/crates/weaver_resolved_schema/src/lib.rs
@@ -392,14 +392,14 @@ impl ResolvedTelemetrySchema {
                     match deprecated {
                         Deprecated::Renamed {
                             renamed_to: rename_to,
-                            note,
+                            ..
                         } => {
                             changes.add_change(
                                 SchemaItemType::RegistryAttributes,
                                 SchemaItemChange::Renamed {
                                     old_name: baseline_attr.name.clone(),
                                     new_name: rename_to.clone(),
-                                    note: note.clone(),
+                                    note: deprecated.note(),
                                 },
                             );
                         }
@@ -473,14 +473,14 @@ impl ResolvedTelemetrySchema {
                     match deprecated {
                         Deprecated::Renamed {
                             renamed_to: rename_to,
-                            note,
+                            ..
                         } => {
                             changes.add_change(
                                 schema_item_type,
                                 SchemaItemChange::Renamed {
                                     old_name: (*signal_name).to_owned(),
                                     new_name: rename_to.clone(),
-                                    note: note.clone(),
+                                    note: deprecated.note(),
                                 },
                             );
                         }
@@ -669,11 +669,11 @@ mod tests {
                 Attribute::boolean("attr1", "brief1", "note1"),
                 Attribute::string("attr2", "brief2", "note2").deprecated(Deprecated::Renamed {
                     renamed_to: "attr2_bis".to_owned(),
-                    note: "".to_owned(),
+                    note: None,
                 }),
                 Attribute::int("attr3", "brief3", "note3").deprecated(Deprecated::Renamed {
                     renamed_to: "attr3_bis".to_owned(),
-                    note: "".to_owned(),
+                    note: None,
                 }),
                 Attribute::double("attr4", "brief4", "note4"),
             ],
@@ -715,11 +715,11 @@ mod tests {
                 Attribute::boolean("attr1", "brief1", "note1"),
                 Attribute::string("attr2", "brief2", "note2").deprecated(Deprecated::Renamed {
                     renamed_to: "attr5".to_owned(),
-                    note: "".to_owned(),
+                    note: None,
                 }),
                 Attribute::int("attr3", "brief3", "note3").deprecated(Deprecated::Renamed {
                     renamed_to: "attr5".to_owned(),
-                    note: "".to_owned(),
+                    note: None,
                 }),
                 Attribute::double("attr4", "brief4", "note4"),
             ],
@@ -753,11 +753,11 @@ mod tests {
                 Attribute::boolean("attr1", "brief1", "note1"),
                 Attribute::string("attr2", "brief2", "note2").deprecated(Deprecated::Renamed {
                     renamed_to: "attr5".to_owned(),
-                    note: "".to_owned(),
+                    note: None,
                 }),
                 Attribute::int("attr3", "brief3", "note3").deprecated(Deprecated::Renamed {
                     renamed_to: "attr5".to_owned(),
-                    note: "".to_owned(),
+                    note: None,
                 }),
                 Attribute::double("attr4", "brief4", "note4"),
             ],
@@ -817,7 +817,7 @@ mod tests {
             [],
             Some(Deprecated::Renamed {
                 renamed_to: "system.cpu.time".to_owned(),
-                note: "Replaced by `system.cpu.utilization`".to_owned(),
+                note: Some("Replaced by `system.cpu.utilization`".to_owned()),
             }),
         );
         latest_schema.add_metric_group("metrics.system.cpu.time", "system.cpu.time", [], None);

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -625,12 +625,12 @@ fn diff_signals_by_hash<T: Signal>(
                 match deprecated {
                     Deprecated::Renamed {
                         renamed_to: rename_to,
-                        note,
+                        ..
                     } => {
                         changes.push(SchemaItemChange::Renamed {
                             old_name: signal_id.to_owned(),
                             new_name: rename_to.clone(),
-                            note: note.clone(),
+                            note: deprecated.note(),
                         });
                     }
                     Deprecated::Obsoleted { note } => {
@@ -1342,7 +1342,7 @@ mod tests {
                 stability: Stability::Stable,
                 deprecated: Some(Deprecated::Renamed {
                     renamed_to: "test.key.new".to_owned(),
-                    note: "hated it".to_owned(),
+                    note: Some("hated it".to_owned()),
                 }),
                 annotations: Default::default(),
             },

--- a/crates/weaver_semconv/src/deprecated.rs
+++ b/crates/weaver_semconv/src/deprecated.rs
@@ -115,7 +115,7 @@ where
             match action.as_deref() {
                 Some("renamed") => {
                     let renamed_to =
-                        new_name.ok_or_else(|| de::Error::missing_field("rename_to"))?;
+                        new_name.ok_or_else(|| de::Error::missing_field("renamed_to"))?;
                     Ok(Deprecated::Renamed { renamed_to, note })
                 }
                 Some("obsoleted") => Ok(Deprecated::Obsoleted {

--- a/crates/weaver_semconv/src/deprecated.rs
+++ b/crates/weaver_semconv/src/deprecated.rs
@@ -9,14 +9,15 @@
 
 use schemars::JsonSchema;
 use serde::de::{MapAccess, Visitor};
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::ser::SerializeMap;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
 /// The different ways to deprecate an attribute, a metric, ...
-#[derive(
-    Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash, JsonSchema, PartialOrd, Ord,
-)]
+// Note: `Serialize` is implemented manually so that the `note` always shows up,
+// including when it was inferred. See `Deprecated::note`.
+#[derive(Deserialize, Clone, Debug, Eq, PartialEq, Hash, JsonSchema, PartialOrd, Ord)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "reason")]
@@ -27,7 +28,8 @@ pub enum Deprecated {
         /// The new name of the telemetry object.
         renamed_to: String,
         /// The note to provide more context about the deprecation.
-        note: String,
+        /// When not provided, it is inferred from `renamed_to`.
+        note: Option<String>,
     },
     /// The telemetry object containing the deprecated field has been obsoleted
     /// because it no longer exists and has no valid replacement.
@@ -114,7 +116,6 @@ where
                 Some("renamed") => {
                     let renamed_to =
                         new_name.ok_or_else(|| de::Error::missing_field("rename_to"))?;
-                    let note = note.unwrap_or_else(|| format!("Replaced by `{renamed_to}`."));
                     Ok(Deprecated::Renamed { renamed_to, note })
                 }
                 Some("obsoleted") => Ok(Deprecated::Obsoleted {
@@ -176,16 +177,62 @@ where
     deserializer.deserialize_option(OptionDeprecatedVisitor)
 }
 
+impl Deprecated {
+    /// The note providing more context about the deprecation.
+    ///
+    /// Definitions don't have to provide one for a `renamed` deprecation - it is
+    /// then derived from `renamed_to`.
+    #[must_use]
+    pub fn note(&self) -> String {
+        match self {
+            Deprecated::Renamed {
+                renamed_to,
+                note: None,
+            } => format!("Replaced by `{renamed_to}`."),
+            Deprecated::Renamed {
+                note: Some(note), ..
+            }
+            | Deprecated::Obsoleted { note }
+            | Deprecated::Uncategorized { note }
+            | Deprecated::Unspecified { note } => note.clone(),
+        }
+    }
+
+    /// The deprecation reason, as it appears in the `reason` field.
+    #[must_use]
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Deprecated::Renamed { .. } => "renamed",
+            Deprecated::Obsoleted { .. } => "obsoleted",
+            Deprecated::Uncategorized { .. } => "uncategorized",
+            Deprecated::Unspecified { .. } => "unspecified",
+        }
+    }
+}
+
+/// Always serializes the `note`, even when the definition left it out and it had
+/// to be inferred, so that every consumer (templates, resolved schemas, ...) can
+/// rely on it being there.
+impl Serialize for Deprecated {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let renamed_to = match self {
+            Deprecated::Renamed { renamed_to, .. } => Some(renamed_to),
+            _ => None,
+        };
+        let mut map = serializer.serialize_map(Some(2 + usize::from(renamed_to.is_some())))?;
+        map.serialize_entry("reason", self.reason())?;
+        if let Some(renamed_to) = renamed_to {
+            map.serialize_entry("renamed_to", renamed_to)?;
+        }
+        map.serialize_entry("note", &self.note())?;
+        map.end()
+    }
+}
+
 /// Implements a human-readable display for the `Deprecated` enum.
 impl Display for Deprecated {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let text = match self {
-            Deprecated::Renamed { note, .. }
-            | Deprecated::Obsoleted { note }
-            | Deprecated::Uncategorized { note }
-            | Deprecated::Unspecified { note } => note,
-        };
-        write!(f, "{text}")
+        write!(f, "{}", self.note())
     }
 }
 
@@ -235,7 +282,20 @@ mod tests {
             items[2].deprecated,
             Some(Deprecated::Renamed {
                 renamed_to: "foo.unique_id".to_owned(),
-                note: "Replaced by `foo.unique_id`.".to_owned()
+                note: None
+            })
+        );
+        assert_eq!(
+            items[2].deprecated.clone().unwrap().to_string(),
+            "Replaced by `foo.unique_id`."
+        );
+        // The inferred note is serialized like any other one.
+        assert_eq!(
+            serde_json::to_value(items[2].deprecated.as_ref().unwrap()).unwrap(),
+            serde_json::json!({
+                "reason": "renamed",
+                "renamed_to": "foo.unique_id",
+                "note": "Replaced by `foo.unique_id`.",
             })
         );
         assert_eq!(
@@ -248,7 +308,7 @@ mod tests {
             items[4].deprecated,
             Some(Deprecated::Renamed {
                 renamed_to: "foo.unique_id".to_owned(),
-                note: "Replaced by a new attribute `foo.unique_id`.".to_owned()
+                note: Some("Replaced by a new attribute `foo.unique_id`.".to_owned())
             })
         );
     }

--- a/crates/weaver_semconv/src/v2/mod.rs
+++ b/crates/weaver_semconv/src/v2/mod.rs
@@ -338,6 +338,41 @@ mod tests {
     }
 
     #[test]
+    fn test_v2_deprecated_note_is_optional_for_renamed_only() {
+        let spec = |deprecated: &str| {
+            format!(
+                "attributes:\n  - key: my.attr\n    type: string\n    brief: b\n    stability: development\n    deprecated:\n{deprecated}"
+            )
+        };
+
+        let parsed = serde_yaml::from_str::<SemConvSpecV2>(&spec(
+            "      reason: renamed\n      renamed_to: my.new_attr\n",
+        ))
+        .expect("`renamed` must parse without a note");
+        assert_eq!(
+            parsed.attributes[0]
+                .common
+                .deprecated
+                .as_ref()
+                .expect("attribute is deprecated")
+                .note(),
+            "Replaced by `my.new_attr`."
+        );
+
+        // Nothing to infer from for the other reasons, so the note stays required.
+        for reason in ["obsoleted", "uncategorized"] {
+            let err = serde_yaml::from_str::<SemConvSpecV2>(&spec(&format!(
+                "      reason: {reason}\n"
+            )))
+            .expect_err("`{reason}` must require a note");
+            assert!(
+                err.to_string().contains("note"),
+                "expected a missing `note` error for `{reason}`, got: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn test_v2_requirement_level_set_no_warning() {
         for level in ["recommended", "opt_in"] {
             let yaml = format!(

--- a/crates/weaver_semconv/src/v2/mod.rs
+++ b/crates/weaver_semconv/src/v2/mod.rs
@@ -360,11 +360,10 @@ mod tests {
         );
 
         // Nothing to infer from for the other reasons, so the note stays required.
-        for reason in ["obsoleted", "uncategorized"] {
-            let err = serde_yaml::from_str::<SemConvSpecV2>(&spec(&format!(
-                "      reason: {reason}\n"
-            )))
-            .expect_err("`{reason}` must require a note");
+        for reason in ["obsoleted", "uncategorized", "unspecified"] {
+            let err =
+                serde_yaml::from_str::<SemConvSpecV2>(&spec(&format!("      reason: {reason}\n")))
+                    .unwrap_err();
             assert!(
                 err.to_string().contains("note"),
                 "expected a missing `note` error for `{reason}`, got: {err}"

--- a/schemas/semconv-syntax.v2.md
+++ b/schemas/semconv-syntax.v2.md
@@ -666,10 +666,10 @@ The `requirement_level` on a signal (metric, span, event, or entity) is guidance
 
 The `deprecated` field indicates that a component (attribute, metric, event, etc.) should no longer be used. It supports several deprecation reasons:
 
-All deprecation reasons have the following required properties:
+All deprecation reasons have the following properties:
 
 - `reason` - Required. The type of deprecation. Must be one of: `renamed`, `obsoleted`, `uncategorized`, or `unspecified`.
-- `note` - Required. Provides context about the deprecation.
+- `note` - Provides context about the deprecation. Required for every reason except `renamed`.
 
 Additional properties depending on the reason:
 
@@ -678,6 +678,8 @@ Additional properties depending on the reason:
 Used when a component has been renamed. Requires an additional property:
 
 - `renamed_to` - Required. The new name of the telemetry object.
+
+When `note` is omitted, it defaults to ``Replaced by `<renamed_to>`.`` in the resolved schema.
 
 Example:
 

--- a/schemas/semconv.materialized.v2.json
+++ b/schemas/semconv.materialized.v2.json
@@ -276,8 +276,11 @@
           "type": "object",
           "properties": {
             "note": {
-              "description": "The note to provide more context about the deprecation.",
-              "type": "string"
+              "description": "The note to provide more context about the deprecation.\nWhen not provided, it is inferred from `renamed_to`.",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "reason": {
               "type": "string",
@@ -290,8 +293,7 @@
           },
           "required": [
             "reason",
-            "renamed_to",
-            "note"
+            "renamed_to"
           ]
         },
         {

--- a/schemas/semconv.resolved.v2.json
+++ b/schemas/semconv.resolved.v2.json
@@ -258,8 +258,11 @@
           "type": "object",
           "properties": {
             "note": {
-              "description": "The note to provide more context about the deprecation.",
-              "type": "string"
+              "description": "The note to provide more context about the deprecation.\nWhen not provided, it is inferred from `renamed_to`.",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "reason": {
               "type": "string",
@@ -272,8 +275,7 @@
           },
           "required": [
             "reason",
-            "renamed_to",
-            "note"
+            "renamed_to"
           ]
         },
         {

--- a/schemas/semconv.schema.v2.json
+++ b/schemas/semconv.schema.v2.json
@@ -393,8 +393,11 @@
           "type": "object",
           "properties": {
             "note": {
-              "description": "The note to provide more context about the deprecation.",
-              "type": "string"
+              "description": "The note to provide more context about the deprecation.\nWhen not provided, it is inferred from `renamed_to`.",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "reason": {
               "type": "string",
@@ -407,8 +410,7 @@
           },
           "required": [
             "reason",
-            "renamed_to",
-            "note"
+            "renamed_to"
           ]
         },
         {

--- a/ui/e2e/fixtures/render-registry/registry.yaml
+++ b/ui/e2e/fixtures/render-registry/registry.yaml
@@ -99,7 +99,6 @@ attributes:
     deprecated:
       reason: renamed
       renamed_to: render.attr.string_single_example
-      note: Replaced by `render.attr.string_single_example`.
 
   - key: render.attr.deprecated_obsoleted
     type: string
@@ -208,7 +207,6 @@ metrics:
     deprecated:
       reason: renamed
       renamed_to: render.metric.counter
-      note: Replaced by `render.metric.counter`.
 
 spans:
   - type: render.span.client

--- a/ui/e2e/render.spec.ts
+++ b/ui/e2e/render.spec.ts
@@ -125,6 +125,8 @@ test.describe('attribute rendering', () => {
     // Deprecation alert with a link to the successor attribute.
     const alert = page.getByRole('alert').filter({ hasText: 'Deprecated' })
     await expect(alert).toBeVisible()
+    // The fixture omits the note, it is inferred from `renamed_to`.
+    await expect(alert.getByText('Replaced by `render.attr.string_single_example`.')).toBeVisible()
     const successor = alert.getByRole('link', { name: 'render.attr.string_single_example' })
     await expect(successor).toBeVisible()
     await successor.click()


### PR DESCRIPTION
Fixes #1556

on v1 we had optional deprecated.note (at least for renamed_to) and it make sense

```yaml
deprecated:
  reason: renamed
  rename_to: foo.bar
```

It's self-descriptive. We can generate a perfect note like`Renamed to 'foo.bar'`. 
Requiring a note would mean duplication in 99% of cases.

So this PR makes note optional for renamed.

Unfortunately it leaks to resolved schema where we actually would always populate note (inferred from structured props) because we share models between definition and resolved schema and it'd be a giant change to prevent it and make note required on resolved side only.