### PR TITLE
Fix transitive dependency provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
 - Fix signals imported from a dependency losing their per-signal attribute data. When several signals reference the same attribute with different `requirement_level` or `role`, each imported signal was re-pointed at whichever variant of the attribute was registered first. E.g. silently rewriting requirement levels or dropping `role: identifying` from imported entities. Each signal now references the attribute variant it actually declares. Per-name conflict resolution still applies to root-attribute provenance. ([#1635](https://github.com/open-telemetry/weaver/pull/1635) by @jerbly)
 
 # [0.25.0] - 2026-07-24

--- a/crates/weaver_resolver/data/transitive-provenance/base/manifest.yaml
+++ b/crates/weaver_resolver/data/transitive-provenance/base/manifest.yaml
@@ -1,0 +1,3 @@
+name: base
+description: Registry defining the `base.host.id` attribute and a metric that uses it.
+schema_url: https://example.com/base/1.0.0

--- a/crates/weaver_resolver/data/transitive-provenance/base/semconv.yaml
+++ b/crates/weaver_resolver/data/transitive-provenance/base/semconv.yaml
@@ -1,0 +1,15 @@
+file_format: definition/2
+attributes:
+  - key: base.host.id
+    type: string
+    stability: stable
+    brief: Unique host ID, defined in base.
+    examples: ["abc123"]
+metrics:
+  - name: base.uptime
+    brief: Uptime metric defined in base.
+    instrument: gauge
+    unit: "s"
+    stability: stable
+    attributes:
+      - ref: base.host.id

--- a/crates/weaver_resolver/data/transitive-provenance/main/imports.yaml
+++ b/crates/weaver_resolver/data/transitive-provenance/main/imports.yaml
@@ -1,0 +1,7 @@
+# `base.uptime` is defined in base, which main does not depend on directly — it
+# arrives through middle. Its provenance must still name base as the origin
+# registry, not fall back to "defined locally" for want of an entry to point at.
+file_format: definition/2
+imports:
+  metrics:
+    - base.uptime

--- a/crates/weaver_resolver/data/transitive-provenance/main/manifest.yaml
+++ b/crates/weaver_resolver/data/transitive-provenance/main/manifest.yaml
@@ -1,0 +1,9 @@
+name: main
+description: >
+  Registry depending on middle only. `base` is reachable solely through middle,
+  so it is a purely transitive dependency of main.
+schema_url: https://example.com/main/0.1.0
+dependencies:
+  - name: middle
+    schema_url: https://example.com/middle/0.1.0
+    registry_path: data/transitive-provenance/middle

--- a/crates/weaver_resolver/data/transitive-provenance/middle/imports.yaml
+++ b/crates/weaver_resolver/data/transitive-provenance/middle/imports.yaml
@@ -1,0 +1,4 @@
+file_format: definition/2
+imports:
+  metrics:
+    - base.uptime

--- a/crates/weaver_resolver/data/transitive-provenance/middle/manifest.yaml
+++ b/crates/weaver_resolver/data/transitive-provenance/middle/manifest.yaml
@@ -1,0 +1,7 @@
+name: middle
+description: Registry re-exporting base's metric. Its only role is to sit between base and main.
+schema_url: https://example.com/middle/0.1.0
+dependencies:
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/transitive-provenance/base

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -2002,14 +2002,27 @@ groups:
         Ok(())
     }
 
-    /// Elements inherited through a dependency-of-a-dependency must be
-    /// attributed to the registry that actually defined them, rather than
-    /// falling back to "defined locally" because their schema URL was missing
-    /// from the `DependencyRef` target table.
+    /// An element reaching a registry through a dependency-of-a-dependency must
+    /// be attributed to the registry that defined it.
+    ///
+    /// The `transitive-provenance` fixture is a plain three-level chain:
+    /// `base <- middle <- main`, where `middle` only re-exports base's metric and
+    /// `main` depends on `middle` alone. `base` is therefore reachable solely
+    /// through `middle`.
+    ///
+    /// Provenance is a `DependencyRef` index into the resolved schema's
+    /// `dependencies` set. If that set records only the direct dependencies,
+    /// `base` has no entry for the metric to point at, its `source` is left
+    /// empty, and the metric is reported as defined by `main` itself — even
+    /// though its recorded path names a file in `base`.
     #[test]
     fn test_transitive_dependency_provenance_resolves() -> Result<(), Error> {
+        use weaver_resolved_schema::v2::catalog::AttributeCatalog;
+
+        const BASE: &str = "https://example.com/base/1.0.0";
+
         let registry_path = VirtualDirectoryPath::LocalFolder {
-            path: "data/compatible-version-conflict/main".to_owned(),
+            path: "data/transitive-provenance/main".to_owned(),
         };
         let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])
             .expect("failed to create registry repo");
