### PR TITLE
Fix imported attributes losing their origin registry provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Fix imported attributes losing their origin registry provenance ([#1649](https://github.com/open-telemetry/weaver/issues/1649))
 - Fix signals imported from a dependency losing their per-signal attribute data. When several signals reference the same attribute with different `requirement_level` or `role`, each imported signal was re-pointed at whichever variant of the attribute was registered first. E.g. silently rewriting requirement levels or dropping `role: identifying` from imported entities. Each signal now references the attribute variant it actually declares. Per-name conflict resolution still applies to root-attribute provenance. ([#1635](https://github.com/open-telemetry/weaver/pull/1635) by @jerbly)
 
 # [0.25.0] - 2026-07-24

--- a/crates/weaver_resolver/data/correct-provenance/base/manifest.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/base/manifest.yaml
@@ -1,0 +1,3 @@
+name: base
+description: Registry defining the `host.id` attribute and a metric that uses it.
+schema_url: https://example.com/base/1.0.0

--- a/crates/weaver_resolver/data/correct-provenance/base/semconv.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/base/semconv.yaml
@@ -1,0 +1,15 @@
+file_format: definition/2
+attributes:
+  - key: host.id
+    type: string
+    stability: stable
+    brief: Unique host ID.
+    examples: ["abc123"]
+metrics:
+  - name: base.uptime
+    brief: Uptime metric defined in base.
+    instrument: gauge
+    unit: "s"
+    stability: stable
+    attributes:
+      - ref: host.id

--- a/crates/weaver_resolver/data/correct-provenance/main/imports.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/main/imports.yaml
@@ -1,0 +1,9 @@
+# `host.id` is defined only in base, but reaches main via both dependency
+# paths: directly (`base.uptime`) and through middle's re-export
+# (`middle.throughput`). The re-export must preserve base's provenance so
+# both paths agree on the attribute's origin schema_url.
+file_format: definition/2
+imports:
+  metrics:
+    - base.uptime
+    - middle.throughput

--- a/crates/weaver_resolver/data/correct-provenance/main/manifest.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/main/manifest.yaml
@@ -1,0 +1,10 @@
+name: main
+description: Registry depending on both base and middle, importing a metric from each.
+schema_url: https://example.com/main/0.1.0
+dependencies:
+  - name: middle
+    schema_url: https://example.com/middle/0.1.0
+    registry_path: data/correct-provenance/middle
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/correct-provenance/base

--- a/crates/weaver_resolver/data/correct-provenance/middle/manifest.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/middle/manifest.yaml
@@ -1,0 +1,7 @@
+name: middle
+description: Registry depending on base, with a metric referencing `host.id`.
+schema_url: https://example.com/middle/0.1.0
+dependencies:
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/correct-provenance/base

--- a/crates/weaver_resolver/data/correct-provenance/middle/semconv.yaml
+++ b/crates/weaver_resolver/data/correct-provenance/middle/semconv.yaml
@@ -1,0 +1,9 @@
+file_format: definition/2
+metrics:
+  - name: middle.throughput
+    brief: Throughput metric defined in middle, using `host.id` from the base dependency.
+    instrument: gauge
+    unit: "By"
+    stability: stable
+    attributes:
+      - ref: host.id

--- a/crates/weaver_resolver/src/attribute.rs
+++ b/crates/weaver_resolver/src/attribute.rs
@@ -562,31 +562,40 @@ impl AttributeLookup for V1Schema {
     fn lookup_attribute(&self, key: &str) -> Result<Option<AttributeWithSource>, Error> {
         if let Some((attr, group_id)) = self.catalog.root_attribute(key) {
             // We encode pure schema_url dependencies with magic strings in V1.
-            let group = if let Some(schema_name) = group_id.strip_prefix("v2_dependency.") {
-                self.registry.groups.iter().find(|g| {
-                    if let Some(prov) = g.provenance() {
-                        prov.schema_url.name() == schema_name
-                    } else {
-                        false
-                    }
-                })
-            } else {
-                self.registry.groups.iter().find(|g| g.id == group_id)
-            };
-            let source = if let Some(g) = group {
-                if let Some(prov) = g.provenance() {
-                    AttributeSource::Dependency {
-                        schema_url: prov.schema_url.clone(),
-                    }
-                } else {
-                    AttributeSource::Local {
+            let source = if let Some(schema_name) = group_id.strip_prefix("v2_dependency.") {
+                // The attribute originates in one of this schema's own
+                // dependencies. That registry may not have contributed any
+                // whole group to this schema (e.g. only an attribute was
+                // referenced), so recover the full schema URL from the
+                // dependency list first and only fall back to the provenance
+                // of an imported group.
+                self.dependencies
+                    .iter()
+                    .find(|url| url.name() == schema_name)
+                    .cloned()
+                    .or_else(|| {
+                        self.registry.groups.iter().find_map(|g| {
+                            g.provenance()
+                                .filter(|prov| prov.schema_url.name() == schema_name)
+                                .map(|prov| prov.schema_url)
+                        })
+                    })
+                    .map(|schema_url| AttributeSource::Dependency { schema_url })
+                    .unwrap_or_else(|| AttributeSource::Local {
                         group_id: group_id.to_owned(),
-                    }
-                }
+                    })
             } else {
-                AttributeSource::Local {
-                    group_id: group_id.to_owned(),
-                }
+                self.registry
+                    .groups
+                    .iter()
+                    .find(|g| g.id == group_id)
+                    .and_then(|g| g.provenance())
+                    .map(|prov| AttributeSource::Dependency {
+                        schema_url: prov.schema_url,
+                    })
+                    .unwrap_or_else(|| AttributeSource::Local {
+                        group_id: group_id.to_owned(),
+                    })
             };
             return Ok(Some(AttributeWithSource {
                 attribute: attr.clone(),

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -413,35 +413,34 @@ fn find_attribute_source(
     my_schema_url: &SchemaUrl,
 ) -> AttributeSource {
     if let Some((_, source_group_id)) = schema.catalog().root_attribute(attr_name) {
-        let group = if let Some(schema_name) = source_group_id.strip_prefix("v2_dependency.") {
-            schema.registry.groups.iter().find(|g| {
-                if let Some(prov) = g.provenance() {
-                    prov.schema_url.name() == schema_name
-                } else {
-                    false
-                }
-            })
+        let schema_url = if let Some(schema_name) = source_group_id.strip_prefix("v2_dependency.") {
+            // The attribute originates in one of `schema`'s own dependencies.
+            // That registry may not have contributed any whole group to
+            // `schema` (e.g. only an attribute was referenced), so recover
+            // the full schema URL from the dependency list first and only
+            // fall back to the provenance of an imported group.
+            schema
+                .dependencies
+                .iter()
+                .find(|url| url.name() == schema_name)
+                .cloned()
+                .or_else(|| {
+                    schema.registry.groups.iter().find_map(|g| {
+                        g.provenance()
+                            .filter(|prov| prov.schema_url.name() == schema_name)
+                            .map(|prov| prov.schema_url)
+                    })
+                })
         } else {
             schema
                 .registry
                 .groups
                 .iter()
                 .find(|g| g.id == *source_group_id)
+                .and_then(|g| g.provenance().map(|prov| prov.schema_url))
         };
-        if let Some(group) = group {
-            if let Some(prov) = group.provenance() {
-                AttributeSource::Dependency {
-                    schema_url: prov.schema_url.clone(),
-                }
-            } else {
-                AttributeSource::Dependency {
-                    schema_url: my_schema_url.clone(),
-                }
-            }
-        } else {
-            AttributeSource::Dependency {
-                schema_url: my_schema_url.clone(),
-            }
+        AttributeSource::Dependency {
+            schema_url: schema_url.unwrap_or_else(|| my_schema_url.clone()),
         }
     } else {
         // Fallback: search in all groups to find where this attribute came from

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -1757,6 +1757,33 @@ groups:
     }
 
     #[test]
+    fn test_imported_attribute_keeps_origin_provenance() -> Result<(), weaver_semconv::Error> {
+        // `main` imports one metric from `base` and one from `middle`; both
+        // use `host.id`, which is defined only in `base` (a dependency of
+        // `middle`). Middle's re-export of `host.id` must keep base's
+        // provenance so both paths agree on the attribute's origin and the
+        // schema resolves cleanly.
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/correct-provenance/main".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let config = WeaverResolverConfig::default();
+        let mut resolver = WeaverResolver::new(config);
+
+        let resolved = match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+            WResult::Ok(r) | WResult::OkWithNFEs(r, _) => r.into_v1().unwrap(),
+            WResult::FatalErr(e) => panic!("Failed to resolve schema: {e}"),
+        };
+
+        let (attr, _) = resolved
+            .catalog
+            .root_attribute("host.id")
+            .expect("host.id not found in catalog");
+        assert_eq!(attr.brief, "Unique host ID.");
+        Ok(())
+    }
+
+    #[test]
     fn test_standalone_vs_graph_provenance_immutability() -> Result<(), weaver_semconv::Error> {
         // 1. Setup a single WeaverResolver instance with overrides pointing to compatible-version-conflict.
         let mut config = WeaverResolverConfig::default();


### PR DESCRIPTION
Fixes case 1 of #1646 (`test_imported_attribute_keeps_origin_provenance`, included here with its fixture).

## Problem

With a dependency chain `main -> middle -> base`, where `middle` defines a metric referencing an attribute defined only in `base`, resolving `main` (which imports one metric from each dependency) fails:

```
Ambiguous reference 'host.id' found in multiple dependencies with different
SchemaURLs: https://example.com/base/1.0.0 and https://example.com/middle/0.1.0
```

`middle`'s resolved schema correctly records the attribute's origin (`source_group: v2_dependency.example.com/base`), but when `main` consumes it, the resolver recovers the full origin schema URL by scanning `middle`'s resolved groups for one carrying `base`'s provenance. If `base` contributed no whole group to `middle` — only an attribute — the scan misses and the attribute is stamped with `middle`'s own schema URL. The same attribute then reaches `main` under two different registry names, which conflict resolution rejects as ambiguous.

## Fix

Recover the origin schema URL from the resolved schema's `dependencies` list first (matching by registry name, exactly as the v1→v2 conversion in `weaver_resolved_schema` already does), and only fall back to the group-provenance scan. Applied to both lookup sites: `find_attribute_source` in `dependency.rs` and `AttributeLookup for V1Schema` in `attribute.rs`.

## Testing

- New fixture `crates/weaver_resolver/data/correct-provenance/` modeling the shape above.
- `cargo test -p weaver_resolver test_imported_attribute_keeps_origin_provenance` — red before this fix, green after.
- Full workspace test suite passes.