### PR TITLE
Fix live-check admin server (and /stop) shutting down 60s after startup

### DIFF
--- a/src/registry/otlp/mod.rs
+++ b/src/registry/otlp/mod.rs
@@ -525,20 +525,32 @@ async fn spawn_http_admin_handler(
                 .with_state(state);
 
             let _ = tasks.spawn(async move {
-                // Bounded so a stalled client can't hang the CLI forever.
-                let result = tokio::time::timeout(ADMIN_REQUEST_TIMEOUT, async {
-                    axum::serve(listener, app)
-                        .with_graceful_shutdown(async {
-                            let _ = admin_shutdown_rx.await;
-                        })
-                        .await
-                })
-                .await;
+                // ADMIN_REQUEST_TIMEOUT bounds only the graceful-shutdown drain
+                // (after the stop signal), not the server's whole lifetime.
+                // Wrapping the entire `serve` in the timeout would tear the admin
+                // server (and `/stop`) down that long after startup, so a `/stop`
+                // sent later in a long-running live-check could never stop it.
+                let (drain_started_tx, drain_started_rx) = oneshot::channel();
+                let serve = axum::serve(listener, app).with_graceful_shutdown(async move {
+                    let _ = admin_shutdown_rx.await;
+                    let _ = drain_started_tx.send(());
+                });
 
-                match result {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => warn!("Admin HTTP server error: {e}"),
-                    Err(_) => warn!(
+                let drain_deadline = async {
+                    if drain_started_rx.await.is_ok() {
+                        sleep(ADMIN_REQUEST_TIMEOUT).await;
+                    } else {
+                        std::future::pending::<()>().await;
+                    }
+                };
+
+                tokio::select! {
+                    result = serve => {
+                        if let Err(e) = result {
+                            warn!("Admin HTTP server error: {e}");
+                        }
+                    }
+                    _ = drain_deadline => warn!(
                         "Admin HTTP server graceful shutdown did not complete within \
                          {ADMIN_REQUEST_TIMEOUT:?}; a client may not have finished reading \
                          a response"


### PR DESCRIPTION
Fixes #1644 

`registry live-check`'s admin HTTP server (serving `/health` and `/stop`) is torn
down roughly **60 seconds after startup**, regardless of activity. After that,
`POST /stop` gets no response and can no longer stop the live-check. If OTLP data
is still arriving — so `--inactivity-timeout` never fires — the ingestion loop
never terminates, no report is ever written, and the process hangs indefinitely.

This is a regression introduced in #1632: bounding the *whole* admin server in a
60s timeout means any live-check session longer than a minute (instrument an app,
exercise it, then `/stop`) can't be stopped via `/stop`.

## Root cause

In `spawn_http_admin_handler`, the entire server future was wrapped in the request
timeout:

```rust
let result = tokio::time::timeout(ADMIN_REQUEST_TIMEOUT, async {
    axum::serve(listener, app)
        .with_graceful_shutdown(async { let _ = admin_shutdown_rx.await; })
        .await
})
.await;
```

`tokio::time::timeout(60s, serve_future)` bounds the *accept* phase, not just the
graceful-shutdown drain — so the server (and `/stop`) is dropped 60s after it
starts. The intent (per the `ADMIN_REQUEST_TIMEOUT` doc comment — "how long the
admin server's graceful shutdown gets to finish delivering it") was to bound only
the drain.
