### PR TITLE
Fix imported groups keeping the losing version's definition and provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix imported attributes losing their origin registry provenance ([#1649](https://github.com/open-telemetry/weaver/issues/1649))
+- Fix imported groups keeping the losing version's definition and provenance ([#1650](https://github.com/open-telemetry/weaver/issues/1650) by @jerbly)
+- Fix imported attributes losing their origin registry provenance ([#1649](https://github.com/open-telemetry/weaver/issues/1649) by @jerbly)
 - Fix signals imported from a dependency losing their per-signal attribute data. When several signals reference the same attribute with different `requirement_level` or `role`, each imported signal was re-pointed at whichever variant of the attribute was registered first. E.g. silently rewriting requirement levels or dropping `role: identifying` from imported entities. Each signal now references the attribute variant it actually declares. Per-name conflict resolution still applies to root-attribute provenance. ([#1635](https://github.com/open-telemetry/weaver/pull/1635) by @jerbly)
 
 # [0.25.0] - 2026-07-24

--- a/crates/weaver_resolver/data/compatible-version-conflict-published/main/manifest.yaml
+++ b/crates/weaver_resolver/data/compatible-version-conflict-published/main/manifest.yaml
@@ -1,0 +1,8 @@
+name: main
+description: Main Registry
+schema_url: https://example.com/main/0.1.0
+dependencies:
+  - schema_url: https://example.com/a/0.1.0
+    registry_path: data/compatible-version-conflict-published/registry_a_published
+  - schema_url: https://example.com/b/0.1.0
+    registry_path: data/compatible-version-conflict-published/registry_b

--- a/crates/weaver_resolver/data/compatible-version-conflict-published/main/semconv.yaml
+++ b/crates/weaver_resolver/data/compatible-version-conflict-published/main/semconv.yaml
@@ -1,0 +1,6 @@
+file_format: definition/2
+imports:
+  metrics:
+    - c.metric.1
+  spans:
+    - c.span.2

--- a/crates/weaver_resolver/data/compatible-version-conflict-published/registry_a_published/manifest.yaml
+++ b/crates/weaver_resolver/data/compatible-version-conflict-published/registry_a_published/manifest.yaml
@@ -1,0 +1,5 @@
+file_format: manifest/2.0
+schema_url: https://example.com/a/0.1.0
+description: Registry A, published as a resolved schema (resolved against C v1.1).
+stability: development
+resolved_registry_uri: resolved.yaml

--- a/crates/weaver_resolver/data/compatible-version-conflict-published/registry_a_published/resolved.yaml
+++ b/crates/weaver_resolver/data/compatible-version-conflict-published/registry_a_published/resolved.yaml
@@ -1,0 +1,34 @@
+file_format: resolved/2.0
+schema_url: https://example.com/a/0.1.0
+dependencies:
+  - https://example.com/c/1.1.0
+attribute_catalog:
+- key: c.attr1
+  type: string
+  brief: Attribute 1 from C v1.1
+  stability: stable
+  provenance:
+    source: 0
+registry:
+  attributes:
+  - 0
+  attribute_groups: []
+  spans: []
+  events: []
+  entities: []
+  metrics:
+  - name: c.metric.1
+    instrument: counter
+    unit: '1'
+    brief: Metric 1 in C v1.1
+    stability: stable
+    attributes:
+    - base: 0
+      requirement_level: recommended
+    provenance:
+      source: 0
+refinements:
+  spans: []
+  metrics: []
+  events: []
+  entities: []

--- a/crates/weaver_resolver/data/compatible-version-conflict-published/registry_b/manifest.yaml
+++ b/crates/weaver_resolver/data/compatible-version-conflict-published/registry_b/manifest.yaml
@@ -1,0 +1,6 @@
+name: registry_b
+description: Registry B
+schema_url: https://example.com/b/0.1.0
+dependencies:
+  - schema_url: https://example.com/c/1.2.0
+    registry_path: data/compatible-version-conflict-published/registry_c_v1_2

--- a/crates/weaver_resolver/data/compatible-version-conflict-published/registry_b/semconv.yaml
+++ b/crates/weaver_resolver/data/compatible-version-conflict-published/registry_b/semconv.yaml
@@ -1,0 +1,4 @@
+file_format: definition/2
+imports:
+  spans:
+    - c.span.2

--- a/crates/weaver_resolver/data/compatible-version-conflict-published/registry_c_v1_2/manifest.yaml
+++ b/crates/weaver_resolver/data/compatible-version-conflict-published/registry_c_v1_2/manifest.yaml
@@ -1,0 +1,3 @@
+name: registry_c
+description: Registry C v1.2
+schema_url: https://example.com/c/1.2.0

--- a/crates/weaver_resolver/data/compatible-version-conflict-published/registry_c_v1_2/semconv.yaml
+++ b/crates/weaver_resolver/data/compatible-version-conflict-published/registry_c_v1_2/semconv.yaml
@@ -1,0 +1,29 @@
+file_format: definition/2
+attributes:
+  - key: c.attr1
+    type: string
+    brief: Attribute 1 from C v1.2 (updated)
+    stability: stable
+  - key: c.attr2
+    type: string
+    brief: Attribute 2 from C v1.2 (new)
+    stability: stable
+
+metrics:
+  - name: c.metric.1
+    brief: Metric 1 in C v1.2 (updated)
+    unit: "1"
+    instrument: counter
+    stability: stable
+    attributes:
+      - ref: c.attr1
+
+spans:
+  - type: c.span.2
+    kind: client
+    brief: Span 2 in C v1.2 (new)
+    stability: stable
+    name:
+      note: "c.span.2"
+    attributes:
+      - ref: c.attr2

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -368,65 +368,29 @@ impl ImportableDependency for V1Schema {
                     continue;
                 }
             }
-            let mut g = g.clone();
-
-            // The group may originate in a transitive dependency (its
-            // lineage provenance points there rather than at `self`). When
-            // graph-wide version conflict resolution chose a newer
-            // compatible version of that origin registry, take the group's
-            // definition from the chosen version so its body, lineage, and
-            // attributes stay consistent with the upgraded attribute
-            // catalog.
-            let origin_url = g
-                .provenance()
-                .map(|prov| prov.schema_url)
-                .unwrap_or_else(|| my_schema_url.clone());
-            let upgraded_origin = cache_lookup
-                .chosen_version(origin_url.name())
-                .filter(|chosen_url| **chosen_url != origin_url)
-                .filter(|chosen_url| {
-                    UseLatestMajorVersion
-                        .resolve_conflict(&origin_url, chosen_url)
-                        .is_ok_and(|winning_url| winning_url == **chosen_url)
-                })
-                .and_then(|chosen_url| {
-                    cache_lookup
-                        .lookup_schema(chosen_url)
-                        .map(|schema| (schema, chosen_url.clone()))
-                });
-            let (source_schema, source_url) = match &upgraded_origin {
-                Some((schema, chosen_url)) => {
-                    match schema
-                        .as_v1()
-                        .and_then(|v1| v1.registry.groups.iter().find(|ug| ug.id == g.id))
-                    {
-                        Some(upgraded_group) => {
-                            g = upgraded_group.clone();
-                            (schema.as_v1().expect("checked above"), chosen_url)
-                        }
-                        // The chosen registry no longer defines this group
-                        // (or is not a V1 schema): keep the copy we have.
-                        None => (self, &my_schema_url),
-                    }
-                }
-                None => (self, &my_schema_url),
-            };
-
-            let mut attributes = vec![];
-            for a in g
-                .attributes
-                .iter()
-                .filter_map(|ar| source_schema.catalog().attribute(ar))
+            let g = if let Some(upgraded) =
+                upgrade_imported_group(g, &my_schema_url, attribute_catalog, cache_lookup)?
             {
-                let source = find_attribute_source(source_schema, &a.name, source_url);
-                let ar = attribute_catalog.attribute_ref_with_provenance(
-                    a.clone(),
-                    source,
-                    cache_lookup,
-                )?;
-                attributes.push(ar);
-            }
-            g.attributes = attributes;
+                upgraded
+            } else {
+                let mut g = g.clone();
+                let mut attributes = vec![];
+                for a in g
+                    .attributes
+                    .iter()
+                    .filter_map(|ar| self.catalog().attribute(ar))
+                {
+                    let source = find_attribute_source(self, &a.name, &my_schema_url);
+                    let ar = attribute_catalog.attribute_ref_with_provenance(
+                        a.clone(),
+                        source,
+                        cache_lookup,
+                    )?;
+                    attributes.push(ar);
+                }
+                g.attributes = attributes;
+                g
+            };
             let mut g_url = my_schema_url.clone();
             if let Some(chosen_url) = cache_lookup.chosen_version(g_url.name()) {
                 if chosen_url != &g_url {
@@ -447,6 +411,106 @@ impl ImportableDependency for V1Schema {
         }
         Ok(result)
     }
+}
+
+/// If an imported group's origin registry (recorded in its lineage
+/// provenance, which may point at a transitive dependency rather than the
+/// immediate one) was upgraded to a newer compatible version by graph-wide
+/// version conflict resolution, returns the group's definition from the
+/// chosen registry so its body, lineage, and attributes stay consistent
+/// with the upgraded attribute catalog — mirroring what
+/// `upgrade_attribute_with_source` does for attributes.
+///
+/// Returns `None` when no upgrade applies, or when the chosen registry does
+/// not define the group; the caller then keeps the copy it has.
+fn upgrade_imported_group<C: crate::SchemaCacheLookup>(
+    group: &Group,
+    fallback_url: &SchemaUrl,
+    attribute_catalog: &mut AttributeCatalog,
+    cache_lookup: &C,
+) -> Result<Option<Group>, Error> {
+    let origin_url = group
+        .provenance()
+        .map(|prov| prov.schema_url)
+        .unwrap_or_else(|| fallback_url.clone());
+    let Some(chosen_url) = cache_lookup.chosen_version(origin_url.name()) else {
+        return Ok(None);
+    };
+    if *chosen_url == origin_url {
+        return Ok(None);
+    }
+    let Ok(winning_url) = UseLatestMajorVersion.resolve_conflict(&origin_url, chosen_url) else {
+        return Ok(None);
+    };
+    if winning_url != *chosen_url {
+        return Ok(None);
+    }
+    let Some(chosen_schema) = cache_lookup.lookup_schema(chosen_url) else {
+        return Ok(None);
+    };
+    // TODO: also look up the group when the chosen registry is a published
+    // resolved V2 schema.
+    let Some(chosen_v1) = chosen_schema.as_v1() else {
+        return Ok(None);
+    };
+    let Some(upgraded) = chosen_v1
+        .registry
+        .groups
+        .iter()
+        .find(|candidate| is_same_imported_group(group, candidate))
+    else {
+        return Ok(None);
+    };
+    let mut upgraded = upgraded.clone();
+    let mut attributes = vec![];
+    for a in upgraded
+        .attributes
+        .iter()
+        .filter_map(|ar| chosen_v1.catalog().attribute(ar))
+    {
+        let source = find_attribute_source(chosen_v1, &a.name, chosen_url);
+        attributes.push(attribute_catalog.attribute_ref_with_provenance(
+            a.clone(),
+            source,
+            cache_lookup,
+        )?);
+    }
+    upgraded.attributes = attributes;
+    Ok(Some(upgraded))
+}
+
+/// Whether `candidate` (a group in a chosen upgraded registry) defines the
+/// same signal as `group` (an imported group). Group ids may differ in their
+/// `<type>.` prefix between the definition (V1) and published (V2) import
+/// paths, so signals are matched by type and name where available.
+fn is_same_imported_group(group: &Group, candidate: &Group) -> bool {
+    if group.r#type != candidate.r#type {
+        return false;
+    }
+    if group.metric_name.is_some() || candidate.metric_name.is_some() {
+        return group.metric_name == candidate.metric_name;
+    }
+    if group.name.is_some() || candidate.name.is_some() {
+        return group.name == candidate.name;
+    }
+    strip_group_type_prefix(&group.id) == strip_group_type_prefix(&candidate.id)
+}
+
+/// Strips a group-type id prefix, if present.
+fn strip_group_type_prefix(id: &str) -> &str {
+    for prefix in [
+        "metric.",
+        "event.",
+        "entity.",
+        "span.",
+        "attribute_group.",
+        "registry.",
+    ] {
+        if let Some(rest) = id.strip_prefix(prefix) {
+            return rest;
+        }
+    }
+    id
 }
 
 /// Finds the attribute source for a V1 attribute.
@@ -1022,6 +1086,18 @@ impl ImportableDependency for V2Schema {
         if !exclusion_errors.is_empty() {
             return Err(Error::CompoundError(exclusion_errors));
         }
+
+        // The imported groups may originate in transitive dependencies that
+        // graph-wide version conflict resolution upgraded; substitute the
+        // chosen version's definition where that applies.
+        for group in result.iter_mut() {
+            if let Some(upgraded) =
+                upgrade_imported_group(group, &self.schema_url, attribute_catalog, cache_lookup)?
+            {
+                *group = upgraded;
+            }
+        }
+
         let mut g_url = self.schema_url.clone();
         if let Some(chosen_url) = cache_lookup.chosen_version(g_url.name()) {
             if chosen_url != &g_url {

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -369,13 +369,56 @@ impl ImportableDependency for V1Schema {
                 }
             }
             let mut g = g.clone();
+
+            // The group may originate in a transitive dependency (its
+            // lineage provenance points there rather than at `self`). When
+            // graph-wide version conflict resolution chose a newer
+            // compatible version of that origin registry, take the group's
+            // definition from the chosen version so its body, lineage, and
+            // attributes stay consistent with the upgraded attribute
+            // catalog.
+            let origin_url = g
+                .provenance()
+                .map(|prov| prov.schema_url)
+                .unwrap_or_else(|| my_schema_url.clone());
+            let upgraded_origin = cache_lookup
+                .chosen_version(origin_url.name())
+                .filter(|chosen_url| **chosen_url != origin_url)
+                .filter(|chosen_url| {
+                    UseLatestMajorVersion
+                        .resolve_conflict(&origin_url, chosen_url)
+                        .is_ok_and(|winning_url| winning_url == **chosen_url)
+                })
+                .and_then(|chosen_url| {
+                    cache_lookup
+                        .lookup_schema(chosen_url)
+                        .map(|schema| (schema, chosen_url.clone()))
+                });
+            let (source_schema, source_url) = match &upgraded_origin {
+                Some((schema, chosen_url)) => {
+                    match schema
+                        .as_v1()
+                        .and_then(|v1| v1.registry.groups.iter().find(|ug| ug.id == g.id))
+                    {
+                        Some(upgraded_group) => {
+                            g = upgraded_group.clone();
+                            (schema.as_v1().expect("checked above"), chosen_url)
+                        }
+                        // The chosen registry no longer defines this group
+                        // (or is not a V1 schema): keep the copy we have.
+                        None => (self, &my_schema_url),
+                    }
+                }
+                None => (self, &my_schema_url),
+            };
+
             let mut attributes = vec![];
             for a in g
                 .attributes
                 .iter()
-                .filter_map(|ar| self.catalog().attribute(ar))
+                .filter_map(|ar| source_schema.catalog().attribute(ar))
             {
-                let source = find_attribute_source(self, &a.name, &my_schema_url);
+                let source = find_attribute_source(source_schema, &a.name, source_url);
                 let ar = attribute_catalog.attribute_ref_with_provenance(
                     a.clone(),
                     source,

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -1793,6 +1793,41 @@ groups:
     }
 
     #[test]
+    fn test_upgraded_group_keeps_winning_version_provenance_published(
+    ) -> Result<(), weaver_semconv::Error> {
+        // Same shape as test_upgraded_group_keeps_winning_version_provenance,
+        // but A is a *published* (resolved/2.0) registry whose embedded copy
+        // of `c.metric.1` was resolved against C v1.1. B (a definition
+        // registry) pins C v1.2, which wins the version conflict. The metric
+        // imported through the published V2 path must also be upgraded to
+        // C v1.2's definition and provenance.
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/compatible-version-conflict-published/main".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let config = WeaverResolverConfig::default();
+        let mut resolver = WeaverResolver::new(config);
+
+        let resolved = match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+            WResult::Ok(r) | WResult::OkWithNFEs(r, _) => r.into_v1().unwrap(),
+            WResult::FatalErr(e) => panic!("Failed to resolve schema: {e}"),
+        };
+
+        let metrics = resolved.groups(GroupType::Metric);
+        let metric = metrics
+            .values()
+            .find(|g| g.metric_name.as_deref() == Some("c.metric.1"))
+            .expect("metric c.metric.1 not found");
+        let provenance = metric.provenance().expect("c.metric.1 has no lineage");
+        assert_eq!(
+            provenance.schema_url.to_string(),
+            "https://example.com/c/1.2.0"
+        );
+        assert_eq!(metric.brief, "Metric 1 in C v1.2 (updated)");
+        Ok(())
+    }
+
+    #[test]
     fn test_standalone_vs_graph_provenance_immutability() -> Result<(), weaver_semconv::Error> {
         // 1. Setup a single WeaverResolver instance with overrides pointing to compatible-version-conflict.
         let mut config = WeaverResolverConfig::default();

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -1757,6 +1757,42 @@ groups:
     }
 
     #[test]
+    fn test_upgraded_group_keeps_winning_version_provenance() -> Result<(), weaver_semconv::Error> {
+        // `main` imports `c.metric.1` via A (which pins C v1.1) and
+        // `c.span.2` via B (which pins C v1.2). The compatible version
+        // conflict resolves in favor of C v1.2 and the attribute catalog is
+        // upgraded accordingly (`c.attr1` reports the v1.2 brief, as covered
+        // by test_standalone_vs_graph_provenance_immutability). The group
+        // must be upgraded consistently: `metric.c.metric.1` should carry
+        // C v1.2's definition and provenance.
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/compatible-version-conflict/main".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let config = WeaverResolverConfig::default();
+        let mut resolver = WeaverResolver::new(config);
+
+        let resolved = match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+            WResult::Ok(r) | WResult::OkWithNFEs(r, _) => r.into_v1().unwrap(),
+            WResult::FatalErr(e) => panic!("Failed to resolve schema: {e}"),
+        };
+
+        let metrics = resolved.groups(GroupType::Metric);
+        let metric = metrics
+            .get("metric.c.metric.1")
+            .expect("metric.c.metric.1 not found");
+        let provenance = metric
+            .provenance()
+            .expect("metric.c.metric.1 has no lineage");
+        assert_eq!(
+            provenance.schema_url.to_string(),
+            "https://example.com/c/1.2.0"
+        );
+        assert_eq!(metric.brief, "Metric 1 in C v1.2 (updated)");
+        Ok(())
+    }
+
+    #[test]
     fn test_standalone_vs_graph_provenance_immutability() -> Result<(), weaver_semconv::Error> {
         // 1. Setup a single WeaverResolver instance with overrides pointing to compatible-version-conflict.
         let mut config = WeaverResolverConfig::default();


### PR DESCRIPTION
Fixes case 2 of #1646 (`test_upgraded_group_keeps_winning_version_provenance`), covering both the definition (V1) and published (resolved V2) dependency import paths.

## Problem

In the `compatible-version-conflict` fixture, `main` imports `c.metric.1` via A (which pins C v1.1) and `c.span.2` via B (which pins C v1.2). Version conflict resolution correctly chooses C v1.2 — but only for the attribute catalog. Resolving `main` produces an internally inconsistent schema:

```yaml
- id: metric.c.metric.1
  brief: Metric 1 in C v1.1            # losing version's body
  attributes:
  - name: c.attr1
    brief: Attribute 1 from C v1.2 (updated)   # upgraded attribute
  lineage:
    provenance:
      schema_url: https://example.com/c/1.1.0   # losing version's provenance
```

`resolve_dependency_imports` in `registry.rs` already relabels the stored provenance URL to the winning version, but the group's own body and `lineage` — which is what the resolved output reports — are cloned unchanged from the intermediate dependency's stale copy.

The same inconsistency exists when the intermediate dependency is published as a `resolved/2.0` schema: `V2Schema::import_groups` builds the group from the published registry's embedded (stale) copy while the attributes get upgraded. The new `compatible-version-conflict-published` fixture demonstrates this: registry A is a published resolved V2 schema whose embedded `c.metric.1` was resolved against C v1.1.

## Fix

A shared `upgrade_imported_group` helper, used by both `V1Schema::import_groups` and `V2Schema::import_groups`: when an imported group's origin registry (from its lineage provenance, which may point at a transitive dependency) has a chosen newer compatible version in the resolution cache, the group's definition is taken from the chosen schema — body, lineage, and attribute refs registered consistently with the upgraded attribute catalog. This mirrors what `upgrade_attribute_with_source` already does for attributes. If the chosen registry no longer defines the group, the existing copy is kept (previous behavior).

Note: the definition and published import paths disagree on group id prefixes (`metric.c.metric.1` vs `c.metric.1`), so groups are matched in the chosen registry by type and name rather than raw id. A side benefit is that upgraded groups imported through the published path now come out with the canonical prefixed id and a real provenance path.

## Testing

- `cargo test -p weaver_resolver test_upgraded_group_keeps_winning_version_provenance` — V1 path, red before, green after.
- `cargo test -p weaver_resolver test_upgraded_group_keeps_winning_version_provenance_published` — published V2 path with the new fixture, red before, green after.
- Resolved output for both fixtures now reports the v1.2 body, v1.2 provenance, and v1.2 attributes consistently.
- Full workspace test suite passes (899 tests).
