### PR TITLE
Failing tests: dependency provenance and mandatory schema_url

### DIFF
--- a/crates/weaver_resolver/data/correct-provenance/base/manifest.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/base/manifest.yaml
@@ -1,0 +1,3 @@
+name: base
+description: Registry defining the `host.id` attribute and a metric that uses it.
+schema_url: https://example.com/base/1.0.0

--- a/crates/weaver_resolver/data/correct-provenance/base/semconv.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/base/semconv.yaml
@@ -1,0 +1,15 @@
+file_format: definition/2
+attributes:
+  - key: host.id
+    type: string
+    stability: stable
+    brief: Unique host ID.
+    examples: ["abc123"]
+metrics:
+  - name: base.uptime
+    brief: Uptime metric defined in base.
+    instrument: gauge
+    unit: "s"
+    stability: stable
+    attributes:
+      - ref: host.id

--- a/crates/weaver_resolver/data/correct-provenance/main/imports.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/main/imports.yaml
@@ -1,0 +1,9 @@
+# `host.id` is defined only in base, but reaches main via both dependency
+# paths: directly (`base.uptime`) and through middle's re-export
+# (`middle.throughput`). The re-export must preserve base's provenance so
+# both paths agree on the attribute's origin schema_url.
+file_format: definition/2
+imports:
+  metrics:
+    - base.uptime
+    - middle.throughput

--- a/crates/weaver_resolver/data/correct-provenance/main/manifest.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/main/manifest.yaml
@@ -1,0 +1,10 @@
+name: main
+description: Registry depending on both base and middle, importing a metric from each.
+schema_url: https://example.com/main/0.1.0
+dependencies:
+  - name: middle
+    schema_url: https://example.com/middle/0.1.0
+    registry_path: data/correct-provenance/middle
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/correct-provenance/base

--- a/crates/weaver_resolver/data/correct-provenance/middle/manifest.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/middle/manifest.yaml
@@ -1,0 +1,7 @@
+name: middle
+description: Registry depending on base, with a metric referencing `host.id`.
+schema_url: https://example.com/middle/0.1.0
+dependencies:
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/correct-provenance/base

--- a/crates/weaver_resolver/data/correct-provenance/middle/semconv.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/middle/semconv.yaml
@@ -1,0 +1,9 @@
+file_format: definition/2
+metrics:
+  - name: middle.throughput
+    brief: Throughput metric defined in middle, using `host.id` from the base dependency.
+    instrument: gauge
+    unit: "By"
+    stability: stable
+    attributes:
+      - ref: host.id

--- a/crates/weaver_resolver/data/mandatory-schema-url/dep/manifest.yaml
+++ b/crates/weaver_resolver/data/mandatory-schema-url/dep/manifest.yaml
@@ -1,0 +1,3 @@
+name: dep
+description: Dependency registry defining a metric.
+schema_url: https://example.com/dep/1.0.0

--- a/crates/weaver_resolver/data/mandatory-schema-url/dep/semconv.yaml
+++ b/crates/weaver_resolver/data/mandatory-schema-url/dep/semconv.yaml
@@ -1,0 +1,15 @@
+file_format: definition/2
+attributes:
+  - key: dep.id
+    type: string
+    stability: stable
+    brief: Unique ID.
+    examples: ["abc123"]
+metrics:
+  - name: dep.uptime
+    brief: Uptime metric defined in dep.
+    instrument: gauge
+    unit: "s"
+    stability: stable
+    attributes:
+      - ref: dep.id

--- a/crates/weaver_resolver/data/mandatory-schema-url/main/imports.yaml
+++ b/crates/weaver_resolver/data/mandatory-schema-url/main/imports.yaml
@@ -1,0 +1,3 @@
+imports:
+  metrics:
+    - dep.uptime

--- a/crates/weaver_resolver/data/mandatory-schema-url/main/manifest.yaml
+++ b/crates/weaver_resolver/data/mandatory-schema-url/main/manifest.yaml
@@ -1,0 +1,6 @@
+name: main
+description: Registry whose dependency declaration omits the mandatory `schema_url`.
+schema_url: https://example.com/main/0.1.0
+dependencies:
+  - name: dep
+    registry_path: data/mandatory-schema-url/dep

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -1757,6 +1757,108 @@ groups:
     }
 
     #[test]
