### PR TITLE
Fix same dependency version reported as an unresolvable conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix two references to the same dependency version being reported as an unresolvable conflict. Version comparison parsed the semver of both URLs before considering whether they were the same URL, so a dependency declared without a `schema_url` — which gets a synthesized, version-less `https://<name>/unknown` — failed against itself. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
+- Fix two references to the same dependency version being reported as an unresolvable conflict. Version comparison parsed the semver of both URLs before considering whether they were the same URL, so a dependency declared without a `schema_url` — which gets a synthesized, version-less `https://<name>/unknown` — failed against itself. ([#1639](https://github.com/open-telemetry/weaver/pull/1639) by @jerbly)
 - Fix signals imported from a dependency losing their per-signal attribute data. When several signals reference the same attribute with different `requirement_level` or `role`, each imported signal was re-pointed at whichever variant of the attribute was registered first. E.g. silently rewriting requirement levels or dropping `role: identifying` from imported entities. Each signal now references the attribute variant it actually declares. Per-name conflict resolution still applies to root-attribute provenance. ([#1635](https://github.com/open-telemetry/weaver/pull/1635) by @jerbly)
 
 # [0.25.0] - 2026-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Fix two references to the same dependency version being reported as an unresolvable conflict. Version comparison parsed the semver of both URLs before considering whether they were the same URL, so a dependency declared without a `schema_url` — which gets a synthesized, version-less `https://<name>/unknown` — failed against itself. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
 - Fix signals imported from a dependency losing their per-signal attribute data. When several signals reference the same attribute with different `requirement_level` or `role`, each imported signal was re-pointed at whichever variant of the attribute was registered first. E.g. silently rewriting requirement levels or dropping `role: identifying` from imported entities. Each signal now references the attribute variant it actually declares. Per-name conflict resolution still applies to root-attribute provenance. ([#1635](https://github.com/open-telemetry/weaver/pull/1635) by @jerbly)
 
 # [0.25.0] - 2026-07-24

--- a/crates/weaver_resolver/src/conflict_strategy.rs
+++ b/crates/weaver_resolver/src/conflict_strategy.rs
@@ -25,6 +25,14 @@ pub(crate) struct UseLatestMajorVersion;
 
 impl DependencyVersionConflictStrategy for UseLatestMajorVersion {
     fn resolve_conflict(&self, url1: &SchemaUrl, url2: &SchemaUrl) -> Result<SchemaUrl, Error> {
+        // The same version seen twice is not a conflict, and saying so must not
+        // depend on parsing the version: a dependency declared without a
+        // `schema_url` gets a synthesized, version-less URL, which would
+        // otherwise fail `semver()` below and be reported as unresolvable
+        // against itself.
+        if url1 == url2 {
+            return Ok(url1.clone());
+        }
         if url1.name() != url2.name() {
             return Err(Error::AmbiguousReference {
                 r#ref: format!("registry mismatch: {} vs {}", url1.name(), url2.name()),
@@ -62,6 +70,21 @@ mod tests {
 
         assert_eq!(strategy.resolve_conflict(&u1, &u2).unwrap(), u2);
         assert_eq!(strategy.resolve_conflict(&u2, &u1).unwrap(), u2);
+    }
+
+    /// The same registry seen twice needs no resolution, and must not require a
+    /// parseable version to say so: a dependency declared without a `schema_url`
+    /// gets a synthesized, version-less URL (`https://<name>/unknown`), and two
+    /// sightings of it were reported as a conflict rather than as one registry.
+    #[test]
+    fn test_resolve_conflict_identical_urls_without_semver() {
+        let strategy = UseLatestMajorVersion;
+        let unknown = SchemaUrl::try_from_name_version("otel", "unknown").unwrap();
+
+        assert_eq!(
+            strategy.resolve_conflict(&unknown, &unknown).unwrap(),
+            unknown
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two references to the same version need no resolution, and saying so should not depend on parsing the version.

Repro: a registry whose manifest omits `schema_url` on a dependency entry fails `weaver registry check` with `Ambiguous reference ... https://otel/unknown and https://otel/unknown`.
