### PR TITLE
fix ref_group resolution on refinements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix v2 attribute resolution so a `ref` inside an included group (`ref_group`) merges field-by-field instead of replacing the whole attribute. ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @lmolkova)
+- Fix v2 attribute resolution so a `ref` inside an included group (`ref_group`) merges field-by-field instead of replacing the whole attribute. ([#1634](https://github.com/open-telemetry/weaver/pull/1634) by @lmolkova)
 
 # [0.25.0] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Fix v2 attribute resolution so a `ref` inside an included group (`ref_group`) merges field-by-field instead of replacing the whole attribute. ([#TODO](https://github.com/open-telemetry/weaver/pull/TODO) by @lmolkova)
+
 # [0.25.0] - 2026-07-24
 
 - Use semantic conventions v2 for `weaver registry infer`. ([#1334](https://github.com/open-telemetry/weaver/pull/1334) by @ArthurSens)

--- a/crates/weaver_resolver/data/registry-test-v2-4-refinements/expected-attribute-catalog.json
+++ b/crates/weaver_resolver/data/registry-test-v2-4-refinements/expected-attribute-catalog.json
@@ -23,6 +23,37 @@
     "role": "identifying"
   },
   {
+    "name": "test.attr",
+    "type": "int",
+    "brief": "Test attribute",
+    "requirement_level": {
+      "conditionally_required": "on the base signal"
+    },
+    "stability": "stable"
+  },
+  {
+    "name": "test.attr",
+    "type": "int",
+    "brief": "Test attribute",
+    "examples": [
+      42
+    ],
+    "requirement_level": "recommended",
+    "stability": "stable"
+  },
+  {
+    "name": "test.attr",
+    "type": "int",
+    "brief": "Test attribute",
+    "examples": [
+      42
+    ],
+    "requirement_level": {
+      "conditionally_required": "on the base signal"
+    },
+    "stability": "stable"
+  },
+  {
     "name": "test.attr2",
     "type": "string",
     "brief": "Refined description attribute",

--- a/crates/weaver_resolver/data/registry-test-v2-4-refinements/expected-registry.json
+++ b/crates/weaver_resolver/data/registry-test-v2-4-refinements/expected-registry.json
@@ -8,7 +8,7 @@
       "stability": "stable",
       "attributes": [
         2,
-        5
+        8
       ],
       "name": "base.entity",
       "lineage": {
@@ -51,8 +51,8 @@
       "stability": "stable",
       "attributes": [
         0,
-        3,
-        6
+        6,
+        9
       ],
       "name": "entity.refined.entity",
       "lineage": {
@@ -134,7 +134,7 @@
       "brief": "Base metric",
       "stability": "stable",
       "attributes": [
-        1
+        3
       ],
       "metric_name": "base.metric",
       "instrument": "histogram",
@@ -150,8 +150,10 @@
             "inherited_fields": [
               "brief",
               "note",
-              "requirement_level",
               "stability"
+            ],
+            "locally_overridden_fields": [
+              "requirement_level"
             ]
           }
         },
@@ -176,8 +178,8 @@
       "brief": "Refined metric",
       "stability": "stable",
       "attributes": [
-        1,
-        7
+        5,
+        10
       ],
       "metric_name": "base.metric",
       "instrument": "histogram",
@@ -194,8 +196,11 @@
             "inherited_fields": [
               "brief",
               "note",
-              "requirement_level",
               "stability"
+            ],
+            "locally_overridden_fields": [
+              "examples",
+              "requirement_level"
             ]
           },
           "test.attr3": {
@@ -233,8 +238,8 @@
       "brief": "<synthetic v2>",
       "attributes": [
         1,
-        4,
-        7
+        7,
+        10
       ],
       "lineage": {
         "provenance": {
@@ -278,7 +283,7 @@
       "brief": "Test group",
       "stability": "stable",
       "attributes": [
-        1
+        3
       ],
       "lineage": {
         "provenance": {
@@ -291,8 +296,10 @@
             "inherited_fields": [
               "brief",
               "note",
-              "requirement_level",
               "stability"
+            ],
+            "locally_overridden_fields": [
+              "requirement_level"
             ]
           }
         }

--- a/crates/weaver_resolver/data/registry-test-v2-4-refinements/registry/v2-refinements.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-4-refinements/registry/v2-refinements.yaml
@@ -19,10 +19,19 @@ attribute_groups:
     brief: Test group
     stability: stable
     attributes:
+      # Base sets a non-default requirement level on test.attr.
       - ref: test.attr
+        requirement_level:
+          conditionally_required: "on the base signal"
   - id: test.refine.extras
     visibility: internal
     attributes:
+      # Re-refs test.attr with ONLY an example (no requirement_level). When this
+      # group is pulled into a refinement via `ref_group`, it must NOT reset the
+      # `conditionally_required` inherited from test.group above back to the
+      # `recommended` default.
+      - ref: test.attr
+        examples: [42]
       - ref: test.attr3
         requirement_level: recommended
 

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -871,32 +871,28 @@ fn resolve_inheritance_attrs_unified(
     for (parent_group_id, included_group) in include_groups {
         for parent_attr in included_group.iter() {
             let attr_id = parent_attr.spec.id();
-            match inherited_attrs.get_mut(&attr_id) {
-                Some(existing) => {
-                    existing.spec = resolve_inheritance_attr(
-                        &parent_attr.spec,
-                        &existing.spec,
-                        &mut existing.lineage,
-                    );
-                    existing.lineage.source_group = parent_group_id.to_owned();
-                }
-                None => {
-                    let lineage =
-                        AttributeLineage::inherit_from(parent_group_id, &parent_attr.spec);
-                    log::debug!(
-                        "Inheriting attribute {} from group {}, resolved to {:#?}",
-                        attr_id,
-                        parent_group_id,
-                        lineage.source_group
-                    );
-                    _ = inherited_attrs.insert(
-                        attr_id.clone(),
-                        AttrWithLineage {
-                            spec: parent_attr.spec.clone(),
-                            lineage,
-                        },
-                    );
-                }
+            if let Some(existing) = inherited_attrs.get_mut(&attr_id) {
+                existing.spec = resolve_inheritance_attr(
+                    &parent_attr.spec,
+                    &existing.spec,
+                    &mut existing.lineage,
+                );
+                existing.lineage.source_group = parent_group_id.to_owned();
+            } else {
+                let lineage = AttributeLineage::inherit_from(parent_group_id, &parent_attr.spec);
+                log::debug!(
+                    "Inheriting attribute {} from group {}, resolved to {:#?}",
+                    attr_id,
+                    parent_group_id,
+                    lineage.source_group
+                );
+                _ = inherited_attrs.insert(
+                    attr_id.clone(),
+                    AttrWithLineage {
+                        spec: parent_attr.spec.clone(),
+                        lineage,
+                    },
+                );
             }
         }
     }
@@ -1181,9 +1177,9 @@ mod tests {
     use crate::registry::resolve_inheritance_attrs_unified;
     use crate::registry::UnresolvedGroup;
     use crate::registry::UnresolvedRegistry;
-    use weaver_resolved_schema::attribute::UnresolvedAttribute;
     use crate::{WeaverResolver, WeaverResolverConfig};
     use std::sync::Arc;
+    use weaver_resolved_schema::attribute::UnresolvedAttribute;
 
     /// Settings for resolution tests.
     #[derive(Serialize, Deserialize, Default)]
@@ -1904,7 +1900,11 @@ groups:
         };
 
         // Lowest priority base (parent `extends`): sets conditionally_required.
-        let parent = vec![bare_ref("messaging.destination.name", Some(cond.clone()), None)];
+        let parent = vec![bare_ref(
+            "messaging.destination.name",
+            Some(cond.clone()),
+            None,
+        )];
         // Higher priority base (`ref_group`): only sets an example, no level.
         let included = vec![bare_ref(
             "messaging.destination.name",
@@ -1939,7 +1939,9 @@ groups:
                     "ref_group example override should still win"
                 );
             }
-            other => panic!("expected a Ref attribute, got {other:?}"),
+            other @ AttributeSpec::Id { .. } => {
+                panic!("expected a Ref attribute, got {other:?}")
+            }
         }
     }
 }

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -1180,6 +1180,7 @@ mod tests {
     use crate::{WeaverResolver, WeaverResolverConfig};
     use std::sync::Arc;
     use weaver_resolved_schema::attribute::UnresolvedAttribute;
+    use weaver_semconv::attribute::{AttributeSpec, Examples, RequirementLevel};
 
     /// Settings for resolution tests.
     #[derive(Serialize, Deserialize, Default)]
@@ -1866,11 +1867,11 @@ groups:
 
     fn bare_ref(
         id: &str,
-        requirement_level: Option<weaver_semconv::attribute::RequirementLevel>,
-        examples: Option<weaver_semconv::attribute::Examples>,
+        requirement_level: Option<RequirementLevel>,
+        examples: Option<Examples>,
     ) -> UnresolvedAttribute {
         UnresolvedAttribute {
-            spec: weaver_semconv::attribute::AttributeSpec::Ref {
+            spec: AttributeSpec::Ref {
                 r#ref: id.to_owned(),
                 brief: None,
                 examples,
@@ -1893,8 +1894,6 @@ groups:
     /// `ref`: unset fields inherit rather than replacing the whole spec.
     #[test]
     fn ref_group_bare_ref_preserves_inherited_requirement_level() {
-        use weaver_semconv::attribute::{AttributeSpec, Examples, RequirementLevel};
-
         let cond = RequirementLevel::ConditionallyRequired {
             text: "If span describes operation on a single message.".to_owned(),
         };

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -868,14 +868,6 @@ fn resolve_inheritance_attrs_unified(
     // their id in the resolved registry. This is useful for unit tests to
     // ensure that the resolved registry is easy to compare.
     let mut inherited_attrs: BTreeMap<String, AttrWithLineage> = BTreeMap::new();
-
-    // Inherit the attributes from all bases (parent signal + included groups),
-    // lowest priority first. When the same attribute id appears in more than one
-    // base, the higher-priority base overrides the lower one *field by field*:
-    // fields it leaves unset inherit from the lower-priority base instead of
-    // replacing the whole spec. This mirrors how inline `ref:` overrides are
-    // merged below, so a bare `ref:` inside a `ref_group` behaves the same as a
-    // bare inline `ref:`.
     for (parent_group_id, included_group) in include_groups {
         for parent_attr in included_group.iter() {
             let attr_id = parent_attr.spec.id();
@@ -1903,10 +1895,6 @@ groups:
     /// example must NOT reset the `requirement_level` inherited from a
     /// lower-priority base (`extends`). It must behave the same as a bare inline
     /// `ref`: unset fields inherit rather than replacing the whole spec.
-    ///
-    /// Regression for the messaging `destination.name` flip
-    /// (`conditionally_required` -> `recommended`) caused by resolving-then-
-    /// merging `ref_group` bases instead of merging their fields in place.
     #[test]
     fn ref_group_bare_ref_preserves_inherited_requirement_level() {
         use weaver_semconv::attribute::{AttributeSpec, Examples, RequirementLevel};

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -867,26 +867,45 @@ fn resolve_inheritance_attrs_unified(
     // Note: we use a BTreeMap to ensure that the attributes are sorted by
     // their id in the resolved registry. This is useful for unit tests to
     // ensure that the resolved registry is easy to compare.
-    let mut inherited_attrs = BTreeMap::new();
+    let mut inherited_attrs: BTreeMap<String, AttrWithLineage> = BTreeMap::new();
 
-    // Inherit the attributes from all included groups.
+    // Inherit the attributes from all bases (parent signal + included groups),
+    // lowest priority first. When the same attribute id appears in more than one
+    // base, the higher-priority base overrides the lower one *field by field*:
+    // fields it leaves unset inherit from the lower-priority base instead of
+    // replacing the whole spec. This mirrors how inline `ref:` overrides are
+    // merged below, so a bare `ref:` inside a `ref_group` behaves the same as a
+    // bare inline `ref:`.
     for (parent_group_id, included_group) in include_groups {
         for parent_attr in included_group.iter() {
             let attr_id = parent_attr.spec.id();
-            let lineage = AttributeLineage::inherit_from(parent_group_id, &parent_attr.spec);
-            log::debug!(
-                "Inheriting attribute {} from group {}, resolved to {:#?}",
-                attr_id,
-                parent_group_id,
-                lineage.source_group
-            );
-            _ = inherited_attrs.insert(
-                attr_id.clone(),
-                AttrWithLineage {
-                    spec: parent_attr.spec.clone(),
-                    lineage,
-                },
-            );
+            match inherited_attrs.get_mut(&attr_id) {
+                Some(existing) => {
+                    existing.spec = resolve_inheritance_attr(
+                        &parent_attr.spec,
+                        &existing.spec,
+                        &mut existing.lineage,
+                    );
+                    existing.lineage.source_group = parent_group_id.to_owned();
+                }
+                None => {
+                    let lineage =
+                        AttributeLineage::inherit_from(parent_group_id, &parent_attr.spec);
+                    log::debug!(
+                        "Inheriting attribute {} from group {}, resolved to {:#?}",
+                        attr_id,
+                        parent_group_id,
+                        lineage.source_group
+                    );
+                    _ = inherited_attrs.insert(
+                        attr_id.clone(),
+                        AttrWithLineage {
+                            spec: parent_attr.spec.clone(),
+                            lineage,
+                        },
+                    );
+                }
+            }
         }
     }
 
@@ -1167,8 +1186,10 @@ mod tests {
 
     use crate::attribute::AttributeCatalog;
     use crate::registry::cleanup_and_stabilize_catalog_and_registry;
+    use crate::registry::resolve_inheritance_attrs_unified;
     use crate::registry::UnresolvedGroup;
     use crate::registry::UnresolvedRegistry;
+    use weaver_resolved_schema::attribute::UnresolvedAttribute;
     use crate::{WeaverResolver, WeaverResolverConfig};
     use std::sync::Arc;
 
@@ -1853,5 +1874,84 @@ groups:
 
     fn to_json<T: Serialize + ?Sized>(value: &T) -> String {
         serde_json::to_string_pretty(value).unwrap()
+    }
+
+    fn bare_ref(
+        id: &str,
+        requirement_level: Option<weaver_semconv::attribute::RequirementLevel>,
+        examples: Option<weaver_semconv::attribute::Examples>,
+    ) -> UnresolvedAttribute {
+        UnresolvedAttribute {
+            spec: weaver_semconv::attribute::AttributeSpec::Ref {
+                r#ref: id.to_owned(),
+                brief: None,
+                examples,
+                tag: None,
+                requirement_level,
+                sampling_relevant: None,
+                note: None,
+                stability: None,
+                deprecated: None,
+                prefix: false,
+                annotations: None,
+                role: None,
+            },
+        }
+    }
+
+    /// A bare `ref` inside an included group (`ref_group`) that only narrows the
+    /// example must NOT reset the `requirement_level` inherited from a
+    /// lower-priority base (`extends`). It must behave the same as a bare inline
+    /// `ref`: unset fields inherit rather than replacing the whole spec.
+    ///
+    /// Regression for the messaging `destination.name` flip
+    /// (`conditionally_required` -> `recommended`) caused by resolving-then-
+    /// merging `ref_group` bases instead of merging their fields in place.
+    #[test]
+    fn ref_group_bare_ref_preserves_inherited_requirement_level() {
+        use weaver_semconv::attribute::{AttributeSpec, Examples, RequirementLevel};
+
+        let cond = RequirementLevel::ConditionallyRequired {
+            text: "If span describes operation on a single message.".to_owned(),
+        };
+
+        // Lowest priority base (parent `extends`): sets conditionally_required.
+        let parent = vec![bare_ref("messaging.destination.name", Some(cond.clone()), None)];
+        // Higher priority base (`ref_group`): only sets an example, no level.
+        let included = vec![bare_ref(
+            "messaging.destination.name",
+            None,
+            Some(Examples::String("MyTopic".to_owned())),
+        )];
+
+        let resolved = resolve_inheritance_attrs_unified(
+            "span.messaging.rocketmq.send.producer",
+            &[], // no inline `ref:` overrides on the refinement itself
+            vec![
+                ("messaging.attributes.common", parent.as_slice()),
+                ("messaging.rocketmq.attributes.common", included.as_slice()),
+            ],
+            None,
+        );
+
+        assert_eq!(resolved.len(), 1);
+        match &resolved[0].spec {
+            AttributeSpec::Ref {
+                requirement_level,
+                examples,
+                ..
+            } => {
+                assert_eq!(
+                    requirement_level,
+                    &Some(cond),
+                    "ref_group must not reset the inherited requirement_level"
+                );
+                assert!(
+                    matches!(examples, Some(Examples::String(s)) if s == "MyTopic"),
+                    "ref_group example override should still win"
+                );
+            }
+            other => panic!("expected a Ref attribute, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
```yaml
file_format: definition/2
attributes:
  - key: test.attr
    type: string
    brief: Test attribute
    stability: stable

metrics:
  - name: base.metric
    instrument: histogram
    unit: s
    brief: Base
    stability: stable
    attributes:
      - ref: test.attr
        requirement_level:
          conditionally_required: "on the base signal"

attribute_groups:
  - id: some.group
    visibility: internal 
    attributes:
      - ref: test.attr
        examples: ["MyExample"]

metric_refinements:
  - id: refined.metric
    ref: base.metric
    brief: Refined
    attributes:
      - ref_group: some.group
```

`test.attr` on `refined.metric`

|  | requirement_level | examples
-- | -- | --
Expected | conditionally_required | MyExample
Actual | recommended ❌ | MyExample

when we do `ref` on a refinement, we ignore missing properties, when we do `ref_group`, we use the resolved group with default values of missing properties. 
