### PR TITLE
Make schema_url mandatory for manifest dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Make schema_url mandatory for manifest dependencies ([#1651](https://github.com/open-telemetry/weaver/issues/1651) by @jerbly)
 - Fix imported groups keeping the losing version's definition and provenance ([#1650](https://github.com/open-telemetry/weaver/issues/1650) by @jerbly)
 - Fix imported attributes losing their origin registry provenance ([#1649](https://github.com/open-telemetry/weaver/issues/1649) by @jerbly)
 - Fix signals imported from a dependency losing their per-signal attribute data. When several signals reference the same attribute with different `requirement_level` or `role`, each imported signal was re-pointed at whichever variant of the attribute was registered first. E.g. silently rewriting requirement levels or dropping `role: identifying` from imported entities. Each signal now references the attribute variant it actually declares. Per-name conflict resolution still applies to root-attribute provenance. ([#1635](https://github.com/open-telemetry/weaver/pull/1635) by @jerbly)

--- a/crates/weaver_resolver/data/circular-registry-test/registry_b/registry_manifest.yaml
+++ b/crates/weaver_resolver/data/circular-registry-test/registry_b/registry_manifest.yaml
@@ -2,6 +2,5 @@ name: registry_b
 description: Test registry B for circular dependency testing.
 schema_url: https://example.com/registry_b/schemas/0.1.0
 dependencies:
-  - name: registry_a
-    # schema_url: is not necessary here, we're using deprecated, but valid for now `name`
+  - schema_url: https://example.com/registry_a/schemas/0.1.0
     registry_path: data/circular-registry-test/registry_a

--- a/crates/weaver_resolver/data/mandatory-schema-url/dep/manifest.yaml
+++ b/crates/weaver_resolver/data/mandatory-schema-url/dep/manifest.yaml
@@ -1,0 +1,3 @@
+name: dep
+description: Dependency registry defining a metric.
+schema_url: https://example.com/dep/1.0.0

--- a/crates/weaver_resolver/data/mandatory-schema-url/dep/semconv.yaml
+++ b/crates/weaver_resolver/data/mandatory-schema-url/dep/semconv.yaml
@@ -1,0 +1,15 @@
+file_format: definition/2
+attributes:
+  - key: dep.id
+    type: string
+    stability: stable
+    brief: Unique ID.
+    examples: ["abc123"]
+metrics:
+  - name: dep.uptime
+    brief: Uptime metric defined in dep.
+    instrument: gauge
+    unit: "s"
+    stability: stable
+    attributes:
+      - ref: dep.id

--- a/crates/weaver_resolver/data/mandatory-schema-url/main/imports.yaml
+++ b/crates/weaver_resolver/data/mandatory-schema-url/main/imports.yaml
@@ -1,0 +1,3 @@
+imports:
+  metrics:
+    - dep.uptime

--- a/crates/weaver_resolver/data/mandatory-schema-url/main/manifest.yaml
+++ b/crates/weaver_resolver/data/mandatory-schema-url/main/manifest.yaml
@@ -1,0 +1,6 @@
+name: main
+description: Registry whose dependency declaration omits the mandatory `schema_url`.
+schema_url: https://example.com/main/0.1.0
+dependencies:
+  - name: dep
+    registry_path: data/mandatory-schema-url/dep

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -1757,6 +1757,34 @@ groups:
     }
 
     #[test]
+    fn test_dependency_without_schema_url_is_rejected() {
+        // `main`'s manifest declares its dependency with only `name` and
+        // `registry_path`. `schema_url` is mandatory for dependencies — it is
+        // the identity that provenance and version-conflict resolution key
+        // on — so this must fail with an error naming the offending
+        // dependency.
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/mandatory-schema-url/main".to_owned(),
+        };
+        let err_msg = match RegistryRepo::try_new(None, &registry_path, &mut vec![]) {
+            Err(e) => e.to_string(),
+            Ok(registry_repo) => {
+                let mut resolver = WeaverResolver::new(WeaverResolverConfig::default());
+                match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+                    WResult::Ok(_) | WResult::OkWithNFEs(_, _) => panic!(
+                        "expected an error for the dependency missing 'schema_url', but resolution succeeded"
+                    ),
+                    WResult::FatalErr(e) => e.to_string(),
+                }
+            }
+        };
+        assert!(
+            err_msg.contains("schema_url") && err_msg.contains("dep"),
+            "error should name the dependency missing 'schema_url'; got: {err_msg}"
+        );
+    }
+
+    #[test]
     fn test_standalone_vs_graph_provenance_immutability() -> Result<(), weaver_semconv::Error> {
         // 1. Setup a single WeaverResolver instance with overrides pointing to compatible-version-conflict.
         let mut config = WeaverResolverConfig::default();

--- a/crates/weaver_semconv/src/manifest.rs
+++ b/crates/weaver_semconv/src/manifest.rs
@@ -128,11 +128,18 @@ impl<'de> Deserialize<'de> for Dependency {
 
         let schema_url = match (helper.schema_url, helper.name) {
             (Some(url), _) => url,
-            (None, Some(name)) => SchemaUrl::try_from_name_version(&name, "unknown")
-                .map_err(serde::de::Error::custom)?,
+            (None, Some(name)) => {
+                return Err(serde::de::Error::custom(format!(
+                    "missing required field 'schema_url' for dependency '{name}'. \
+                     The schema_url uniquely identifies the dependency registry and its \
+                     version, e.g. https://example.com/{name}/1.0.0"
+                )))
+            }
             (None, None) => {
                 return Err(serde::de::Error::custom(
-                    "Either 'schema_url' or 'name' must be provided for a dependency",
+                    "missing required field 'schema_url' for a dependency. \
+                     The schema_url uniquely identifies the dependency registry and its \
+                     version, e.g. https://example.com/my-registry/1.0.0",
                 ))
             }
         };
@@ -490,12 +497,17 @@ registry_path: "./registry"
     }
 
     #[test]
-    fn test_dependency_deserialize_with_deprecated_name() {
+    fn test_dependency_deserialize_name_only_is_rejected() {
         let yaml = r#"
 name: "acme-registry"
 "#;
-        let dep: Dependency = serde_yaml::from_str(yaml).expect("Failed to deserialize");
-        assert_eq!(dep.schema_url.as_str(), "https://acme-registry/unknown");
+        let err = serde_yaml::from_str::<Dependency>(yaml)
+            .expect_err("a dependency without 'schema_url' must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("schema_url") && msg.contains("acme-registry"),
+            "error should name the dependency missing 'schema_url'; got: {msg}"
+        );
     }
 
     #[test]
@@ -521,7 +533,7 @@ registry_path: "./registry"
         let err = result.unwrap_err();
         assert!(err
             .to_string()
-            .contains("Either 'schema_url' or 'name' must be provided"));
+            .contains("missing required field 'schema_url'"));
     }
 
     #[test]

--- a/docs/define-your-own-telemetry-schema.md
+++ b/docs/define-your-own-telemetry-schema.md
@@ -27,9 +27,16 @@ name: <custom registry name>
 description: <an optional description of the custom registry>
 schema_url: <base URL where the registry's schema files are hosted>/<version of this custom registry>
 dependencies:
-  - name: <an alias for the dependency>
+  - schema_url: <base URL of the dependency>/<version of the dependency>
     registry_path: <the location of the dependency>
 ```
+
+The `schema_url` of a dependency is required. It uniquely identifies the
+dependency registry and its version, and is what provenance tracking and
+version conflict resolution key on. It does not have to be a URL the registry
+can actually be fetched from — the files themselves are located via
+`registry_path` — but it must follow the OTel schema URL format and include a
+version segment.
 
 > **Current limitations**:
 > - Weaver supports a maximum of 10 registry levels without circular
@@ -43,7 +50,7 @@ name: acme
 description: This registry contains the semantic conventions for the Acme vendor.
 schema_url: https://acme.com/schemas/0.1.0
 dependencies:
-  - name: otel
+  - schema_url: https://opentelemetry.io/schemas/1.40.0
     registry_path: https://github.com/open-telemetry/semantic-conventions@v1.40.0[model]
 ```
 


### PR DESCRIPTION
Fixes case 3 of #1646 (`test_dependency_without_schema_url_is_rejected`, included here with its fixture).

## Problem

A manifest dependency declared with only `name` (and optionally `registry_path`) was silently accepted: a schema URL was synthesized with version `unknown`, and resolution proceeded without complaint. The `schema_url` is the identity that provenance tracking and version conflict resolution key on, so a fabricated version quietly undermines both.

## Fix

Reject such dependencies at manifest deserialization (`Dependency`'s `Deserialize` impl in `weaver_semconv/src/manifest.rs`) with an error that names the offending dependency, explains what the `schema_url` is for, and shows an example value. The console output:

```
× The registry manifest at "data/mandatory-schema-url/main/manifest.yaml" is
│ invalid. dependencies: missing required field 'schema_url' for dependency
│ 'dep'. The schema_url uniquely identifies the dependency registry and its
│ version, e.g. https://example.com/dep/1.0.0 at line 5 column 3
```

The `name` field is still accepted alongside `schema_url` (it remains informational); only the name-only form is rejected. This removes the last consumer of the deprecated name-only fallback:

- `test_dependency_deserialize_with_deprecated_name` is replaced by `test_dependency_deserialize_name_only_is_rejected`.
- The `circular-registry-test` fixture used the name-only form; it now declares a proper `schema_url` so it keeps exercising circular dependency detection (verified: it still fails with the circular dependency error).

## Testing

- New fixture `crates/weaver_resolver/data/mandatory-schema-url/` with a `name`-only dependency.
- `cargo test -p weaver_resolver test_dependency_without_schema_url_is_rejected` — red before this fix (resolution succeeded silently), green after. The test asserts the error message contains both `schema_url` and the dependency name, and accepts the error surfacing at either manifest load or resolution.
- Full workspace test suite passes (898 tests).