### PR TITLE
Live-check: Add overrides to rewrite matching finding levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Live-check: (Fixes: [#1614](https://github.com/open-telemetry/weaver/issues/1614)) add `[[live-check.finding_level_overrides]]` to rewrite a finding's level instead of dropping it (e.g. treat `undefined_enum_variant` as a violation), scoped by the same `signal_type`/`sample_names` rules as `finding_filters`. ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @jerbly)
 - Change v2 refinement attribute precedence so `ref_group` details win over inherited attributes. ([#1604](https://github.com/open-telemetry/weaver/pull/1604) by @lmolkova)
 - Make `deprecated.note` optional for `{reason: renamed}` - inferred from `renamed_to`. ([#1622](https://github.com/open-telemetry/weaver/pull/1622) by @lmolkova)
 - Add v2 entity refinements to the resolved and materialized schema, allow to refine attributes without changing entity identity. ([#1588](https://github.com/open-telemetry/weaver/pull/1588) by @lmolkova)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Live-check: (Fixes: [#1614](https://github.com/open-telemetry/weaver/issues/1614)) add `[[live-check.finding_level_overrides]]` to rewrite a finding's level instead of dropping it (e.g. treat `undefined_enum_variant` as a violation), scoped by the same `signal_type`/`sample_names` rules as `finding_filters`. ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @jerbly)
+- Live-check: (Fixes: [#1614](https://github.com/open-telemetry/weaver/issues/1614)) add `[[live-check.finding_level_overrides]]` to rewrite a finding's level instead of dropping it (e.g. treat `undefined_enum_variant` as a violation), scoped by the same `signal_type`/`sample_names` rules as `finding_filters`. ([#1625](https://github.com/open-telemetry/weaver/pull/1625) by @jerbly)
 - Change v2 refinement attribute precedence so `ref_group` details win over inherited attributes. ([#1604](https://github.com/open-telemetry/weaver/pull/1604) by @lmolkova)
 - Make `deprecated.note` optional for `{reason: renamed}` - inferred from `renamed_to`. ([#1622](https://github.com/open-telemetry/weaver/pull/1622) by @lmolkova)
 - Add v2 entity refinements to the resolved and materialized schema, allow to refine attributes without changing entity identity. ([#1588](https://github.com/open-telemetry/weaver/pull/1588) by @lmolkova)

--- a/crates/weaver_config/src/lib.rs
+++ b/crates/weaver_config/src/lib.rs
@@ -23,7 +23,8 @@ pub use effective::{
     DEFAULT_DIAGNOSTIC_FORMAT, DEFAULT_DIAGNOSTIC_TEMPLATE, DEFAULT_REGISTRY,
 };
 pub use live_check::{
-    FailOnLevel, FindingFilter, LiveCheckConfig, LiveCheckEmitConfig, LiveCheckOtlpConfig,
+    FailOnLevel, FindingFilter, FindingLevelOverride, LiveCheckConfig, LiveCheckEmitConfig,
+    LiveCheckOtlpConfig,
 };
 pub use overrides::{CliOverrides, CommandConfig, FieldMapping};
 pub use registry::{DiagnosticsConfig, PolicyConfig, RegistryConfig};

--- a/crates/weaver_config/src/live_check.rs
+++ b/crates/weaver_config/src/live_check.rs
@@ -82,6 +82,14 @@ pub struct LiveCheckConfig {
     #[serde(default)]
     pub finding_filters: Vec<FindingFilter>,
 
+    /// Rules that override the level of matching findings instead of dropping
+    /// them (e.g. promote `undefined_enum_variant` from `information` to
+    /// `violation`). Scoped the same way as `finding_filters` (optional
+    /// `signal_type` and `sample_names`). Applied before `finding_filters`,
+    /// so a subsequent `min_level` filter sees the overridden level.
+    #[serde(default)]
+    pub finding_level_overrides: Vec<FindingLevelOverride>,
+
     /// Where to read the input telemetry from. `{file path}` | `stdin` | `otlp`.
     pub input_source: String,
 
@@ -133,6 +141,7 @@ impl Default for LiveCheckConfig {
     fn default() -> Self {
         Self {
             finding_filters: Vec::new(),
+            finding_level_overrides: Vec::new(),
             input_source: "otlp".to_owned(),
             input_format: "json".to_owned(),
             format: "ansi".to_owned(),
@@ -219,6 +228,26 @@ pub struct FindingFilter {
     /// Optional sample name scope (supports glob wildcards, e.g. `"http.*"`).
     /// When set, this filter only applies to samples whose name matches one
     /// of these patterns, in addition to any `signal_type` scope.
+    #[serde(default)]
+    pub sample_names: Vec<String>,
+}
+
+/// A rule that overrides the level of matching findings instead of dropping
+/// them. Optional `signal_type` and `sample_names` scope the rule the same
+/// way as `FindingFilter`.
+#[derive(Debug, Clone, Deserialize, PartialEq, JsonSchema)]
+pub struct FindingLevelOverride {
+    /// Override the level of findings with these IDs. When unset, applies to
+    /// any finding ID within scope.
+    pub ids: Option<Vec<String>>,
+    /// The level to set on matching findings.
+    pub level: FindingLevel,
+    /// Optional signal type scope. When set, this rule only applies to
+    /// findings with a matching signal_type.
+    pub signal_type: Option<String>,
+    /// Optional sample name scope (supports glob wildcards, e.g. `"http.*"`).
+    /// When set, this rule only applies to samples whose name matches one of
+    /// these patterns, in addition to any `signal_type` scope.
     #[serde(default)]
     pub sample_names: Vec<String>,
 }
@@ -445,6 +474,45 @@ min_level = "violation"
         let config: WeaverConfig = toml::from_str(toml).expect("Failed to parse TOML");
         let lc = live_check(&config);
         assert!(lc.finding_filters[0].sample_names.is_empty());
+    }
+
+    #[test]
+    fn test_parse_finding_level_overrides() {
+        let toml = r#"
+[["live-check".finding_level_overrides]]
+ids = ["undefined_enum_variant"]
+level = "violation"
+
+[["live-check".finding_level_overrides]]
+signal_type = "span"
+sample_names = ["custom.*"]
+ids = ["undefined_enum_variant"]
+level = "improvement"
+"#;
+        let config: WeaverConfig = toml::from_str(toml).expect("Failed to parse TOML");
+        let lc = live_check(&config);
+        assert_eq!(lc.finding_level_overrides.len(), 2);
+
+        let o0 = &lc.finding_level_overrides[0];
+        assert!(o0.signal_type.is_none());
+        assert!(o0.sample_names.is_empty());
+        assert_eq!(
+            o0.ids.as_deref(),
+            Some(&["undefined_enum_variant".to_owned()][..])
+        );
+        assert_eq!(o0.level, FindingLevel::Violation);
+
+        let o1 = &lc.finding_level_overrides[1];
+        assert_eq!(o1.signal_type.as_deref(), Some("span"));
+        assert_eq!(o1.sample_names, vec!["custom.*"]);
+        assert_eq!(o1.level, FindingLevel::Improvement);
+    }
+
+    #[test]
+    fn test_parse_finding_level_overrides_defaults_to_empty() {
+        let config: WeaverConfig = toml::from_str("").expect("Failed to parse empty TOML");
+        let lc = live_check(&config);
+        assert!(lc.finding_level_overrides.is_empty());
     }
 
     #[test]

--- a/crates/weaver_live_check/README.md
+++ b/crates/weaver_live_check/README.md
@@ -206,27 +206,49 @@ Filters drop findings entirely. Use `exclude` to drop by ID, `min_level` to drop
 
 ```toml
 # Drop deprecated and missing_namespace findings, and anything below improvement
-[[live_check.finding_filters]]
+[[live-check.finding_filters]]
 exclude = ["deprecated", "missing_namespace"]
 min_level = "improvement"
 
 # Additionally drop not_stable findings, but only for spans
-[[live_check.finding_filters]]
+[[live-check.finding_filters]]
 signal_type = "span"
 exclude = ["not_stable"]
 
 # Suppress all findings for these attribute names (wildcards supported)
-[[live_check.finding_filters]]
+[[live-check.finding_filters]]
 exclude_samples = ["trace.parent_id", "trace.span_id", "trace.trace_id"]
 
 # Drop illegal_namespace only for these specific attributes — the same
 # advice on any other attribute still surfaces as a finding
-[[live_check.finding_filters]]
+[[live-check.finding_filters]]
 exclude = ["illegal_namespace"]
 sample_names = ["server.address", "server.port", "client.address", "client.port"]
 ```
 
 The `exclude_samples` and `sample_names` fields match by sample name: attribute key for attributes, span name for spans, metric name for metrics, event name for logs, and span event name for span events. They can be combined with other filter fields, for example scoping to a specific `signal_type`.
+
+### Finding level overrides
+
+`[[live-check.finding_level_overrides]]` changes a finding's `level` instead of dropping it, so it continues through the report at the new severity. It's scoped the same way as finding filters — optional `signal_type` and `sample_names` (wildcards supported) — plus `ids` to pick which finding IDs it applies to (omit `ids` to apply to any finding ID within scope).
+
+Level overrides are applied before finding filters, so a `min_level` filter evaluated afterwards sees the overridden level rather than the original one.
+
+Note that `signal_type` scopes by the _parent_ signal, not by what the finding is about — an attribute finding like `undefined_enum_variant` (which only ever fires on attribute values) still carries the `signal_type` of the span/metric/log/resource that attribute belongs to.
+
+```toml
+# undefined_enum_variant is information by default; treat it as a violation everywhere
+[[live-check.finding_level_overrides]]
+ids = ["undefined_enum_variant"]
+level = "violation"
+
+# ...or only for a specific set of attributes on spans
+[[live-check.finding_level_overrides]]
+ids = ["undefined_enum_variant"]
+level = "violation"
+signal_type = "span"
+sample_names = ["http.*"]
+```
 
 ## Output
 

--- a/crates/weaver_live_check/allowed-external-types.toml
+++ b/crates/weaver_live_check/allowed-external-types.toml
@@ -15,6 +15,7 @@ allowed_external_types = [
     "weaver_semconv::*",
     "weaver_checker::*",
     "weaver_config::live_check::FindingFilter",
+    "weaver_config::live_check::FindingLevelOverride",
     "weaver_config::live_check::LiveCheckConfig",
     "opentelemetry::common::Key",
     "opentelemetry::logs::record::*",

--- a/crates/weaver_live_check/src/finding_modifier.rs
+++ b/crates/weaver_live_check/src/finding_modifier.rs
@@ -8,14 +8,17 @@
 use crate::{Error, SampleRef};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use weaver_checker::PolicyFinding;
-use weaver_config::{FindingFilter, LiveCheckConfig};
+use weaver_config::{FindingFilter, FindingLevelOverride, LiveCheckConfig};
 
-/// Engine that applies finding filters.
+/// Engine that applies finding filters and level overrides.
 ///
-/// Used inline during `add_advice()` to drop findings before they are stored,
-/// avoiding collect-then-filter overhead.
+/// Used inline during `add_advice()` to modify or drop findings before they
+/// are stored, avoiding collect-then-filter overhead.
 #[derive(Debug)]
 pub struct FindingModifier {
+    /// Applied first: may change a finding's level (but never drops it).
+    level_overrides: Vec<CompiledLevelOverride>,
+    /// Applied second, to the (possibly relevelled) finding: may drop it.
     filters: Vec<CompiledFilter>,
 }
 
@@ -28,6 +31,15 @@ struct CompiledFilter {
     sample_names_matcher: Option<GlobSet>,
     /// Compiled `filter.exclude_samples` (exclusion condition), if non-empty.
     exclude_samples_matcher: Option<GlobSet>,
+}
+
+/// A `FindingLevelOverride` with its glob patterns precompiled once at
+/// construction time.
+#[derive(Debug)]
+struct CompiledLevelOverride {
+    rule: FindingLevelOverride,
+    /// Compiled `rule.sample_names` (scope), if non-empty.
+    sample_names_matcher: Option<GlobSet>,
 }
 
 /// Compile a list of glob patterns into a `GlobSet`. Returns `Ok(None)` when
@@ -49,28 +61,34 @@ fn compile_globset(patterns: &[String]) -> Result<Option<GlobSet>, Error> {
     Ok(Some(set))
 }
 
-/// Check whether a compiled filter's scope (`signal_type` and `sample_names`)
-/// matches a finding. Both scopes are optional and combine as AND; an unset
-/// scope matches everything.
+/// Check whether a `signal_type`/`sample_names` scope (shared by
+/// `FindingFilter` and `FindingLevelOverride`) matches a finding. Both scopes
+/// are optional and combine as AND; an unset scope matches everything.
 fn scope_matches(
-    compiled: &CompiledFilter,
+    signal_type: Option<&String>,
+    sample_names_matcher: Option<&GlobSet>,
     finding: &PolicyFinding,
     sample: &SampleRef<'_>,
 ) -> bool {
-    let signal_type_ok = compiled
-        .filter
-        .signal_type
-        .as_ref()
-        .is_none_or(|s| finding.signal_type.as_deref() == Some(s.as_str()));
+    let signal_type_ok =
+        signal_type.is_none_or(|s| finding.signal_type.as_deref() == Some(s.as_str()));
     if !signal_type_ok {
         return false;
     }
-    match &compiled.sample_names_matcher {
+    match sample_names_matcher {
         None => true,
         Some(matcher) => sample
             .sample_name()
             .is_some_and(|name| matcher.is_match(name)),
     }
+}
+
+/// Check whether a finding's ID is matched by a level override rule. An
+/// unset `ids` list matches any finding ID within scope.
+fn is_matched_by(finding: &PolicyFinding, rule: &FindingLevelOverride) -> bool {
+    rule.ids
+        .as_ref()
+        .is_none_or(|ids| ids.iter().any(|id| id == &finding.id))
 }
 
 /// Check whether a finding should be excluded by a given filter.
@@ -103,13 +121,17 @@ fn is_excluded_by(
 }
 
 impl FindingModifier {
-    /// Create a new `FindingModifier` from finding filters.
+    /// Create a new `FindingModifier` from finding filters and level
+    /// overrides.
     ///
-    /// Returns `Ok(None)` if the filter list is empty. Returns `Err` if any
-    /// filter's `sample_names` or `exclude_samples` contains an invalid glob
-    /// pattern.
-    pub fn from_filters(filters: &[FindingFilter]) -> Result<Option<Self>, Error> {
-        if filters.is_empty() {
+    /// Returns `Ok(None)` if both lists are empty. Returns `Err` if any
+    /// filter's or rule's `sample_names`/`exclude_samples` contains an
+    /// invalid glob pattern.
+    pub fn from_rules(
+        filters: &[FindingFilter],
+        level_overrides: &[FindingLevelOverride],
+    ) -> Result<Option<Self>, Error> {
+        if filters.is_empty() && level_overrides.is_empty() {
             return Ok(None);
         }
         let filters = filters
@@ -122,35 +144,70 @@ impl FindingModifier {
                 })
             })
             .collect::<Result<Vec<_>, Error>>()?;
-        Ok(Some(Self { filters }))
+        let level_overrides = level_overrides
+            .iter()
+            .map(|rule| {
+                Ok(CompiledLevelOverride {
+                    sample_names_matcher: compile_globset(&rule.sample_names)?,
+                    rule: rule.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+        Ok(Some(Self {
+            level_overrides,
+            filters,
+        }))
     }
 
     /// Create a new `FindingModifier` from a `LiveCheckConfig`.
     ///
-    /// Returns `Ok(None)` if the config has no filters.
+    /// Returns `Ok(None)` if the config has no filters or level overrides.
     pub fn from_config(config: &LiveCheckConfig) -> Result<Option<Self>, Error> {
-        Self::from_filters(&config.finding_filters)
+        Self::from_rules(&config.finding_filters, &config.finding_level_overrides)
     }
 
-    /// Apply filters to a finding.
+    /// Apply level overrides then filters to a finding.
     ///
     /// Returns `None` if the finding should be excluded, or `Some(finding)`
-    /// otherwise.
+    /// (possibly with an overridden `level`) otherwise.
     ///
     /// `sample` is the sample that produced this finding. It is used by
-    /// `sample_names` to scope a filter to matching samples, and by
+    /// `sample_names` to scope a rule to matching samples, and by
     /// `exclude_samples` to suppress findings by sample name (e.g. attribute
     /// key for attribute samples). Both support glob wildcards (e.g.
     /// `"http.*"`).
     ///
-    /// A global filter (no `signal_type` or `sample_names`) applies to all
-    /// findings; a scoped filter applies only when its `signal_type` and/or
+    /// A global filter/rule (no `signal_type` or `sample_names`) applies to
+    /// all findings; a scoped one applies only when its `signal_type` and/or
     /// `sample_names` match the finding's signal type and sample name.
+    ///
+    /// Level overrides are applied first (first match wins), so a
+    /// `min_level` filter evaluated afterwards sees the overridden level —
+    /// e.g. promoting `undefined_enum_variant` to `violation` makes it
+    /// subject to any `min_level = "violation"` gating, rather than being
+    /// dropped at its original `information` level beforehand.
     #[must_use]
     pub fn apply(&self, finding: PolicyFinding, sample: &SampleRef<'_>) -> Option<PolicyFinding> {
+        let mut finding = finding;
+        for compiled in &self.level_overrides {
+            if scope_matches(
+                compiled.rule.signal_type.as_ref(),
+                compiled.sample_names_matcher.as_ref(),
+                &finding,
+                sample,
+            ) && is_matched_by(&finding, &compiled.rule)
+            {
+                finding.level = compiled.rule.level;
+                break;
+            }
+        }
         for compiled in &self.filters {
-            if scope_matches(compiled, &finding, sample)
-                && is_excluded_by(&finding, compiled, sample)
+            if scope_matches(
+                compiled.filter.signal_type.as_ref(),
+                compiled.sample_names_matcher.as_ref(),
+                &finding,
+                sample,
+            ) && is_excluded_by(&finding, compiled, sample)
             {
                 return None;
             }
@@ -199,6 +256,20 @@ mod tests {
             min_level,
             signal_type,
             exclude_samples,
+            sample_names,
+        }
+    }
+
+    fn make_level_override(
+        ids: Option<Vec<String>>,
+        level: FindingLevel,
+        signal_type: Option<String>,
+        sample_names: Vec<String>,
+    ) -> FindingLevelOverride {
+        FindingLevelOverride {
+            ids,
+            level,
+            signal_type,
             sample_names,
         }
     }
@@ -499,6 +570,157 @@ mod tests {
     fn test_invalid_exclude_samples_pattern_errors() {
         let config = LiveCheckConfig {
             finding_filters: vec![make_filter(None, None, None, vec!["[".to_owned()], vec![])],
+            ..Default::default()
+        };
+        let err = FindingModifier::from_config(&config).expect_err("invalid glob pattern");
+        assert!(matches!(err, Error::ConfigError { .. }));
+    }
+
+    #[test]
+    fn test_level_override_promotes_by_id() {
+        // undefined_enum_variant: information -> violation, globally.
+        let config = LiveCheckConfig {
+            finding_level_overrides: vec![make_level_override(
+                Some(vec!["undefined_enum_variant".to_owned()]),
+                FindingLevel::Violation,
+                None,
+                vec![],
+            )],
+            ..Default::default()
+        };
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
+        let attr = make_attribute("some.attr");
+        let sample = SampleRef::Attribute(&attr);
+
+        let finding = make_finding("undefined_enum_variant", FindingLevel::Information, None);
+        let result = modifier.apply(finding, &sample).expect("not dropped");
+        assert_eq!(result.level, FindingLevel::Violation);
+
+        // A different id is untouched.
+        let finding = make_finding("deprecated", FindingLevel::Information, None);
+        let result = modifier.apply(finding, &sample).expect("not dropped");
+        assert_eq!(result.level, FindingLevel::Information);
+    }
+
+    #[test]
+    fn test_level_override_scoped_by_signal_type_and_sample_names() {
+        let config = LiveCheckConfig {
+            finding_level_overrides: vec![make_level_override(
+                Some(vec!["undefined_enum_variant".to_owned()]),
+                FindingLevel::Violation,
+                Some("span".to_owned()),
+                vec!["http.*".to_owned()],
+            )],
+            ..Default::default()
+        };
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
+
+        // Matching signal_type + sample_names — promoted.
+        let attr = make_attribute("http.method");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding(
+            "undefined_enum_variant",
+            FindingLevel::Information,
+            Some("span"),
+        );
+        let result = modifier.apply(finding, &sample).expect("not dropped");
+        assert_eq!(result.level, FindingLevel::Violation);
+
+        // Matching signal_type but non-matching sample name — untouched.
+        let attr = make_attribute("server.address");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding(
+            "undefined_enum_variant",
+            FindingLevel::Information,
+            Some("span"),
+        );
+        let result = modifier.apply(finding, &sample).expect("not dropped");
+        assert_eq!(result.level, FindingLevel::Information);
+
+        // Non-matching signal_type — untouched even though sample name matches.
+        let attr = make_attribute("http.method");
+        let sample = SampleRef::Attribute(&attr);
+        let finding = make_finding(
+            "undefined_enum_variant",
+            FindingLevel::Information,
+            Some("metric"),
+        );
+        let result = modifier.apply(finding, &sample).expect("not dropped");
+        assert_eq!(result.level, FindingLevel::Information);
+    }
+
+    #[test]
+    fn test_level_override_never_drops() {
+        let config = LiveCheckConfig {
+            finding_level_overrides: vec![make_level_override(
+                None,
+                FindingLevel::Violation,
+                None,
+                vec![],
+            )],
+            ..Default::default()
+        };
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
+        let attr = make_attribute("some.attr");
+        let sample = SampleRef::Attribute(&attr);
+
+        let finding = make_finding("anything", FindingLevel::Information, None);
+        let result = modifier.apply(finding, &sample).expect("never dropped");
+        assert_eq!(result.level, FindingLevel::Violation);
+    }
+
+    #[test]
+    fn test_level_override_runs_before_min_level_filter() {
+        // A finding below the min_level floor gets promoted first, then
+        // survives the floor instead of being dropped at its original level.
+        let config = LiveCheckConfig {
+            finding_level_overrides: vec![make_level_override(
+                Some(vec!["undefined_enum_variant".to_owned()]),
+                FindingLevel::Violation,
+                None,
+                vec![],
+            )],
+            finding_filters: vec![make_filter(
+                None,
+                Some(FindingLevel::Violation),
+                None,
+                vec![],
+                vec![],
+            )],
+            ..Default::default()
+        };
+        let modifier = FindingModifier::from_config(&config)
+            .expect("valid config")
+            .expect("modifier");
+        let attr = make_attribute("some.attr");
+        let sample = SampleRef::Attribute(&attr);
+
+        let finding = make_finding("undefined_enum_variant", FindingLevel::Information, None);
+        let result = modifier
+            .apply(finding, &sample)
+            .expect("rescued by override");
+        assert_eq!(result.level, FindingLevel::Violation);
+
+        // An unrelated finding at Information is still dropped by the floor.
+        let finding = make_finding("deprecated", FindingLevel::Information, None);
+        assert!(modifier.apply(finding, &sample).is_none());
+    }
+
+    #[test]
+    fn test_invalid_level_override_sample_names_pattern_errors() {
+        let config = LiveCheckConfig {
+            finding_level_overrides: vec![make_level_override(
+                None,
+                FindingLevel::Violation,
+                None,
+                vec!["[".to_owned()],
+            )],
             ..Default::default()
         };
         let err = FindingModifier::from_config(&config).expect_err("invalid glob pattern");

--- a/schemas/weaver-config.json
+++ b/schemas/weaver-config.json
@@ -248,6 +248,13 @@
             "$ref": "#/$defs/FindingFilter"
           }
         },
+        "finding_level_overrides": {
+          "description": "Rules that override the level of matching findings instead of dropping\nthem (e.g. promote `undefined_enum_variant` from `information` to\n`violation`). Scoped the same way as `finding_filters` (optional\n`signal_type` and `sample_names`). Applied before `finding_filters`,\nso a subsequent `min_level` filter sees the overridden level.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FindingLevelOverride"
+          }
+        },
         "format": {
           "description": "Format used to render the report.\nBuiltin formats: `json`, `yaml`, `jsonl`. Other values are template names\n(e.g. `ansi` selects the ansi templates).",
           "type": "string",
@@ -626,6 +633,44 @@
           "type": "string",
           "const": "violation"
         }
+      ]
+    },
+    "FindingLevelOverride": {
+      "description": "A rule that overrides the level of matching findings instead of dropping\nthem. Optional `signal_type` and `sample_names` scope the rule the same\nway as `FindingFilter`.",
+      "type": "object",
+      "properties": {
+        "ids": {
+          "description": "Override the level of findings with these IDs. When unset, applies to\nany finding ID within scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "level": {
+          "description": "The level to set on matching findings.",
+          "$ref": "#/$defs/FindingLevel"
+        },
+        "sample_names": {
+          "description": "Optional sample name scope (supports glob wildcards, e.g. `\"http.*\"`).\nWhen set, this rule only applies to samples whose name matches one of\nthese patterns, in addition to any `signal_type` scope.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "signal_type": {
+          "description": "Optional signal type scope. When set, this rule only applies to\nfindings with a matching signal_type.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "level"
       ]
     },
     "LiveCheckEmitConfig": {

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -81,7 +81,7 @@ impl From<String> for InputFormat {
 #[weaver_command(
     section = "live-check",
     config_type = "::weaver_config::LiveCheckConfig",
-    extra_config_only = "finding_filters"
+    extra_config_only = "finding_filters,finding_level_overrides"
 )]
 #[derive(Debug, Args, WeaverCommand)]
 pub struct RegistryLiveCheckArgs {
@@ -302,7 +302,8 @@ pub(crate) fn command(
     // Create the live checker with advisors
     let mut live_checker = LiveChecker::new(Arc::new(registry), default_advisors());
 
-    live_checker.finding_modifier = FindingModifier::from_filters(&config.finding_filters)?;
+    live_checker.finding_modifier =
+        FindingModifier::from_rules(&config.finding_filters, &config.finding_level_overrides)?;
 
     let rego_advisor = RegoAdvisor::new(
         &live_checker,


### PR DESCRIPTION
Fixes: #1614 

add `[[live-check.finding_level_overrides]]` to rewrite a finding's level instead of dropping it (e.g. treat `undefined_enum_variant` as a violation), scoped by the same `signal_type`/`sample_names` rules as `finding_filters`.

Now you can do this:
```toml
# undefined_enum_variant is information by default; treat it as a violation everywhere
[[live-check.finding_level_overrides]]
ids = ["undefined_enum_variant"]
level = "violation"

# ...or only for a specific set of attributes on spans
[[live-check.finding_level_overrides]]
ids = ["undefined_enum_variant"]
level = "violation"
signal_type = "span"
sample_names = ["http.*"]
```