+    fn test_imported_attribute_keeps_origin_provenance() -> Result<(), weaver_semconv::Error> {
+        // `main` imports one metric from `base` and one from `middle`; both
+        // use `host.id`, which is defined only in `base` (a dependency of
+        // `middle`). Middle's re-export of `host.id` must keep base's
+        // provenance so both paths agree on the attribute's origin and the
+        // schema resolves cleanly.
+        //
+        // Currently fails with `AmbiguousReference`: the re-export is stamped
+        // with middle's schema_url instead of base's, so conflict resolution
+        // sees two different registry names for the same attribute.
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/correct-provenance/main".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let config = WeaverResolverConfig::default();
+        let mut resolver = WeaverResolver::new(config);
+
+        let resolved = match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+            WResult::Ok(r) | WResult::OkWithNFEs(r, _) => r.into_v1().unwrap(),
+            WResult::FatalErr(e) => panic!("Failed to resolve schema: {e}"),
+        };
+
+        let (attr, _) = resolved
+            .catalog
+            .root_attribute("host.id")
+            .expect("host.id not found in catalog");
+        assert_eq!(attr.brief, "Unique host ID.");
+        Ok(())
+    }
+
+    #[test]
+    fn test_upgraded_group_keeps_winning_version_provenance(
+    ) -> Result<(), weaver_semconv::Error> {
+        // `main` imports `c.metric.1` via A (which pins C v1.1) and
+        // `c.span.2` via B (which pins C v1.2). The compatible version
+        // conflict resolves in favor of C v1.2 and the attribute catalog is
+        // upgraded accordingly (`c.attr1` reports the v1.2 brief, as covered
+        // by test_standalone_vs_graph_provenance_immutability). The group
+        // must be upgraded consistently: `metric.c.metric.1` should carry
+        // C v1.2's definition and provenance.
+        //
+        // Currently fails: the metric group keeps C v1.1's body and
+        // provenance while its attribute is upgraded to v1.2, leaving the
+        // resolved schema internally inconsistent.
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/compatible-version-conflict/main".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let config = WeaverResolverConfig::default();
+        let mut resolver = WeaverResolver::new(config);
+
+        let resolved = match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+            WResult::Ok(r) | WResult::OkWithNFEs(r, _) => r.into_v1().unwrap(),
+            WResult::FatalErr(e) => panic!("Failed to resolve schema: {e}"),
+        };
+
+        let metrics = resolved.groups(GroupType::Metric);
+        let metric = metrics
+            .get("metric.c.metric.1")
+            .expect("metric.c.metric.1 not found");
+        let provenance = metric.provenance().expect("metric.c.metric.1 has no lineage");
+        assert_eq!(
+            provenance.schema_url.to_string(),
+            "https://example.com/c/1.2.0"
+        );
+        assert_eq!(metric.brief, "Metric 1 in C v1.2 (updated)");
+        Ok(())
+    }
+
+    #[test]
+    fn test_dependency_without_schema_url_is_rejected() {
+        // `main`'s manifest declares its dependency with only `name` and
+        // `registry_path`. `schema_url` is mandatory for dependencies — it is
+        // the identity that provenance and version-conflict resolution key
+        // on — so this must fail with an error naming the offending
+        // dependency.
+        //
+        // Currently fails: the missing `schema_url` is silently replaced
+        // with a synthesized URL with version "unknown" and resolution
+        // succeeds.
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/mandatory-schema-url/main".to_owned(),
+        };
+        let err_msg = match RegistryRepo::try_new(None, &registry_path, &mut vec![]) {
+            Err(e) => e.to_string(),
+            Ok(registry_repo) => {
+                let mut resolver = WeaverResolver::new(WeaverResolverConfig::default());
+                match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+                    WResult::Ok(_) | WResult::OkWithNFEs(_, _) => panic!(
+                        "expected an error for the dependency missing 'schema_url', but resolution succeeded"
+                    ),
+                    WResult::FatalErr(e) => e.to_string(),
+                }
+            }
+        };
+        assert!(
+            err_msg.contains("schema_url") && err_msg.contains("dep"),
+            "error should name the dependency missing 'schema_url'; got: {err_msg}"
+        );
+    }
+
+    #[test]
     fn test_standalone_vs_graph_provenance_immutability() -> Result<(), weaver_semconv::Error> {
         // 1. Setup a single WeaverResolver instance with overrides pointing to compatible-version-conflict.
         let mut config = WeaverResolverConfig::default();

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -1788,8 +1788,7 @@ groups:
     }
 
     #[test]
-    fn test_upgraded_group_keeps_winning_version_provenance(
-    ) -> Result<(), weaver_semconv::Error> {
+    fn test_upgraded_group_keeps_winning_version_provenance() -> Result<(), weaver_semconv::Error> {
         // `main` imports `c.metric.1` via A (which pins C v1.1) and
         // `c.span.2` via B (which pins C v1.2). The compatible version
         // conflict resolves in favor of C v1.2 and the attribute catalog is
@@ -1817,7 +1816,9 @@ groups:
         let metric = metrics
             .get("metric.c.metric.1")
             .expect("metric.c.metric.1 not found");
-        let provenance = metric.provenance().expect("metric.c.metric.1 has no lineage");
+        let provenance = metric
+            .provenance()
+            .expect("metric.c.metric.1 has no lineage");
         assert_eq!(
             provenance.schema_url.to_string(),
             "https://example.com/c/1.2.0"


### PR DESCRIPTION
Three intentionally-red tests in `weaver_resolver` pinning down expected behavior. Each fails until the corresponding fix lands — the CI failure on this PR is intentional.

### 1. Imported attributes must keep their origin provenance

`main` imports a metric from `base` and one from `middle`; both use `host.id`, which is defined only in `base` (a dependency of `middle`). Middle's re-export is stamped with middle's schema_url instead of base's, so resolution fails with `AmbiguousReference`. Fixture: `crates/weaver_resolver/data/correct-provenance/`.

```
cargo test -p weaver_resolver test_imported_attribute_keeps_origin_provenance
```

### 2. Upgraded groups must carry the winning version's definition and provenance

The `compatible-version-conflict` fixture resolves C v1.1 vs v1.2 in favour of v1.2 for the attribute catalog, but `metric.c.metric.1` keeps v1.1's body and provenance — the resolved schema is internally inconsistent.

```
cargo test -p weaver_resolver test_upgraded_group_keeps_winning_version_provenance
```

### 3. `schema_url` is mandatory for dependencies

A dependency declared with only `name` + `registry_path` currently gets a synthesized schema URL with version `unknown` and resolves silently. It must instead fail with a useful error naming the offending dependency. Fixture: `crates/weaver_resolver/data/mandatory-schema-url/`.

```
cargo test -p weaver_resolver test_dependency_without_schema_url_is_rejected
```