### PR TITLE
Fix imported signals losing their per-signal attribute requirement_level/role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Fix signals imported from a dependency losing their per-signal attribute data. When several signals reference the same attribute with different `requirement_level` or `role`, each imported signal was re-pointed at whichever variant of the attribute was registered first. E.g. silently rewriting requirement levels or dropping `role: identifying` from imported entities. Each signal now references the attribute variant it actually declares. Per-name conflict resolution still applies to root-attribute provenance. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
+
 # [0.25.0] - 2026-07-24
 
 - Use semantic conventions v2 for `weaver registry infer`. ([#1334](https://github.com/open-telemetry/weaver/pull/1334) by @ArthurSens)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix signals imported from a dependency losing their per-signal attribute data. When several signals reference the same attribute with different `requirement_level` or `role`, each imported signal was re-pointed at whichever variant of the attribute was registered first. E.g. silently rewriting requirement levels or dropping `role: identifying` from imported entities. Each signal now references the attribute variant it actually declares. Per-name conflict resolution still applies to root-attribute provenance. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
+- Fix signals imported from a dependency losing their per-signal attribute data. When several signals reference the same attribute with different `requirement_level` or `role`, each imported signal was re-pointed at whichever variant of the attribute was registered first. E.g. silently rewriting requirement levels or dropping `role: identifying` from imported entities. Each signal now references the attribute variant it actually declares. Per-name conflict resolution still applies to root-attribute provenance. ([#1635](https://github.com/open-telemetry/weaver/pull/1635) by @jerbly)
 
 # [0.25.0] - 2026-07-24
 

--- a/crates/weaver_resolver/data/registry-test-published-1/expected-attribute-catalog.json
+++ b/crates/weaver_resolver/data/registry-test-published-1/expected-attribute-catalog.json
@@ -6,5 +6,22 @@
     "requirement_level": "required",
     "stability": "stable",
     "annotations": {}
+  },
+  {
+    "name": "a",
+    "type": "string",
+    "brief": "test a",
+    "requirement_level": "required",
+    "stability": "stable",
+    "annotations": {},
+    "role": "identifying"
+  },
+  {
+    "name": "a",
+    "type": "string",
+    "brief": "test a",
+    "requirement_level": "recommended",
+    "stability": "stable",
+    "annotations": {}
   }
 ]

--- a/crates/weaver_resolver/data/registry-test-published-1/expected-registry.json
+++ b/crates/weaver_resolver/data/registry-test-published-1/expected-registry.json
@@ -8,7 +8,7 @@
       "note": "an entity note",
       "stability": "stable",
       "attributes": [
-        0
+        1
       ],
       "name": "imported.entity.a",
       "lineage": {
@@ -26,7 +26,7 @@
       "note": "an event note",
       "stability": "stable",
       "attributes": [
-        0
+        2
       ],
       "name": "imported.event.a",
       "lineage": {

--- a/crates/weaver_resolver/data/registry-test-published-2/expected-attribute-catalog.json
+++ b/crates/weaver_resolver/data/registry-test-published-2/expected-attribute-catalog.json
@@ -20,5 +20,13 @@
     "requirement_level": "required",
     "stability": "stable",
     "annotations": {}
+  },
+  {
+    "name": "my.attr.1",
+    "type": "int",
+    "brief": "test attr 1",
+    "requirement_level": "recommended",
+    "stability": "stable",
+    "annotations": {}
   }
 ]

--- a/crates/weaver_resolver/data/registry-test-published-2/expected-registry.json
+++ b/crates/weaver_resolver/data/registry-test-published-2/expected-registry.json
@@ -8,7 +8,7 @@
       "note": "a group note",
       "stability": "stable",
       "attributes": [
-        2
+        3
       ],
       "annotations": {}
     },

--- a/crates/weaver_resolver/src/attribute.rs
+++ b/crates/weaver_resolver/src/attribute.rs
@@ -146,15 +146,21 @@ impl AttributeCatalog {
         // Make sure we pick the attribute from the *correct* version of a transitive dependency.
         new_attr = Self::upgrade_attribute_with_source(new_attr, cache_lookup)?;
 
-        // If we have a version conflict - resolve it.
-        let winning_attr = if let Some(existing) = self.root_attributes.get(&attr_name) {
+        // Return a ref to this group's own copy of the attribute. Different
+        // groups may reference the same attribute with different
+        // `requirement_level` or `role`, so we must not return a variant
+        // registered earlier by another group.
+        let attr_ref = self.attribute_ref(new_attr.attribute.clone());
+
+        // Separately, keep `root_attributes` (one entry per attribute name,
+        // used for provenance lookups) up to date. If the name was already
+        // registered, `resolve_conflict` decides which source wins.
+        let root_attr = if let Some(existing) = self.root_attributes.get(&attr_name) {
             resolve_conflict(&attr_name, new_attr, existing.clone())?
         } else {
             new_attr
         };
-
-        let attr_ref = self.attribute_ref(winning_attr.attribute.clone());
-        let _ = self.root_attributes.insert(attr_name, winning_attr);
+        let _ = self.root_attributes.insert(attr_name, root_attr);
 
         Ok(attr_ref)
     }


### PR DESCRIPTION
Regression in 0.25.0 (#1573): the dependency version conflict resolution added there also re-pointed each imported signal's attribute ref at the per-name conflict winner. Previously the ref was always created from the attribute the signal declares. When several signals reference the same attribute with different per-signal data, requirement levels were silently rewritten in either direction and `role: identifying` dropped from imported entities, so live-check failed valid telemetry (or passed invalid telemetry) against unchanged registries.

The fix restores the 0.24.2 behaviour: return the ref of the attribute the signal declares. It keeps #1573's conflict resolution for root-attribute provenance and version selection.

The two `registry-test-published-*` expected snapshots are regenerated: their old expectations encoded the bug.