### PR TITLE
Fix: serve imported attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix attributes imported from a dependency going uncounted and unsearchable. Such an attribute is only ever referenced by the signals that use it, never listed as a definition, so `weaver registry stats` reported it nowhere and `weaver serve` left it out of search and detail pages. Statistics and the search index now cover every attribute the registry can reach. ([#1656](https://github.com/open-telemetry/weaver/pull/1656) by @jerbly)
+- Fix attributes imported from a dependency being treated as if they were not part of the registry. Such an attribute is only ever referenced by the signals that use it, never listed as a definition, so `weaver registry stats` counted it nowhere, `weaver serve` left it out of search and detail pages, and `weaver registry live-check --v2` reported it as a `missing_attribute` violation and excluded it from registry coverage. All three now consider every attribute the registry can reach. ([#1656](https://github.com/open-telemetry/weaver/pull/1656) by @jerbly)
 - Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#1655](https://github.com/open-telemetry/weaver/pull/1655) by @jerbly)
 
 # [0.25.1] - 2026-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix `weaver serve` not exposing attributes imported from a dependency. Search, detail pages and registry stats now cover every attribute the registry can reach. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
-- Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
+- Fix `weaver serve` not exposing attributes imported from a dependency. Search, detail pages and registry stats now cover every attribute the registry can reach. ([#1656](https://github.com/open-telemetry/weaver/pull/1656) by @jerbly)
+- Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#1655](https://github.com/open-telemetry/weaver/pull/1655) by @jerbly)
 
 # [0.25.1] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix `weaver serve` not exposing attributes imported from a dependency. Such attributes are inlined into the signals that use them rather than listed in `registry.attributes`, so they were unsearchable, had no detail page, and the attribute links on every imported signal's page dead-ended on "Attribute not found". Search, detail pages and registry stats now cover every attribute the registry can reach. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
+- Fix `weaver serve` not exposing attributes imported from a dependency. Search, detail pages and registry stats now cover every attribute the registry can reach. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
 
 # [0.25.1] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 
 - Fix `weaver serve` not exposing attributes imported from a dependency. Search, detail pages and registry stats now cover every attribute the registry can reach. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
-
-# Unreleased
-
 - Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
 
 # [0.25.1] - 2026-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix `weaver serve` not exposing attributes imported from a dependency. Search, detail pages and registry stats now cover every attribute the registry can reach. ([#1656](https://github.com/open-telemetry/weaver/pull/1656) by @jerbly)
+- Fix attributes imported from a dependency going uncounted and unsearchable. Such an attribute is only ever referenced by the signals that use it, never listed as a definition, so `weaver registry stats` reported it nowhere and `weaver serve` left it out of search and detail pages. Statistics and the search index now cover every attribute the registry can reach. ([#1656](https://github.com/open-telemetry/weaver/pull/1656) by @jerbly)
 - Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#1655](https://github.com/open-telemetry/weaver/pull/1655) by @jerbly)
 
 # [0.25.1] - 2026-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Fix `weaver serve` not exposing attributes imported from a dependency. Such attributes are inlined into the signals that use them rather than listed in `registry.attributes`, so they were unsearchable, had no detail page, and the attribute links on every imported signal's page dead-ended on "Attribute not found". Search, detail pages and registry stats now cover every attribute the registry can reach. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
 - Fix signals imported from a dependency losing their per-signal attribute data. When several signals reference the same attribute with different `requirement_level` or `role`, each imported signal was re-pointed at whichever variant of the attribute was registered first. E.g. silently rewriting requirement levels or dropping `role: identifying` from imported entities. Each signal now references the attribute variant it actually declares. Per-name conflict resolution still applies to root-attribute provenance. ([#1635](https://github.com/open-telemetry/weaver/pull/1635) by @jerbly)
 
 # [0.25.0] - 2026-07-24

--- a/crates/weaver_forge/src/v2/registry.rs
+++ b/crates/weaver_forge/src/v2/registry.rs
@@ -55,6 +55,44 @@ pub struct Registry {
     pub entities: Vec<Entity>,
 }
 
+impl Registry {
+    /// Every attribute reachable from this registry: the definitions first, then
+    /// the copy inlined into each signal that uses one.
+    ///
+    /// Attributes imported from a dependency only ever exist inlined. A key can
+    /// appear several times; callers keep the first for one entry per key.
+    pub fn all_attributes(&self) -> impl Iterator<Item = &Attribute> {
+        self.attributes
+            .iter()
+            .chain(
+                self.attribute_groups
+                    .iter()
+                    .flat_map(|g| g.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(
+                self.metrics
+                    .iter()
+                    .flat_map(|m| m.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(
+                self.spans
+                    .iter()
+                    .flat_map(|s| s.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(
+                self.events
+                    .iter()
+                    .flat_map(|e| e.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(self.entities.iter().flat_map(|e| {
+                e.identity
+                    .iter()
+                    .chain(e.description.iter())
+                    .map(|a| &a.base)
+            }))
+    }
+}
+
 /// The set of all refinements for a semantic convention registry.
 ///
 /// A refinement is a specialization of a signal for a particular purpose,

--- a/crates/weaver_forge/src/v2/registry.rs
+++ b/crates/weaver_forge/src/v2/registry.rs
@@ -55,44 +55,6 @@ pub struct Registry {
     pub entities: Vec<Entity>,
 }
 
-impl Registry {
-    /// Every attribute reachable from this registry: the definitions first, then
-    /// the copy inlined into each signal that uses one.
-    ///
-    /// Attributes imported from a dependency only ever exist inlined. A key can
-    /// appear several times; keep the first for one entry per key.
-    pub fn all_attributes(&self) -> impl Iterator<Item = &Attribute> {
-        self.attributes
-            .iter()
-            .chain(
-                self.attribute_groups
-                    .iter()
-                    .flat_map(|g| g.attributes.iter().map(|a| &a.base)),
-            )
-            .chain(
-                self.metrics
-                    .iter()
-                    .flat_map(|m| m.attributes.iter().map(|a| &a.base)),
-            )
-            .chain(
-                self.spans
-                    .iter()
-                    .flat_map(|s| s.attributes.iter().map(|a| &a.base)),
-            )
-            .chain(
-                self.events
-                    .iter()
-                    .flat_map(|e| e.attributes.iter().map(|a| &a.base)),
-            )
-            .chain(self.entities.iter().flat_map(|e| {
-                e.identity
-                    .iter()
-                    .chain(e.description.iter())
-                    .map(|a| &a.base)
-            }))
-    }
-}
-
 /// The set of all refinements for a semantic convention registry.
 ///
 /// A refinement is a specialization of a signal for a particular purpose,

--- a/crates/weaver_forge/src/v2/registry.rs
+++ b/crates/weaver_forge/src/v2/registry.rs
@@ -55,6 +55,48 @@ pub struct Registry {
     pub entities: Vec<Entity>,
 }
 
+impl Registry {
+    /// Every attribute reachable from this registry: the registry-level
+    /// definitions first, then the copy inlined into each signal that uses one.
+    ///
+    /// Attributes imported from a dependency are never listed in `attributes` —
+    /// they only exist inlined inside the signals that reference them — so this
+    /// is the complete set, matching the resolved schema's attribute catalog.
+    /// The same key yields several items (one per referencing signal), so
+    /// callers wanting one entry per key should keep the first occurrence, which
+    /// is the registry-level definition whenever there is one.
+    pub fn all_attributes(&self) -> impl Iterator<Item = &Attribute> {
+        self.attributes
+            .iter()
+            .chain(
+                self.attribute_groups
+                    .iter()
+                    .flat_map(|g| g.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(
+                self.metrics
+                    .iter()
+                    .flat_map(|m| m.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(
+                self.spans
+                    .iter()
+                    .flat_map(|s| s.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(
+                self.events
+                    .iter()
+                    .flat_map(|e| e.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(self.entities.iter().flat_map(|e| {
+                e.identity
+                    .iter()
+                    .chain(e.description.iter())
+                    .map(|a| &a.base)
+            }))
+    }
+}
+
 /// The set of all refinements for a semantic convention registry.
 ///
 /// A refinement is a specialization of a signal for a particular purpose,

--- a/crates/weaver_forge/src/v2/registry.rs
+++ b/crates/weaver_forge/src/v2/registry.rs
@@ -56,15 +56,11 @@ pub struct Registry {
 }
 
 impl Registry {
-    /// Every attribute reachable from this registry: the registry-level
-    /// definitions first, then the copy inlined into each signal that uses one.
+    /// Every attribute reachable from this registry: the definitions first, then
+    /// the copy inlined into each signal that uses one.
     ///
-    /// Attributes imported from a dependency are never listed in `attributes` —
-    /// they only exist inlined inside the signals that reference them — so this
-    /// is the complete set, matching the resolved schema's attribute catalog.
-    /// The same key yields several items (one per referencing signal), so
-    /// callers wanting one entry per key should keep the first occurrence, which
-    /// is the registry-level definition whenever there is one.
+    /// Attributes imported from a dependency only ever exist inlined. A key can
+    /// appear several times; keep the first for one entry per key.
     pub fn all_attributes(&self) -> impl Iterator<Item = &Attribute> {
         self.attributes
             .iter()

--- a/crates/weaver_forge/src/v2/registry.rs
+++ b/crates/weaver_forge/src/v2/registry.rs
@@ -3,6 +3,7 @@
 use crate::v2::{attribute_group::AttributeGroupAttribute, provenance::Provenance};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use weaver_resolved_schema::{
     attribute::AttributeRef,
     v2::{catalog::AttributeCatalog, entity::EntityAttributeRef},
@@ -56,12 +57,14 @@ pub struct Registry {
 }
 
 impl Registry {
-    /// Every attribute reachable from this registry: the definitions first, then
-    /// the copy inlined into each signal that uses one.
+    /// Every attribute the registry can reach, one entry per key.
     ///
-    /// Attributes imported from a dependency only ever exist inlined. A key can
-    /// appear several times; callers keep the first for one entry per key.
-    pub fn all_attributes(&self) -> impl Iterator<Item = &Attribute> {
+    /// A superset of `attributes`: an attribute imported from a dependency is
+    /// never listed as a definition and exists only as the copy inlined into
+    /// each signal that uses it. Definitions are walked first, so a definition
+    /// wins over a signal's variant of the same key.
+    pub fn reachable_attributes(&self) -> impl Iterator<Item = &Attribute> {
+        let mut seen = HashSet::new();
         self.attributes
             .iter()
             .chain(
@@ -90,6 +93,7 @@ impl Registry {
                     .chain(e.description.iter())
                     .map(|a| &a.base)
             }))
+            .filter(move |a| seen.insert(a.key.as_str()))
     }
 }
 

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -109,7 +109,17 @@ impl LiveChecker {
                     let entity_rc = Rc::new(VersionedEntity::V2(Box::new(entity.clone())));
                     let _ = semconv_entities.insert(entity_type, entity_rc);
                 }
-                for attribute in &registry.registry.attributes {
+                // Attributes imported from a dependency only exist inlined in the
+                // signals that use them, so indexing `registry.attributes` alone
+                // would report them as missing from the registry.
+                // `all_attributes` yields definitions first, so skipping seen keys
+                // keeps the definition and collapses the copies.
+                for attribute in registry.registry.all_attributes() {
+                    if semconv_attributes.contains_key(&attribute.key)
+                        || semconv_templates.contains_key(&attribute.key)
+                    {
+                        continue;
+                    }
                     let attribute_rc = Rc::new(VersionedAttribute::V2(attribute.clone()));
                     match &attribute.r#type {
                         AttributeType::Template(_) => {
@@ -3365,6 +3375,85 @@ mod tests {
             has_custom_advice,
             "Expected custom_advice_finding to be present. Found: {:?}",
             advice
+        );
+    }
+
+    /// Builds a v2 registry with no attribute definitions: `imported.attr` is
+    /// reachable only through the metric that references it, as happens for an
+    /// attribute pulled in by `imports:` from a dependency.
+    fn make_registry_with_imported_attribute() -> VersionedRegistry {
+        let imported = V2Attribute {
+            key: "imported.attr".to_owned(),
+            r#type: AttributeType::PrimitiveOrArray(PrimitiveOrArrayTypeSpec::String),
+            examples: None,
+            common: CommonFields {
+                brief: "From a dependency".to_owned(),
+                note: String::new(),
+                stability: Stability::Stable,
+                deprecated: None,
+                annotations: BTreeMap::new(),
+            },
+            provenance: Default::default(),
+        };
+        VersionedRegistry::V2(Box::new(ForgeResolvedRegistry {
+            schema_url: "https://example.com/schemas/1.2.3"
+                .try_into()
+                .expect("Should be valid schema url"),
+            registry: Registry {
+                attributes: vec![],
+                attribute_groups: vec![],
+                metrics: vec![V2Metric {
+                    name: "imported.metric".to_owned().into(),
+                    instrument: InstrumentSpec::Counter,
+                    unit: "1".to_owned(),
+                    requirement_level: None,
+                    attributes: vec![MetricAttribute {
+                        base: imported,
+                        requirement_level: RequirementLevel::Basic(
+                            BasicRequirementLevelSpec::Required,
+                        ),
+                    }],
+                    entity_associations: vec![],
+                    common: CommonFields::default(),
+                    provenance: Default::default(),
+                }],
+                spans: vec![],
+                events: vec![],
+                entities: vec![],
+            },
+            refinements: Refinements {
+                metrics: vec![],
+                spans: vec![],
+                events: vec![],
+                entities: vec![],
+            },
+        }))
+    }
+
+    /// An attribute that only exists inlined in a signal is still part of the
+    /// registry, so it must not be reported as missing.
+    #[test]
+    fn test_imported_attribute_is_found_in_registry() {
+        let live_checker =
+            LiveChecker::new(Arc::new(make_registry_with_imported_attribute()), vec![]);
+
+        let found = live_checker
+            .find_attribute("imported.attr")
+            .expect("inlined attribute should be found in the registry");
+        match found.as_ref() {
+            VersionedAttribute::V2(attr) => assert_eq!(attr.common.brief, "From a dependency"),
+            VersionedAttribute::V1(_) => panic!("Expected a v2 attribute"),
+        }
+    }
+
+    /// Registry coverage counts attributes that arrive inlined through a signal.
+    #[test]
+    fn test_imported_attribute_counts_towards_registry_coverage() {
+        let stats = CumulativeStatistics::new(&make_registry_with_imported_attribute());
+        assert!(
+            stats.seen_registry_attributes.contains_key("imported.attr"),
+            "expected the inlined attribute to seed registry coverage, got {:?}",
+            stats.seen_registry_attributes
         );
     }
 

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -112,14 +112,7 @@ impl LiveChecker {
                 // Attributes imported from a dependency only exist inlined in the
                 // signals that use them, so indexing `registry.attributes` alone
                 // would report them as missing from the registry.
-                // `all_attributes` yields definitions first, so skipping seen keys
-                // keeps the definition and collapses the copies.
-                for attribute in registry.registry.all_attributes() {
-                    if semconv_attributes.contains_key(&attribute.key)
-                        || semconv_templates.contains_key(&attribute.key)
-                    {
-                        continue;
-                    }
+                for attribute in registry.registry.reachable_attributes() {
                     let attribute_rc = Rc::new(VersionedAttribute::V2(attribute.clone()));
                     match &attribute.r#type {
                         AttributeType::Template(_) => {
@@ -3378,29 +3371,36 @@ mod tests {
         );
     }
 
-    /// Builds a v2 registry with no attribute definitions: `imported.attr` is
-    /// reachable only through the metric that references it, as happens for an
-    /// attribute pulled in by `imports:` from a dependency.
-    fn make_registry_with_imported_attribute() -> VersionedRegistry {
-        let imported = V2Attribute {
-            key: "imported.attr".to_owned(),
+    fn v2_attribute(key: &str, brief: &str) -> V2Attribute {
+        V2Attribute {
+            key: key.to_owned(),
             r#type: AttributeType::PrimitiveOrArray(PrimitiveOrArrayTypeSpec::String),
             examples: None,
             common: CommonFields {
-                brief: "From a dependency".to_owned(),
+                brief: brief.to_owned(),
                 note: String::new(),
                 stability: Stability::Stable,
                 deprecated: None,
                 annotations: BTreeMap::new(),
             },
             provenance: Default::default(),
-        };
+        }
+    }
+
+    /// Builds a v2 registry whose metric inlines `inlined`. With `definitions`
+    /// empty the attribute is reachable only through that metric, as happens for
+    /// an attribute pulled in by `imports:` from a dependency.
+    fn make_registry_with_inlined_attribute(
+        definitions: Vec<V2Attribute>,
+        inlined: V2Attribute,
+    ) -> VersionedRegistry {
+        let imported = inlined;
         VersionedRegistry::V2(Box::new(ForgeResolvedRegistry {
             schema_url: "https://example.com/schemas/1.2.3"
                 .try_into()
                 .expect("Should be valid schema url"),
             registry: Registry {
-                attributes: vec![],
+                attributes: definitions,
                 attribute_groups: vec![],
                 metrics: vec![V2Metric {
                     name: "imported.metric".to_owned().into(),
@@ -3434,8 +3434,11 @@ mod tests {
     /// registry, so it must not be reported as missing.
     #[test]
     fn test_imported_attribute_is_found_in_registry() {
-        let live_checker =
-            LiveChecker::new(Arc::new(make_registry_with_imported_attribute()), vec![]);
+        let registry = make_registry_with_inlined_attribute(
+            vec![],
+            v2_attribute("imported.attr", "From a dependency"),
+        );
+        let live_checker = LiveChecker::new(Arc::new(registry), vec![]);
 
         let found = live_checker
             .find_attribute("imported.attr")
@@ -3446,10 +3449,33 @@ mod tests {
         }
     }
 
+    /// When an attribute is both defined by the registry and inlined into a
+    /// signal, the definition is the one live-check checks against.
+    #[test]
+    fn test_registry_definition_wins_over_inlined_copy() {
+        let registry = make_registry_with_inlined_attribute(
+            vec![v2_attribute("shared.attr", "The definition")],
+            v2_attribute("shared.attr", "An inlined copy"),
+        );
+        let live_checker = LiveChecker::new(Arc::new(registry), vec![]);
+
+        let found = live_checker
+            .find_attribute("shared.attr")
+            .expect("attribute should be found in the registry");
+        match found.as_ref() {
+            VersionedAttribute::V2(attr) => assert_eq!(attr.common.brief, "The definition"),
+            VersionedAttribute::V1(_) => panic!("Expected a v2 attribute"),
+        }
+    }
+
     /// Registry coverage counts attributes that arrive inlined through a signal.
     #[test]
     fn test_imported_attribute_counts_towards_registry_coverage() {
-        let stats = CumulativeStatistics::new(&make_registry_with_imported_attribute());
+        let registry = make_registry_with_inlined_attribute(
+            vec![],
+            v2_attribute("imported.attr", "From a dependency"),
+        );
+        let stats = CumulativeStatistics::new(&registry);
         assert!(
             stats.seen_registry_attributes.contains_key("imported.attr"),
             "expected the inlined attribute to seed registry coverage, got {:?}",

--- a/crates/weaver_live_check/src/stats.rs
+++ b/crates/weaver_live_check/src/stats.rs
@@ -7,7 +7,7 @@
 //! - `Disabled`: No-op mode for long-running sessions to prevent memory growth
 
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::{FindingLevel, LiveCheckResult, PolicyFinding, VersionedRegistry};
 use weaver_semconv::group::GroupType;
@@ -107,12 +107,7 @@ impl CumulativeStatistics {
             VersionedRegistry::V2(reg) => {
                 // Registry coverage must account for attributes imported from a
                 // dependency, which only exist inlined in the signals using them.
-                // The first entry for a key is the definition, when there is one.
-                let mut keys = HashSet::new();
-                for attribute in reg.registry.all_attributes() {
-                    if !keys.insert(attribute.key.as_str()) {
-                        continue;
-                    }
+                for attribute in reg.registry.reachable_attributes() {
                     if attribute.common.deprecated.is_none() {
                         let _ = seen_attributes.insert(attribute.key.clone(), 0);
                     }

--- a/crates/weaver_live_check/src/stats.rs
+++ b/crates/weaver_live_check/src/stats.rs
@@ -7,7 +7,7 @@
 //! - `Disabled`: No-op mode for long-running sessions to prevent memory growth
 
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::{FindingLevel, LiveCheckResult, PolicyFinding, VersionedRegistry};
 use weaver_semconv::group::GroupType;
@@ -105,7 +105,14 @@ impl CumulativeStatistics {
                 }
             }
             VersionedRegistry::V2(reg) => {
-                for attribute in &reg.registry.attributes {
+                // Registry coverage must account for attributes imported from a
+                // dependency, which only exist inlined in the signals using them.
+                // The first entry for a key is the definition, when there is one.
+                let mut keys = HashSet::new();
+                for attribute in reg.registry.all_attributes() {
+                    if !keys.insert(attribute.key.as_str()) {
+                        continue;
+                    }
                     if attribute.common.deprecated.is_none() {
                         let _ = seen_attributes.insert(attribute.key.clone(), 0);
                     }

--- a/crates/weaver_resolved_schema/src/v2/registry.rs
+++ b/crates/weaver_resolved_schema/src/v2/registry.rs
@@ -51,7 +51,7 @@ pub struct Registry {
 
 impl Registry {
     /// Every attribute reference in this registry: its own definitions first,
-    /// then one per signal attribute. The same attribute yields several
+    /// then one per signal attribute. A single attribute yields several
     /// references, since each signal keeps its own variant.
     pub fn attribute_refs(&self) -> impl Iterator<Item = &AttributeRef> {
         self.attributes
@@ -86,11 +86,9 @@ impl Registry {
 
     /// Every distinct attribute the registry can reach, de-duplicated by key.
     ///
-    /// This is a superset of `attributes`: an attribute imported from a
-    /// dependency is referenced by the signals that use it but never listed as a
-    /// definition, so counting only `attributes` under-reports what the registry
-    /// actually contains. Definitions come first, so a key defined here is
-    /// represented by its definition rather than by a signal's reference to it.
+    /// A superset of `attributes`: an attribute imported from a dependency is
+    /// referenced by signals but never listed as a definition. Definitions come
+    /// first, so they win de-duplication.
     #[must_use]
     pub fn reachable_attributes<T: AttributeCatalog>(&self, catalog: &T) -> Vec<AttributeRef> {
         let mut seen = HashSet::new();

--- a/crates/weaver_resolved_schema/src/v2/registry.rs
+++ b/crates/weaver_resolved_schema/src/v2/registry.rs
@@ -293,9 +293,143 @@ mod test {
         v2::{span::SpanName, CommonFields},
     };
 
-    use crate::v2::{attribute::Attribute, entity::EntityAttributeRef};
+    use crate::v2::{attribute::Attribute, entity::EntityAttributeRef, metric::MetricAttributeRef};
 
     use super::*;
+
+    /// Builds an attribute with the given key and brief.
+    fn attr(key: &str, brief: &str) -> Attribute {
+        Attribute {
+            key: key.to_owned(),
+            r#type: AttributeType::PrimitiveOrArray(
+                weaver_semconv::attribute::PrimitiveOrArrayTypeSpec::String,
+            ),
+            examples: None,
+            common: CommonFields {
+                brief: brief.to_owned(),
+                note: String::new(),
+                stability: Stability::Stable,
+                deprecated: None,
+                annotations: BTreeMap::new(),
+            },
+            provenance: Default::default(),
+        }
+    }
+
+    fn required() -> weaver_semconv::attribute::RequirementLevel {
+        weaver_semconv::attribute::RequirementLevel::Basic(
+            weaver_semconv::attribute::BasicRequirementLevelSpec::Required,
+        )
+    }
+
+    /// A registry whose catalog holds a definition, a second variant of that same
+    /// key, and a key only ever referenced by a signal. Only the definition is
+    /// listed in `attributes`.
+    fn registry_with_inlined_refs() -> (Vec<Attribute>, Registry) {
+        let catalog = vec![
+            attr("defined", "the definition"),
+            attr("defined", "a signal's variant"),
+            attr("inlined.only", "reached only through a signal"),
+        ];
+        let registry = Registry {
+            attributes: vec![AttributeRef(0)],
+            attribute_groups: vec![],
+            metrics: vec![Metric {
+                name: "test.metric".to_owned().into(),
+                instrument: InstrumentSpec::Counter,
+                unit: "{tests}".to_owned(),
+                attributes: vec![
+                    MetricAttributeRef {
+                        base: AttributeRef(1),
+                        requirement_level: required(),
+                    },
+                    MetricAttributeRef {
+                        base: AttributeRef(2),
+                        requirement_level: required(),
+                    },
+                ],
+                entity_associations: vec![],
+                requirement_level: None,
+                common: CommonFields::default(),
+                provenance: Default::default(),
+            }],
+            spans: vec![],
+            events: vec![],
+            entities: vec![Entity {
+                r#type: "test.entity".to_owned().into(),
+                // Identity and description are separate lists; both must be walked.
+                identity: vec![EntityAttributeRef {
+                    base: AttributeRef(2),
+                    requirement_level: required(),
+                }],
+                description: vec![EntityAttributeRef {
+                    base: AttributeRef(1),
+                    requirement_level: required(),
+                }],
+                requirement_level: None,
+                common: CommonFields::default(),
+                provenance: Default::default(),
+            }],
+        };
+        (catalog, registry)
+    }
+
+    #[test]
+    fn test_attribute_refs_yields_definitions_then_signal_refs() {
+        let (_, registry) = registry_with_inlined_refs();
+        let refs: Vec<AttributeRef> = registry.attribute_refs().copied().collect();
+
+        // Definition first, then one entry per signal attribute, including both
+        // an entity's identity and description lists.
+        assert_eq!(
+            refs,
+            vec![
+                AttributeRef(0),
+                AttributeRef(1),
+                AttributeRef(2),
+                AttributeRef(2),
+                AttributeRef(1),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_reachable_attributes_includes_signal_only_keys() {
+        let (catalog, registry) = registry_with_inlined_refs();
+        let keys: Vec<&str> = registry
+            .reachable_attributes(&catalog)
+            .iter()
+            .filter_map(|r| catalog.attribute(r))
+            .map(|a| a.key.as_str())
+            .collect();
+
+        // `inlined.only` is absent from `attributes`, so it is only present if
+        // signal references are walked.
+        assert_eq!(keys, vec!["defined", "inlined.only"]);
+    }
+
+    #[test]
+    fn test_reachable_attributes_dedups_by_key_keeping_the_definition() {
+        let (catalog, registry) = registry_with_inlined_refs();
+        let reachable = registry.reachable_attributes(&catalog);
+
+        // `defined` has two catalog entries and is referenced twice, yet appears
+        // once — as the definition listed in `attributes`, not a signal's variant.
+        assert_eq!(reachable.len(), 2);
+        assert!(!reachable.contains(&AttributeRef(1)));
+        let defined = catalog
+            .attribute(&reachable[0])
+            .expect("definition in catalog");
+        assert_eq!(defined.common.brief, "the definition");
+    }
+
+    #[test]
+    fn test_reachable_attributes_ignores_unknown_refs() {
+        let (catalog, mut registry) = registry_with_inlined_refs();
+        registry.attributes.push(AttributeRef(99));
+        // A ref with no catalog entry is skipped rather than counted.
+        assert_eq!(registry.reachable_attributes(&catalog).len(), 2);
+    }
 
     #[test]
     fn test_stats() {

--- a/crates/weaver_resolved_schema/src/v2/registry.rs
+++ b/crates/weaver_resolved_schema/src/v2/registry.rs
@@ -50,6 +50,60 @@ pub struct Registry {
 }
 
 impl Registry {
+    /// Every attribute reference in this registry: its own definitions first,
+    /// then one per signal attribute. The same attribute yields several
+    /// references, since each signal keeps its own variant.
+    pub fn attribute_refs(&self) -> impl Iterator<Item = &AttributeRef> {
+        self.attributes
+            .iter()
+            .chain(
+                self.attribute_groups
+                    .iter()
+                    .flat_map(|g| g.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(
+                self.metrics
+                    .iter()
+                    .flat_map(|m| m.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(
+                self.spans
+                    .iter()
+                    .flat_map(|s| s.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(
+                self.events
+                    .iter()
+                    .flat_map(|e| e.attributes.iter().map(|a| &a.base)),
+            )
+            .chain(self.entities.iter().flat_map(|e| {
+                e.identity
+                    .iter()
+                    .chain(e.description.iter())
+                    .map(|a| &a.base)
+            }))
+    }
+
+    /// Every distinct attribute the registry can reach, de-duplicated by key.
+    ///
+    /// This is a superset of `attributes`: an attribute imported from a
+    /// dependency is referenced by the signals that use it but never listed as a
+    /// definition, so counting only `attributes` under-reports what the registry
+    /// actually contains. Definitions come first, so a key defined here is
+    /// represented by its definition rather than by a signal's reference to it.
+    #[must_use]
+    pub fn reachable_attributes<T: AttributeCatalog>(&self, catalog: &T) -> Vec<AttributeRef> {
+        let mut seen = HashSet::new();
+        self.attribute_refs()
+            .filter(|r| {
+                catalog
+                    .attribute(r)
+                    .is_some_and(|a| seen.insert(a.key.as_str()))
+            })
+            .copied()
+            .collect()
+    }
+
     /// Returns the statistics for this registry.
     #[must_use]
     pub fn stats<T: AttributeCatalog>(&self, catalog: &T) -> RegistryStats {

--- a/crates/weaver_resolved_schema/src/v2/registry.rs
+++ b/crates/weaver_resolved_schema/src/v2/registry.rs
@@ -53,7 +53,7 @@ impl Registry {
     /// Every attribute reference in this registry: its own definitions first,
     /// then one per signal attribute. A single attribute yields several
     /// references, since each signal keeps its own variant.
-    pub fn attribute_refs(&self) -> impl Iterator<Item = &AttributeRef> {
+    fn attribute_refs(&self) -> impl Iterator<Item = &AttributeRef> {
         self.attributes
             .iter()
             .chain(
@@ -90,7 +90,7 @@ impl Registry {
     /// referenced by signals but never listed as a definition. Definitions come
     /// first, so they win de-duplication. A reference with no catalog entry is
     /// skipped.
-    pub fn reachable_attributes<'a, T: AttributeCatalog>(
+    fn reachable_attributes<'a, T: AttributeCatalog>(
         &'a self,
         catalog: &'a T,
     ) -> impl Iterator<Item = &'a Attribute> {

--- a/crates/weaver_resolved_schema/src/v2/registry.rs
+++ b/crates/weaver_resolved_schema/src/v2/registry.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use weaver_semconv::attribute::AttributeType;
 
 use crate::v2::{
-    attribute::AttributeRef,
+    attribute::{Attribute, AttributeRef},
     attribute_group::AttributeGroup,
     catalog::AttributeCatalog,
     entity::Entity,
@@ -88,18 +88,16 @@ impl Registry {
     ///
     /// A superset of `attributes`: an attribute imported from a dependency is
     /// referenced by signals but never listed as a definition. Definitions come
-    /// first, so they win de-duplication.
-    #[must_use]
-    pub fn reachable_attributes<T: AttributeCatalog>(&self, catalog: &T) -> Vec<AttributeRef> {
+    /// first, so they win de-duplication. A reference with no catalog entry is
+    /// skipped.
+    pub fn reachable_attributes<'a, T: AttributeCatalog>(
+        &'a self,
+        catalog: &'a T,
+    ) -> impl Iterator<Item = &'a Attribute> {
         let mut seen = HashSet::new();
         self.attribute_refs()
-            .filter(|r| {
-                catalog
-                    .attribute(r)
-                    .is_some_and(|a| seen.insert(a.key.as_str()))
-            })
-            .copied()
-            .collect()
+            .filter_map(|r| catalog.attribute(r))
+            .filter(move |a| seen.insert(a.key.as_str()))
     }
 
     /// Returns the statistics for this registry.
@@ -109,11 +107,12 @@ impl Registry {
             let mut attribute_type_breakdown = BTreeMap::new();
             let mut stability_breakdown = HashMap::new();
             let mut deprecated_count = 0;
-            for attribute in self
-                .attributes
-                .iter()
-                .filter_map(|ar| catalog.attribute(ar))
-            {
+            let mut attribute_count = 0;
+            // Counted over reachable attributes, not `self.attributes`: an
+            // attribute imported from a dependency is only ever referenced by a
+            // signal, and would otherwise go uncounted.
+            for attribute in self.reachable_attributes(catalog) {
+                attribute_count += 1;
                 let attribute_type = if let AttributeType::Enum { members, .. } = &attribute.r#type
                 {
                     format!("enum(card:{:03})", members.len())
@@ -131,7 +130,7 @@ impl Registry {
                     .or_default() += 1;
             }
             AttributeStats {
-                attribute_count: self.attributes.len(),
+                attribute_count,
                 attribute_type_breakdown,
                 stability_breakdown,
                 deprecated_count,
@@ -398,8 +397,6 @@ mod test {
         let (catalog, registry) = registry_with_inlined_refs();
         let keys: Vec<&str> = registry
             .reachable_attributes(&catalog)
-            .iter()
-            .filter_map(|r| catalog.attribute(r))
             .map(|a| a.key.as_str())
             .collect();
 
@@ -411,16 +408,12 @@ mod test {
     #[test]
     fn test_reachable_attributes_dedups_by_key_keeping_the_definition() {
         let (catalog, registry) = registry_with_inlined_refs();
-        let reachable = registry.reachable_attributes(&catalog);
+        let reachable: Vec<&Attribute> = registry.reachable_attributes(&catalog).collect();
 
         // `defined` has two catalog entries and is referenced twice, yet appears
         // once — as the definition listed in `attributes`, not a signal's variant.
         assert_eq!(reachable.len(), 2);
-        assert!(!reachable.contains(&AttributeRef(1)));
-        let defined = catalog
-            .attribute(&reachable[0])
-            .expect("definition in catalog");
-        assert_eq!(defined.common.brief, "the definition");
+        assert_eq!(reachable[0].common.brief, "the definition");
     }
 
     #[test]
@@ -428,7 +421,22 @@ mod test {
         let (catalog, mut registry) = registry_with_inlined_refs();
         registry.attributes.push(AttributeRef(99));
         // A ref with no catalog entry is skipped rather than counted.
-        assert_eq!(registry.reachable_attributes(&catalog).len(), 2);
+        assert_eq!(registry.reachable_attributes(&catalog).count(), 2);
+    }
+
+    /// The attribute count reported to `weaver registry stats` and the serve API
+    /// includes attributes that only exist inlined in a signal.
+    #[test]
+    fn test_stats_counts_reachable_attributes() {
+        let (catalog, registry) = registry_with_inlined_refs();
+        let stats = registry.stats(&catalog);
+
+        // One definition plus one signal-only key, not the single `attributes` entry.
+        assert_eq!(stats.attributes.attribute_count, 2);
+        assert_eq!(
+            stats.attributes.attribute_type_breakdown.get("string"),
+            Some(&2)
+        );
     }
 
     #[test]

--- a/crates/weaver_search/src/lib.rs
+++ b/crates/weaver_search/src/lib.rs
@@ -92,12 +92,8 @@ impl SearchContext {
 
         // Attributes imported from a dependency only exist inlined in the signals
         // that use them, so indexing `registry.attributes` alone would leave them
-        // unsearchable. `all_attributes` yields definitions first, so skipping
-        // seen keys keeps the definition and collapses the copies.
-        for attr in registry.registry.all_attributes() {
-            if attr_index.contains_key(&attr.key) || template_index.contains_key(&attr.key) {
-                continue;
-            }
+        // unsearchable.
+        for attr in registry.registry.reachable_attributes() {
             let arc_attr = Arc::new(attr.clone());
             items.push(SearchableItem::Attribute(Arc::clone(&arc_attr)));
 

--- a/crates/weaver_search/src/lib.rs
+++ b/crates/weaver_search/src/lib.rs
@@ -90,15 +90,10 @@ impl SearchContext {
         let mut event_index = HashMap::new();
         let mut entity_index = HashMap::new();
 
-        // Index every attribute the registry can reach, not just the ones it
-        // defines itself: attributes imported from a dependency are inlined into
-        // the signals that use them and never appear in `registry.attributes`,
-        // so indexing only that list would leave them unsearchable and give the
-        // links on signal detail pages nothing to resolve to.
-        //
-        // `all_attributes` yields the registry-level definitions first and then
-        // one copy per referencing signal, so skipping keys already seen keeps
-        // the definition and collapses the duplicates.
+        // Attributes imported from a dependency only exist inlined in the signals
+        // that use them, so indexing `registry.attributes` alone would leave them
+        // unsearchable. `all_attributes` yields definitions first, so skipping
+        // seen keys keeps the definition and collapses the copies.
         for attr in registry.registry.all_attributes() {
             if attr_index.contains_key(&attr.key) || template_index.contains_key(&attr.key) {
                 continue;
@@ -1150,10 +1145,8 @@ mod tests {
     // Inlined (imported) Attribute Indexing Tests
     // =========================================================================
 
-    /// Builds a registry whose only attribute reaches the index through a
-    /// metric, mimicking an attribute imported from a dependency: such
-    /// attributes are inlined into each referencing signal and never listed in
-    /// `registry.attributes`.
+    /// Builds a registry whose only attribute reaches the index through a metric,
+    /// mimicking an attribute imported from a dependency.
     fn registry_with_inlined_attribute(
         registry_level: Vec<Attribute>,
         inlined: Attribute,
@@ -1176,7 +1169,7 @@ mod tests {
     }
 
     /// An attribute that only exists inlined inside a signal is still indexed,
-    /// so it is searchable and has something for detail-page links to resolve to.
+    /// so it stays searchable and its detail page resolves.
     #[test]
     fn test_inlined_attribute_is_indexed() {
         let imported = make_attribute("imported.attr", "From a dependency", "A note", false);

--- a/crates/weaver_search/src/lib.rs
+++ b/crates/weaver_search/src/lib.rs
@@ -16,12 +16,8 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use weaver_forge::v2::{
-    attribute::Attribute,
-    entity::Entity,
-    event::Event,
-    metric::Metric,
-    registry::{ForgeResolvedRegistry, Registry},
-    span::Span,
+    attribute::Attribute, entity::Entity, event::Event, metric::Metric,
+    registry::ForgeResolvedRegistry, span::Span,
 };
 use weaver_semconv::attribute::AttributeType;
 use weaver_semconv::stability::Stability;
@@ -33,47 +29,6 @@ use weaver_semconv::stability::Stability;
 /// above this are clamped. Kept in sync with the documented maximum of the
 /// `/api/v1/registry/search` endpoint (`SearchParams::limit`).
 pub const MAX_SEARCH_LIMIT: usize = 1000;
-
-/// Every attribute reachable from a registry: the definitions first, then the
-/// copy inlined into each signal that uses one.
-///
-/// Attributes imported from a dependency only ever exist inlined. A key can
-/// appear several times; the caller keeps the first for one entry per key.
-fn all_attributes(registry: &Registry) -> impl Iterator<Item = &Attribute> {
-    registry
-        .attributes
-        .iter()
-        .chain(
-            registry
-                .attribute_groups
-                .iter()
-                .flat_map(|g| g.attributes.iter().map(|a| &a.base)),
-        )
-        .chain(
-            registry
-                .metrics
-                .iter()
-                .flat_map(|m| m.attributes.iter().map(|a| &a.base)),
-        )
-        .chain(
-            registry
-                .spans
-                .iter()
-                .flat_map(|s| s.attributes.iter().map(|a| &a.base)),
-        )
-        .chain(
-            registry
-                .events
-                .iter()
-                .flat_map(|e| e.attributes.iter().map(|a| &a.base)),
-        )
-        .chain(registry.entities.iter().flat_map(|e| {
-            e.identity
-                .iter()
-                .chain(e.description.iter())
-                .map(|a| &a.base)
-        }))
-}
 
 /// Search context for performing fuzzy searches and O(1) lookups across the registry.
 pub struct SearchContext {
@@ -139,7 +94,7 @@ impl SearchContext {
         // that use them, so indexing `registry.attributes` alone would leave them
         // unsearchable. `all_attributes` yields definitions first, so skipping
         // seen keys keeps the definition and collapses the copies.
-        for attr in all_attributes(&registry.registry) {
+        for attr in registry.registry.all_attributes() {
             if attr_index.contains_key(&attr.key) || template_index.contains_key(&attr.key) {
                 continue;
             }

--- a/crates/weaver_search/src/lib.rs
+++ b/crates/weaver_search/src/lib.rs
@@ -90,8 +90,19 @@ impl SearchContext {
         let mut event_index = HashMap::new();
         let mut entity_index = HashMap::new();
 
-        // Index all attributes
-        for attr in &registry.registry.attributes {
+        // Index every attribute the registry can reach, not just the ones it
+        // defines itself: attributes imported from a dependency are inlined into
+        // the signals that use them and never appear in `registry.attributes`,
+        // so indexing only that list would leave them unsearchable and give the
+        // links on signal detail pages nothing to resolve to.
+        //
+        // `all_attributes` yields the registry-level definitions first and then
+        // one copy per referencing signal, so skipping keys already seen keeps
+        // the definition and collapses the duplicates.
+        for attr in registry.registry.all_attributes() {
+            if attr_index.contains_key(&attr.key) || template_index.contains_key(&attr.key) {
+                continue;
+            }
             let arc_attr = Arc::new(attr.clone());
             items.push(SearchableItem::Attribute(Arc::clone(&arc_attr)));
 
@@ -577,8 +588,10 @@ fn score_fields(
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+    use weaver_forge::v2::metric::MetricAttribute;
     use weaver_forge::v2::registry::{ForgeResolvedRegistry, Refinements, Registry};
-    use weaver_semconv::attribute::AttributeType;
+    use weaver_forge::v2::span::SpanAttribute;
+    use weaver_semconv::attribute::{AttributeType, BasicRequirementLevelSpec, RequirementLevel};
     use weaver_semconv::deprecated::Deprecated;
     use weaver_semconv::group::{InstrumentSpec, SpanKindSpec};
     use weaver_semconv::signal_requirement_level::SignalRequirementLevel;
@@ -1131,6 +1144,103 @@ mod tests {
 
         let (_, total) = ctx.search(None, SearchType::All, Some(Stability::Stable), true, 100, 0);
         assert_eq!(total, 0);
+    }
+
+    // =========================================================================
+    // Inlined (imported) Attribute Indexing Tests
+    // =========================================================================
+
+    /// Builds a registry whose only attribute reaches the index through a
+    /// metric, mimicking an attribute imported from a dependency: such
+    /// attributes are inlined into each referencing signal and never listed in
+    /// `registry.attributes`.
+    fn registry_with_inlined_attribute(
+        registry_level: Vec<Attribute>,
+        inlined: Attribute,
+    ) -> ForgeResolvedRegistry {
+        let mut registry = make_registry_with_attributes(registry_level);
+        registry.registry.metrics = vec![Metric {
+            name: "imported.metric".to_owned().into(),
+            instrument: InstrumentSpec::Counter,
+            unit: "{x}".to_owned(),
+            requirement_level: None,
+            attributes: vec![MetricAttribute {
+                base: inlined,
+                requirement_level: RequirementLevel::Basic(BasicRequirementLevelSpec::Required),
+            }],
+            entity_associations: vec![],
+            common: CommonFields::default(),
+            provenance: Default::default(),
+        }];
+        registry
+    }
+
+    /// An attribute that only exists inlined inside a signal is still indexed,
+    /// so it is searchable and has something for detail-page links to resolve to.
+    #[test]
+    fn test_inlined_attribute_is_indexed() {
+        let imported = make_attribute("imported.attr", "From a dependency", "A note", false);
+        let registry = registry_with_inlined_attribute(vec![], imported);
+        let ctx = SearchContext::from_registry(&registry);
+
+        let found = ctx
+            .get_attribute("imported.attr")
+            .expect("inlined attribute should be resolvable by key");
+        assert_eq!(found.common.note, "A note");
+
+        let (_, total) = ctx.search(
+            Some("imported.attr"),
+            SearchType::Attribute,
+            None,
+            false,
+            10,
+            0,
+        );
+        assert_eq!(total, 1, "inlined attribute should be searchable");
+    }
+
+    /// The same attribute inlined into several signals is indexed once.
+    #[test]
+    fn test_inlined_attribute_is_not_duplicated() {
+        let imported = make_attribute("imported.attr", "From a dependency", "", false);
+        let mut registry = registry_with_inlined_attribute(vec![], imported.clone());
+        // A second signal referencing the same attribute.
+        registry.registry.spans = vec![Span {
+            r#type: "imported.span".to_owned().into(),
+            kind: SpanKindSpec::Client,
+            name: SpanName {
+                note: "n".to_owned(),
+            },
+            requirement_level: None,
+            attributes: vec![SpanAttribute {
+                base: imported,
+                requirement_level: RequirementLevel::Basic(BasicRequirementLevelSpec::Recommended),
+                sampling_relevant: None,
+            }],
+            entity_associations: vec![],
+            common: CommonFields::default(),
+            provenance: Default::default(),
+        }];
+
+        let ctx = SearchContext::from_registry(&registry);
+        let (_, total) = ctx.search(None, SearchType::Attribute, None, false, 100, 0);
+        assert_eq!(total, 1);
+    }
+
+    /// When an attribute is both defined by this registry and inlined into a
+    /// signal, the registry-level definition is the one that gets indexed.
+    #[test]
+    fn test_registry_definition_wins_over_inlined_copy() {
+        let definition = make_attribute("shared.attr", "The definition", "", false);
+        let inlined_copy = make_attribute("shared.attr", "An inlined copy", "", false);
+        let registry = registry_with_inlined_attribute(vec![definition], inlined_copy);
+
+        let ctx = SearchContext::from_registry(&registry);
+        let found = ctx.get_attribute("shared.attr").expect("attribute indexed");
+        assert_eq!(found.common.brief, "The definition");
+
+        let (_, total) = ctx.search(None, SearchType::Attribute, None, false, 100, 0);
+        assert_eq!(total, 1, "the definition and its copy are one attribute");
     }
 
     // =========================================================================

--- a/crates/weaver_search/src/lib.rs
+++ b/crates/weaver_search/src/lib.rs
@@ -16,8 +16,12 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use weaver_forge::v2::{
-    attribute::Attribute, entity::Entity, event::Event, metric::Metric,
-    registry::ForgeResolvedRegistry, span::Span,
+    attribute::Attribute,
+    entity::Entity,
+    event::Event,
+    metric::Metric,
+    registry::{ForgeResolvedRegistry, Registry},
+    span::Span,
 };
 use weaver_semconv::attribute::AttributeType;
 use weaver_semconv::stability::Stability;
@@ -29,6 +33,47 @@ use weaver_semconv::stability::Stability;
 /// above this are clamped. Kept in sync with the documented maximum of the
 /// `/api/v1/registry/search` endpoint (`SearchParams::limit`).
 pub const MAX_SEARCH_LIMIT: usize = 1000;
+
+/// Every attribute reachable from a registry: the definitions first, then the
+/// copy inlined into each signal that uses one.
+///
+/// Attributes imported from a dependency only ever exist inlined. A key can
+/// appear several times; the caller keeps the first for one entry per key.
+fn all_attributes(registry: &Registry) -> impl Iterator<Item = &Attribute> {
+    registry
+        .attributes
+        .iter()
+        .chain(
+            registry
+                .attribute_groups
+                .iter()
+                .flat_map(|g| g.attributes.iter().map(|a| &a.base)),
+        )
+        .chain(
+            registry
+                .metrics
+                .iter()
+                .flat_map(|m| m.attributes.iter().map(|a| &a.base)),
+        )
+        .chain(
+            registry
+                .spans
+                .iter()
+                .flat_map(|s| s.attributes.iter().map(|a| &a.base)),
+        )
+        .chain(
+            registry
+                .events
+                .iter()
+                .flat_map(|e| e.attributes.iter().map(|a| &a.base)),
+        )
+        .chain(registry.entities.iter().flat_map(|e| {
+            e.identity
+                .iter()
+                .chain(e.description.iter())
+                .map(|a| &a.base)
+        }))
+}
 
 /// Search context for performing fuzzy searches and O(1) lookups across the registry.
 pub struct SearchContext {
@@ -94,7 +139,7 @@ impl SearchContext {
         // that use them, so indexing `registry.attributes` alone would leave them
         // unsearchable. `all_attributes` yields definitions first, so skipping
         // seen keys keeps the definition and collapses the copies.
-        for attr in registry.registry.all_attributes() {
+        for attr in all_attributes(&registry.registry) {
             if attr_index.contains_key(&attr.key) || template_index.contains_key(&attr.key) {
                 continue;
             }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -90,13 +90,9 @@ fn run_serve(
         crate::weaver::Resolved::V2(v) => v,
     };
 
-    // Compute the full registry stats once, before the resolved schema is
-    // consumed into the template (forge) representation.
-    //
-    // Stats are taken over every attribute the registry can reach, not just the
-    // ones it defines: the search index does the same, and the stats page links
-    // its attribute tile straight into that search, so counting only the
-    // definitions would show a total that disagrees with the page it opens.
+    // Computed before the schema is consumed into the forge representation, and
+    // over every attribute the registry can reach so the total matches the search
+    // index the stats page links into.
     let stats = {
         let schema = resolved_v2.resolved_schema();
         let mut registry = schema.registry.clone();
@@ -108,6 +104,9 @@ fn run_serve(
             refinements: schema.refinements.stats(),
         }
     };
+    // From the stats, not `registry.attributes`: the latter counts only this
+    // registry's own definitions and would disagree with the API.
+    let attribute_count = stats.registry.attributes.attribute_count;
     let forge_registry = resolved_v2.into_template_schema();
 
     let stats_response = types::RegistryStatsResponse {
@@ -127,7 +126,7 @@ fn run_serve(
     info!("Registry loaded successfully");
     info!(
         "Found {} attributes, {} metrics, {} spans, {} events, {} entities",
-        forge_registry.registry.attributes.len(),
+        attribute_count,
         forge_registry.registry.metrics.len(),
         forge_registry.registry.spans.len(),
         forge_registry.registry.events.len(),

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -7,7 +7,6 @@ use std::net::SocketAddr;
 use clap::Args;
 use log::info;
 use weaver_common::diagnostic::DiagnosticMessages;
-use weaver_resolved_schema::v2::stats::Stats;
 
 use crate::registry::{load_config, PolicyArgs, RegistryArgs};
 use crate::{CmdResult, DiagnosticArgs, ExitDirectives};
@@ -90,20 +89,8 @@ fn run_serve(
         crate::weaver::Resolved::V2(v) => v,
     };
 
-    // Computed before the schema is consumed into the forge representation, and
-    // over every attribute the registry can reach so the total matches the search
-    // index the stats page links into.
-    let stats = {
-        let schema = resolved_v2.resolved_schema();
-        let mut registry = schema.registry.clone();
-        registry.attributes = schema
-            .registry
-            .reachable_attributes(&schema.attribute_catalog);
-        Stats {
-            registry: registry.stats(&schema.attribute_catalog),
-            refinements: schema.refinements.stats(),
-        }
-    };
+    // Computed before the schema is consumed into the forge representation.
+    let stats = resolved_v2.resolved_schema().stats();
     // From the stats, not `registry.attributes`: the latter counts only this
     // registry's own definitions and would disagree with the API.
     let attribute_count = stats.registry.attributes.attribute_count;

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -7,6 +7,7 @@ use std::net::SocketAddr;
 use clap::Args;
 use log::info;
 use weaver_common::diagnostic::DiagnosticMessages;
+use weaver_resolved_schema::v2::stats::Stats;
 
 use crate::registry::{load_config, PolicyArgs, RegistryArgs};
 use crate::{CmdResult, DiagnosticArgs, ExitDirectives};
@@ -89,9 +90,24 @@ fn run_serve(
         crate::weaver::Resolved::V2(v) => v,
     };
 
-    // Compute the full registry stats once, before the resolved schema is consumed
-    // into the template (forge) representation.
-    let stats = resolved_v2.resolved_schema().stats();
+    // Compute the full registry stats once, before the resolved schema is
+    // consumed into the template (forge) representation.
+    //
+    // Stats are taken over every attribute the registry can reach, not just the
+    // ones it defines: the search index does the same, and the stats page links
+    // its attribute tile straight into that search, so counting only the
+    // definitions would show a total that disagrees with the page it opens.
+    let stats = {
+        let schema = resolved_v2.resolved_schema();
+        let mut registry = schema.registry.clone();
+        registry.attributes = schema
+            .registry
+            .reachable_attributes(&schema.attribute_catalog);
+        Stats {
+            registry: registry.stats(&schema.attribute_catalog),
+            refinements: schema.refinements.stats(),
+        }
+    };
     let forge_registry = resolved_v2.into_template_schema();
 
     let stats_response = types::RegistryStatsResponse {


### PR DESCRIPTION
Update - found the same issue in `stats` and critically `live-check`:

Fix attributes imported from a dependency being treated as if they were not part of the registry. Such an attribute is only ever referenced by the signals that use it, never listed as a definition, so `weaver registry stats` counted it nowhere, `weaver serve` left it out of search and detail pages, and `weaver registry live-check --v2` reported it as a `missing_attribute` violation and excluded it from registry coverage. All three now consider every attribute the registry can reach.

----

Attributes imported from a dependency are inlined into the signals that use them and never listed in `registry.attributes`. `weaver serve` indexed only that list, so those attributes were unsearchable, had no detail page, and the attribute links on every imported signal's page dead-ended on "Attribute not found". Registry stats counted the same list, so the attributes tile showed 0 while the API was serving them.

Search, detail pages and stats now cover every attribute the registry can reach. `weaver registry stats` is unchanged.

Repro, from `crates/weaver_resolver`:
```
    weaver serve --v2 -r data/transitive-provenance/main --skip-policies
```
`/api/v1/registry/attribute/base.host.id` returns 404 before and 200 after.
`/api/v1/registry/search?type=attribute` reports 0 attributes before and 1 after.

Follow-up, not in this PR: a `ref:` can override `brief`/`note`, so an attribute can have several variants. Where the attribute is imported there is no definition to prefer, and the detail page in the UI shows whichever variant is encountered first. A follow-up should surface all variants and where each is used. Note the variants can share a schema URL, they are distinguished by the referencing signal, not by origin registry.