@@ -2018,44 +2031,53 @@ groups:
             WResult::Ok(r) | WResult::OkWithNFEs(r, _) => r,
             WResult::FatalErr(e) => panic!("Failed to resolve main: {e}"),
         };
-
         let v1 = resolved.as_v1().expect("Expected a V1 schema for main");
         let v2: weaver_resolved_schema::v2::ResolvedTelemetrySchema =
             v1.clone().try_into().expect("v1 -> v2 conversion");
 
-        // `main` defines nothing itself; everything arrives through A and B from
-        // C, so no signal may report itself as locally defined.
-        let local: Vec<&str> = v2
+        // `base` is not a direct dependency of `main`, so it is only in the set
+        // if transitive dependencies are recorded.
+        let base_url: SchemaUrl = BASE.try_into().expect("valid schema url");
+        assert!(
+            v2.dependencies.contains(&base_url),
+            "transitive dependency `base` missing from {:?}",
+            v2.dependencies
+        );
+
+        let deps: Vec<&SchemaUrl> = v2.dependencies.iter().collect();
+        let metric = v2
             .registry
             .metrics
             .iter()
-            .filter(|m| m.provenance.is_empty())
-            .map(|m| m.name.as_ref())
-            .chain(
-                v2.registry
-                    .spans
-                    .iter()
-                    .filter(|s| s.provenance.is_empty())
-                    .map(|s| s.r#type.as_ref()),
-            )
-            .collect();
-        assert!(
-            local.is_empty(),
-            "signals from a transitive dependency reported as local: {local:?}"
-        );
+            .find(|m| &*m.name == "base.uptime")
+            .expect("main imported base.uptime");
 
-        // And the reference resolves to C, not to A or B.
-        let deps: Vec<&SchemaUrl> = v2.dependencies.iter().collect();
-        let metric = v2.registry.metrics.first().expect("main has a metric");
+        assert!(
+            !metric.provenance.is_empty(),
+            "`base.uptime` came from `base` but is reported as defined by `main`"
+        );
         let source = metric
             .provenance
             .source
             .and_then(|r| deps.get(r.0 as usize))
             .expect("metric provenance resolves to a dependency");
-        assert!(
-            source.name().ends_with("/c"),
-            "expected the metric to come from registry C, got {source}"
-        );
+        assert_eq!(source.as_str(), BASE, "attributed to the wrong registry");
+
+        // The attribute it carries came from `base` too, not from `middle`.
+        let attr_ref = metric
+            .attributes
+            .first()
+            .expect("base.uptime has attributes");
+        let attr = v2
+            .attribute_catalog
+            .attribute(&attr_ref.base)
+            .expect("attribute in catalog");
+        let attr_source = attr
+            .provenance
+            .source
+            .and_then(|r| deps.get(r.0 as usize))
+            .expect("attribute provenance resolves to a dependency");
+        assert_eq!(attr_source.as_str(), BASE);
 
         Ok(())
     }

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -367,14 +367,6 @@ impl WeaverResolver {
         let mut attr_catalog = AttributeCatalog::default();
 
         // Every registry this schema was built from, direct and transitive.
-        //
-        // This set is the target table that `DependencyRef` provenance indexes
-        // into, so it has to name every registry an element can have come from.
-        // Recording only the direct dependencies left elements inherited through
-        // a dependency-of-a-dependency with no entry to point at, which made them
-        // indistinguishable from locally defined ones. Each dependency's own set
-        // is already its full closure — this function builds it at every level —
-        // so folding those in once is enough.
         let mut dependencies = std::collections::BTreeSet::new();
         for d in &resolved_dependencies {
             match d {

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -366,6 +366,15 @@ impl WeaverResolver {
         };
         let mut attr_catalog = AttributeCatalog::default();
 
+        // Every registry this schema was built from, direct and transitive.
+        //
+        // This set is the target table that `DependencyRef` provenance indexes
+        // into, so it has to name every registry an element can have come from.
+        // Recording only the direct dependencies left elements inherited through
+        // a dependency-of-a-dependency with no entry to point at, which made them
+        // indistinguishable from locally defined ones. Each dependency's own set
+        // is already its full closure — this function builds it at every level —
+        // so folding those in once is enough.
         let mut dependencies = std::collections::BTreeSet::new();
         for d in &resolved_dependencies {
             match d {
@@ -373,9 +382,11 @@ impl WeaverResolver {
                     if let Ok(url) = SchemaUrl::try_from(schema.schema_url.as_str()) {
                         _ = dependencies.insert(url);
                     }
+                    dependencies.extend(schema.dependencies.iter().cloned());
                 }
                 ResolvedDependency::V2(schema) => {
                     _ = dependencies.insert(schema.schema_url.clone());
+                    dependencies.extend(schema.dependencies.iter().cloned());
                 }
             }
         }
@@ -1830,6 +1841,20 @@ groups:
         let url_b = SchemaUrl::try_from("https://example.com/b/0.1.0").unwrap();
         assert!(v1_main.dependencies.contains(&url_a));
         assert!(v1_main.dependencies.contains(&url_b));
+        // `dependencies` is the table `DependencyRef` provenance indexes into,
+        // so it must also name the registries reached *through* A and B —
+        // otherwise elements inherited from C have nothing to point at and are
+        // reported as locally defined.
+        assert!(
+            v1_main.dependencies.contains(&url_c_v1_1),
+            "transitive dependency C v1.1 missing from {:?}",
+            v1_main.dependencies
+        );
+        assert!(
+            v1_main.dependencies.contains(&url_c_v1_2),
+            "transitive dependency C v1.2 missing from {:?}",
+            v1_main.dependencies
+        );
 
         // 4. Check the cached A schema in isolation once again.
         // It MUST remain completely untouched and still report C v1.1.
@@ -1847,6 +1872,64 @@ groups:
         assert_eq!(attr_a_again.brief, "Attribute 1 from C v1.1");
         assert_eq!(source_a_again, "v2_dependency.example.com/c");
         assert!(v1_a_again.dependencies.contains(&url_c_v1_1));
+
+        Ok(())
+    }
+
+    /// Elements inherited through a dependency-of-a-dependency must be
+    /// attributed to the registry that actually defined them, rather than
+    /// falling back to "defined locally" because their schema URL was missing
+    /// from the `DependencyRef` target table.
+    #[test]
+    fn test_transitive_dependency_provenance_resolves() -> Result<(), Error> {
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/compatible-version-conflict/main".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])
+            .expect("failed to create registry repo");
+        let mut resolver = WeaverResolver::new(WeaverResolverConfig::default());
+        let resolved = match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+            WResult::Ok(r) | WResult::OkWithNFEs(r, _) => r,
+            WResult::FatalErr(e) => panic!("Failed to resolve main: {e}"),
+        };
+
+        let v1 = resolved.as_v1().expect("Expected a V1 schema for main");
+        let v2: weaver_resolved_schema::v2::ResolvedTelemetrySchema =
+            v1.clone().try_into().expect("v1 -> v2 conversion");
+
+        // `main` defines nothing itself; everything arrives through A and B from
+        // C, so no signal may report itself as locally defined.
+        let local: Vec<&str> = v2
+            .registry
+            .metrics
+            .iter()
+            .filter(|m| m.provenance.is_empty())
+            .map(|m| m.name.as_ref())
+            .chain(
+                v2.registry
+                    .spans
+                    .iter()
+                    .filter(|s| s.provenance.is_empty())
+                    .map(|s| s.r#type.as_ref()),
+            )
+            .collect();
+        assert!(
+            local.is_empty(),
+            "signals from a transitive dependency reported as local: {local:?}"
+        );
+
+        // And the reference resolves to C, not to A or B.
+        let deps: Vec<&SchemaUrl> = v2.dependencies.iter().collect();
+        let metric = v2.registry.metrics.first().expect("main has a metric");
+        let source = metric
+            .provenance
+            .source
+            .and_then(|r| deps.get(r.0 as usize))
+            .expect("metric provenance resolves to a dependency");
+        assert!(
+            source.name().ends_with("/c"),
+            "expected the metric to come from registry C, got {source}"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure.