### PR TITLE
 resolver: fix provenance and resolution of attributes inherited from dependencies

### DIFF
--- a/crates/weaver_resolved_schema/src/attribute.rs
+++ b/crates/weaver_resolved_schema/src/attribute.rs
@@ -17,6 +17,7 @@ use weaver_semconv::attribute::{
     AttributeRole, AttributeSpec, AttributeType, Examples, RequirementLevel,
 };
 use weaver_semconv::deprecated::Deprecated;
+use weaver_semconv::schema_url::SchemaUrl;
 use weaver_semconv::stability::Stability;
 use weaver_semconv::YamlValue;
 
@@ -102,6 +103,10 @@ pub struct Attribute {
 pub struct UnresolvedAttribute {
     /// The attribute specification.
     pub spec: AttributeSpec,
+    /// The schema of the registry that defines this attribute, when it did not
+    /// originate locally.
+    #[serde(default)]
+    pub origin: Option<SchemaUrl>,
 }
 
 /// An internal reference to an attribute in the catalog.

--- a/crates/weaver_resolved_schema/src/catalog.rs
+++ b/crates/weaver_resolved_schema/src/catalog.rs
@@ -24,7 +24,21 @@ pub struct Catalog {
     /// Attribute definitions available in this registry (including those
     /// from dependencies). Used for cross-registry attribute lookup.
     /// Not serialized — populated only for freshly resolved schemas.
-    root_attributes: HashMap<String, (Attribute, String)>,
+    root_attributes: HashMap<String, RootAttribute>,
+}
+
+/// What is known about an attribute key beyond the individual, possibly
+/// refined, copies held in the catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RootAttribute {
+    /// The attribute.
+    pub attribute: Attribute,
+    /// The group, or dependency, the attribute came from.
+    pub source_group: String,
+    /// Whether this is a definition a reference may resolve against. Attributes
+    /// inherited through a refinement are recorded here for their provenance,
+    /// but they are instances of a definition owned elsewhere, not definitions.
+    pub is_definition: bool,
 }
 
 /// Statistics on a catalog.
@@ -47,7 +61,7 @@ impl Catalog {
     /// Creates a catalog from a list of attributes and root attribute definitions.
     pub fn new(
         attributes: Vec<Attribute>,
-        root_attributes: HashMap<String, (Attribute, String)>,
+        root_attributes: HashMap<String, RootAttribute>,
     ) -> Self {
         Self {
             attributes,
@@ -55,12 +69,24 @@ impl Catalog {
         }
     }
 
-    /// Looks up an attribute by name in the root attribute definitions.
+    /// Looks up an attribute by name, whether or not this registry defines it.
+    /// Use this to answer "where did this attribute come from"; use
+    /// [`Catalog::root_attribute_definition`] to resolve a reference.
     #[must_use]
     pub fn root_attribute(&self, name: &str) -> Option<(&Attribute, &str)> {
         self.root_attributes
             .get(name)
-            .map(|(attr, group_id)| (attr, group_id.as_str()))
+            .map(|root| (&root.attribute, root.source_group.as_str()))
+    }
+
+    /// Looks up the definition of an attribute, ignoring attributes that merely
+    /// passed through this registry as part of a refinement.
+    #[must_use]
+    pub fn root_attribute_definition(&self, name: &str) -> Option<(&Attribute, &str)> {
+        self.root_attributes
+            .get(name)
+            .filter(|root| root.is_definition)
+            .map(|root| (&root.attribute, root.source_group.as_str()))
     }
 
     /// Counts the number of attributes in the catalog.
@@ -145,7 +171,7 @@ pub mod test_utils {
     #[derive(Default)]
     pub struct CatalogBuilder {
         attributes: Vec<Attribute>,
-        root_attributes: HashMap<String, (Attribute, String)>,
+        root_attributes: HashMap<String, RootAttribute>,
     }
 
     impl CatalogBuilder {
@@ -164,9 +190,14 @@ pub mod test_utils {
         /// is also registered as a root definition for cross-registry lookup.
         pub fn add(&mut self, attr: Attribute, group_id: Option<&str>) -> AttributeRef {
             if let Some(gid) = group_id {
-                let _ = self
-                    .root_attributes
-                    .insert(attr.name.clone(), (attr.clone(), gid.to_owned()));
+                let _ = self.root_attributes.insert(
+                    attr.name.clone(),
+                    RootAttribute {
+                        attribute: attr.clone(),
+                        source_group: gid.to_owned(),
+                        is_definition: true,
+                    },
+                );
             }
             let idx = self.attributes.len();
             self.attributes.push(attr);

--- a/crates/weaver_resolver/data/inherited-ref-test/base/manifest.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/base/manifest.yaml
@@ -1,0 +1,2 @@
+description: Defines `base.attr`.
+schema_url: https://base.example.com/schemas/1.0.0

--- a/crates/weaver_resolver/data/inherited-ref-test/base/registry.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/base/registry.yaml
@@ -4,3 +4,12 @@ attributes:
     type: string
     brief: Defined by base.
     stability: stable
+metrics:
+  - name: base.metric
+    brief: Metric defined by base.
+    instrument: counter
+    unit: "1"
+    stability: stable
+    requirement_level: recommended
+    attributes:
+      - ref: base.attr

--- a/crates/weaver_resolver/data/inherited-ref-test/base/registry.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/base/registry.yaml
@@ -1,0 +1,6 @@
+file_format: definition/2
+attributes:
+  - key: base.attr
+    type: string
+    brief: Defined by base.
+    stability: stable

--- a/crates/weaver_resolver/data/inherited-ref-test/middle/manifest.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/middle/manifest.yaml
@@ -1,0 +1,5 @@
+description: Uses `base.attr` on a metric without defining it.
+schema_url: https://middle.example.com/schemas/1.0.0
+dependencies:
+  - schema_url: https://base.example.com/schemas/1.0.0
+    registry_path: data/inherited-ref-test/base

--- a/crates/weaver_resolver/data/inherited-ref-test/middle/registry.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/middle/registry.yaml
@@ -1,0 +1,10 @@
+file_format: definition/2
+metrics:
+  - name: middle.metric
+    brief: Metric defined by middle.
+    instrument: counter
+    unit: "1"
+    stability: stable
+    requirement_level: recommended
+    attributes:
+      - ref: base.attr

--- a/crates/weaver_resolver/data/inherited-ref-test/middle_published/manifest.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/middle_published/manifest.yaml
@@ -1,0 +1,8 @@
+file_format: manifest/2.0
+schema_url: https://middle.example.com/schemas/1.0.0
+description: Uses `base.attr` on a metric without defining it.
+dependencies:
+- schema_url: https://base.example.com/schemas/1.0.0
+  registry_path: data/inherited-ref-test/base
+stability: development
+resolved_registry_uri: resolved.yaml

--- a/crates/weaver_resolver/data/inherited-ref-test/middle_published/resolved.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/middle_published/resolved.yaml
@@ -1,0 +1,42 @@
+file_format: resolved/2.0
+schema_url: https://middle.example.com/schemas/1.0.0
+attribute_catalog:
+- key: base.attr
+  type: string
+  brief: Defined by base.
+  stability: stable
+  provenance:
+    source: 0
+registry:
+  attributes: []
+  attribute_groups: []
+  spans: []
+  metrics:
+  - name: middle.metric
+    instrument: counter
+    unit: '1'
+    attributes:
+    - base: 0
+      requirement_level: recommended
+    requirement_level: recommended
+    brief: Metric defined by middle.
+    stability: stable
+  events: []
+  entities: []
+refinements:
+  spans: []
+  metrics:
+  - id: middle.metric
+    name: middle.metric
+    instrument: counter
+    unit: '1'
+    attributes:
+    - base: 0
+      requirement_level: recommended
+    requirement_level: recommended
+    brief: Metric defined by middle.
+    stability: stable
+  events: []
+  entities: []
+dependencies:
+- https://base.example.com/schemas/1.0.0

--- a/crates/weaver_resolver/data/inherited-ref-test/refiner/manifest.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/refiner/manifest.yaml
@@ -1,0 +1,5 @@
+description: Refines a base signal without defining anything of its own.
+schema_url: https://refiner.example.com/schemas/1.0.0
+dependencies:
+  - schema_url: https://base.example.com/schemas/1.0.0
+    registry_path: data/inherited-ref-test/base

--- a/crates/weaver_resolver/data/inherited-ref-test/refiner/registry.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/refiner/registry.yaml
@@ -1,0 +1,5 @@
+file_format: definition/2
+metric_refinements:
+  - id: refiner.refined
+    ref: base.metric
+    brief: Refined base metric

--- a/crates/weaver_resolver/data/inherited-ref-test/refiner_user/manifest.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/refiner_user/manifest.yaml
@@ -1,0 +1,5 @@
+description: References an attribute that its dependency only inherited, via a source registry.
+schema_url: https://refiner-user.example.com/schemas/1.0.0
+dependencies:
+  - schema_url: https://refiner.example.com/schemas/1.0.0
+    registry_path: data/inherited-ref-test/refiner

--- a/crates/weaver_resolver/data/inherited-ref-test/refiner_user/registry.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/refiner_user/registry.yaml
@@ -1,0 +1,13 @@
+file_format: definition/2
+# `refiner` never defines `base.attr`; it only carries it on a refinement.
+# Resolving from source must refuse this the same way a published `refiner`
+# would.
+metrics:
+  - name: refiner.user.metric
+    brief: Metric defined by refiner_user.
+    instrument: counter
+    unit: "1"
+    stability: stable
+    requirement_level: recommended
+    attributes:
+      - ref: base.attr

--- a/crates/weaver_resolver/data/inherited-ref-test/user/manifest.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/user/manifest.yaml
@@ -1,0 +1,5 @@
+description: Refines a middle signal, then references the inherited attribute directly.
+schema_url: https://user.example.com/schemas/1.0.0
+dependencies:
+  - schema_url: https://middle.example.com/schemas/1.0.0
+    registry_path: data/inherited-ref-test/middle_published

--- a/crates/weaver_resolver/data/inherited-ref-test/user/registry.yaml
+++ b/crates/weaver_resolver/data/inherited-ref-test/user/registry.yaml
@@ -1,0 +1,20 @@
+file_format: definition/2
+# Refining a signal brings `base.attr` into this registry as an instance of a
+# definition owned by `base`, which `middle` never re-published. It must not
+# become something `user.metric` can reference on its own.
+metric_refinements:
+  - id: user.refined
+    ref: middle.metric
+    brief: Refined middle metric
+    attributes:
+      - ref: base.attr
+        brief: base.attr as used by user
+metrics:
+  - name: user.metric
+    brief: Metric defined by user.
+    instrument: counter
+    unit: "1"
+    stability: stable
+    requirement_level: recommended
+    attributes:
+      - ref: base.attr

--- a/crates/weaver_resolver/data/registry-test-v2-dep/deep_registry/expected-schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-dep/deep_registry/expected-schema.yaml
@@ -1,0 +1,76 @@
+file_format: resolved/2.0
+schema_url: https://deep-consumer.example.com/schemas/1.0.0
+attribute_catalog:
+- key: server.address
+  type: string
+  examples:
+  - example.com
+  brief: Server address.
+  stability: stable
+  provenance:
+    source: 1
+- key: server.address
+  type: string
+  examples:
+  - example.com
+  brief: Different brief
+  note: Different note
+  stability: stable
+  provenance:
+    source: 1
+- key: server.port
+  type: int
+  examples:
+  - 80
+  - 443
+  brief: Server port.
+  stability: stable
+  provenance:
+    source: 1
+- key: server.port
+  type: int
+  examples:
+  - 80
+  - 443
+  brief: Deeply refined server port
+  stability: stable
+  provenance:
+    source: 1
+registry:
+  attributes: []
+  attribute_groups: []
+  spans: []
+  metrics: []
+  events: []
+  entities: []
+refinements:
+  spans: []
+  metrics:
+  - id: deep.consumer.count
+    name: consumer.request.count
+    instrument: counter
+    unit: '{request}'
+    attributes:
+    - base: 0
+      requirement_level: required
+    - base: 3
+      requirement_level: recommended
+    requirement_level: recommended
+    brief: Refined consumer request count
+    stability: stable
+  - id: deep.server.duration
+    name: server.request.duration
+    instrument: histogram
+    unit: s
+    attributes:
+    - base: 1
+      requirement_level: required
+    - base: 2
+      requirement_level: recommended
+    brief: Refined server request duration
+    stability: stable
+  events: []
+  entities: []
+dependencies:
+- https://consumer.example.com/schemas/1.0.0
+- https://server.example.com/schemas/1.0.0

--- a/crates/weaver_resolver/data/registry-test-v2-dep/deep_registry/registry/manifest.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-dep/deep_registry/registry/manifest.yaml
@@ -1,0 +1,7 @@
+description: Registry refining signals from two dependencies, one reached transitively.
+schema_url: https://deep-consumer.example.com/schemas/1.0.0
+dependencies:
+  - schema_url: https://consumer.example.com/schemas/1.0.0
+    registry_path: data/registry-test-v2-dep/consumer_registry
+  - schema_url: https://server.example.com/schemas/1.0.0
+    registry_path: data/registry-test-v2-dep/published

--- a/crates/weaver_resolver/data/registry-test-v2-dep/deep_registry/registry/registry.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-dep/deep_registry/registry/registry.yaml
@@ -1,0 +1,14 @@
+file_format: definition/2
+metric_refinements:
+  # `consumer.request.count` comes from `consumer`, but its attributes are
+  # defined in `server` - one level deeper. Provenance must point at `server`.
+  - id: deep.consumer.count
+    ref: consumer.request.count
+    brief: Refined consumer request count
+    attributes:
+      - ref: server.port
+        brief: Deeply refined server port
+  # Same attributes, this time reached through a direct dependency.
+  - id: deep.server.duration
+    ref: server.request.duration
+    brief: Refined server request duration

--- a/crates/weaver_resolver/data/registry-test-v2-dep/entity_registry/expected-schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-dep/entity_registry/expected-schema.yaml
@@ -7,18 +7,24 @@ attribute_catalog:
   - amd64
   brief: Host architecture.
   stability: stable
+  provenance:
+    source: 0
 - key: host.id
   type: string
   examples:
   - fdbf79e8af94cb7f9e8df36789187052
   brief: Refined host ID
   stability: stable
+  provenance:
+    source: 0
 - key: host.name
   type: string
   examples:
   - opentelemetry-test
   brief: Refined host name
   stability: stable
+  provenance:
+    source: 0
 registry:
   attributes: []
   attribute_groups: []

--- a/crates/weaver_resolver/data/registry-test-v2-dep/event_registry/expected-schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-dep/event_registry/expected-schema.yaml
@@ -8,6 +8,8 @@ attribute_catalog:
   brief: Different brief
   note: Different note
   stability: stable
+  provenance:
+    source: 0
 - key: server.port
   type: int
   examples:
@@ -15,6 +17,8 @@ attribute_catalog:
   - 443
   brief: Refined server port
   stability: stable
+  provenance:
+    source: 0
 registry:
   attributes: []
   attribute_groups: []

--- a/crates/weaver_resolver/data/registry-test-v2-dep/metric_registry/expected-schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-dep/metric_registry/expected-schema.yaml
@@ -8,6 +8,8 @@ attribute_catalog:
   brief: Different brief
   note: Different note
   stability: stable
+  provenance:
+    source: 0
 - key: server.port
   type: int
   examples:
@@ -15,6 +17,8 @@ attribute_catalog:
   - 443
   brief: Refined server port
   stability: stable
+  provenance:
+    source: 0
 registry:
   attributes: []
   attribute_groups: []

--- a/crates/weaver_resolver/data/registry-test-v2-dep/span_registry/expected-schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-dep/span_registry/expected-schema.yaml
@@ -8,6 +8,8 @@ attribute_catalog:
   brief: Different brief
   note: Different note
   stability: stable
+  provenance:
+    source: 0
 - key: server.port
   type: int
   examples:
@@ -15,6 +17,8 @@ attribute_catalog:
   - 443
   brief: Refined server port
   stability: stable
+  provenance:
+    source: 0
 registry:
   attributes: []
   attribute_groups: []

--- a/crates/weaver_resolver/data/registry-test-v2-dep/v1_dep_registry/expected-schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-dep/v1_dep_registry/expected-schema.yaml
@@ -1,0 +1,53 @@
+file_format: resolved/2.0
+schema_url: https://v1-dep-consumer.example.com/schemas/1.0.0
+attribute_catalog:
+- key: auction.id
+  type: int
+  brief: |
+    The id of the auction.
+  stability: stable
+  provenance:
+    source: 0
+- key: auction.name
+  type: string
+  examples:
+  - Fish for sale
+  brief: Refined auction name
+  stability: stable
+  provenance:
+    source: 0
+- key: error.type
+  type: string
+  examples: Ex
+  brief: The error type.
+  stability: stable
+  provenance:
+    source: 1
+registry:
+  attributes: []
+  attribute_groups: []
+  spans: []
+  metrics: []
+  events: []
+  entities: []
+refinements:
+  spans: []
+  metrics:
+  - id: refined.bid.count
+    name: auction.bid.count
+    instrument: counter
+    unit: '{bid}'
+    attributes:
+    - base: 0
+      requirement_level: required
+    - base: 1
+      requirement_level: recommended
+    - base: 2
+      requirement_level: required
+    brief: Refined count of bids
+    stability: stable
+  events: []
+  entities: []
+dependencies:
+- https://acme.com/schemas/0.1.0
+- https://opentelemetry.io/schemas/1.30.0

--- a/crates/weaver_resolver/data/registry-test-v2-dep/v1_dep_registry/registry/manifest.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-dep/v1_dep_registry/registry/manifest.yaml
@@ -1,0 +1,5 @@
+description: V2 registry refining a metric from a v1 dependency whose attributes come from a registry one level deeper.
+schema_url: https://v1-dep-consumer.example.com/schemas/1.0.0
+dependencies:
+  - schema_url: https://acme.com/schemas/0.1.0
+    registry_path: data/multi-registry/custom_registry

--- a/crates/weaver_resolver/data/registry-test-v2-dep/v1_dep_registry/registry/registry.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-dep/v1_dep_registry/registry/registry.yaml
@@ -1,0 +1,10 @@
+file_format: definition/2
+metric_refinements:
+  # `auction.*` are defined by acme, `error.type` comes from the otel registry
+  # that acme itself depends on.
+  - id: refined.bid.count
+    ref: auction.bid.count
+    brief: Refined count of bids
+    attributes:
+      - ref: auction.name
+        brief: Refined auction name

--- a/crates/weaver_resolver/src/attribute.rs
+++ b/crates/weaver_resolver/src/attribute.rs
@@ -638,7 +638,16 @@ impl AttributeLookup for V1Schema {
             }));
         }
 
-        // Fallback: search in all groups for the attribute
+        // This schema knows the attribute but does not define it - it arrived
+        // through a refinement and belongs to another registry. Scanning the
+        // groups below would find it on the refinement and hand it out as if
+        // this schema defined it.
+        if self.catalog.root_attribute(key).is_some() {
+            return Ok(None);
+        }
+
+        // Fallback for schemas without root attributes, e.g. ones deserialized
+        // from a published artifact: search in all groups for the attribute.
         for group in self.registry.groups.iter() {
             for attr_ref in group.attributes.iter() {
                 if let Some(a) = self.catalog.attribute(attr_ref) {

--- a/crates/weaver_resolver/src/attribute.rs
+++ b/crates/weaver_resolver/src/attribute.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 use weaver_resolved_schema::attribute::AttributeRef;
 use weaver_resolved_schema::attribute::{self};
-use weaver_resolved_schema::catalog::Catalog;
+use weaver_resolved_schema::catalog::{Catalog, RootAttribute};
 use weaver_resolved_schema::lineage::{AttributeLineage, GroupLineage};
 use weaver_resolved_schema::v2::ResolvedTelemetrySchema as V2Schema;
 use weaver_resolved_schema::ResolvedTelemetrySchema as V1Schema;
@@ -48,6 +48,10 @@ pub struct AttributeWithSource {
     pub attribute: attribute::Attribute,
     /// The source.
     pub source: AttributeSource,
+    /// Whether this is a definition a reference may resolve against. An
+    /// attribute inherited through a refinement is recorded for its provenance
+    /// but is an instance of a definition owned by another registry.
+    pub is_definition: bool,
 }
 
 impl AttributeCatalog {
@@ -142,6 +146,7 @@ impl AttributeCatalog {
         let mut new_attr = AttributeWithSource {
             attribute: attr,
             source,
+            is_definition: true,
         };
         // Make sure we pick the attribute from the *correct* version of a transitive dependency.
         new_attr = Self::upgrade_attribute_with_source(new_attr, cache_lookup)?;
@@ -188,6 +193,11 @@ fn resolve_conflict(
     m: AttributeWithSource,
     existing: AttributeWithSource,
 ) -> Result<AttributeWithSource, Error> {
+    match (m.is_definition, existing.is_definition) {
+        (true, false) => return Ok(m),
+        (false, true) => return Ok(existing),
+        _ => {}
+    }
     match (&m.source, &existing.source) {
         (AttributeSource::Local { .. }, AttributeSource::Local { .. }) => Ok(existing),
         // Prefer Dependency over Local to preserve original SchemaUrl provenance:
@@ -304,7 +314,10 @@ impl AttributeCatalog {
                 role,
             } => {
                 let name;
-                let mut root_attr: Option<&AttributeWithSource> = self.root_attributes.get(r#ref);
+                let mut root_attr: Option<&AttributeWithSource> = self
+                    .root_attributes
+                    .get(r#ref)
+                    .filter(|root| root.is_definition);
                 // If we fail to find an attribute, check dependencies first.
                 if root_attr.is_none() {
                     if let Some(at) = dependencies.lookup_attribute(r#ref)? {
@@ -398,6 +411,7 @@ impl AttributeCatalog {
                                 source: AttributeSource::Local {
                                     group_id: group_id.to_owned(),
                                 },
+                                is_definition: true,
                             },
                         );
                     }
@@ -461,6 +475,10 @@ impl AttributeCatalog {
                 let root_attr = AttributeWithSource {
                     attribute: attr.clone(),
                     source,
+                    // An `Id` spec carrying an origin is an attribute inherited
+                    // from a dependency through a refinement, not a definition
+                    // this registry owns.
+                    is_definition: origin.is_none(),
                 };
                 let root_attr = match self.root_attributes.get(id) {
                     Some(existing) => resolve_conflict(id, root_attr, existing.clone())?,
@@ -485,7 +503,14 @@ impl From<AttributeCatalog> for Catalog {
                         format!("v2_dependency.{}", schema_url.name())
                     }
                 };
-                (k, (v.attribute, source_str))
+                (
+                    k,
+                    RootAttribute {
+                        attribute: v.attribute,
+                        source_group: source_str,
+                        is_definition: v.is_definition,
+                    },
+                )
             })
             .collect();
         let mut attributes: Vec<(attribute::Attribute, AttributeRef)> =
@@ -569,7 +594,7 @@ impl AttributeLookup for ResolvedDependency {
 
 impl AttributeLookup for V1Schema {
     fn lookup_attribute(&self, key: &str) -> Result<Option<AttributeWithSource>, Error> {
-        if let Some((attr, group_id)) = self.catalog.root_attribute(key) {
+        if let Some((attr, group_id)) = self.catalog.root_attribute_definition(key) {
             // We encode pure schema_url dependencies with magic strings in V1.
             let source = if let Some(schema_name) = group_id.strip_prefix("v2_dependency.") {
                 // The attribute originates in one of this schema's own
@@ -609,6 +634,7 @@ impl AttributeLookup for V1Schema {
             return Ok(Some(AttributeWithSource {
                 attribute: attr.clone(),
                 source,
+                is_definition: true,
             }));
         }
 
@@ -629,6 +655,7 @@ impl AttributeLookup for V1Schema {
                         return Ok(Some(AttributeWithSource {
                             attribute: a.clone(),
                             source,
+                            is_definition: true,
                         }));
                     }
                 }
@@ -664,6 +691,7 @@ impl AttributeLookup for V2Schema {
                         value: None,
                         role: None,
                     },
+                    is_definition: true,
                     source: AttributeSource::Dependency {
                         schema_url: if let Some(dep_ref) = &attr.provenance.source {
                             self.dependencies
@@ -911,7 +939,14 @@ mod tests {
             value: None,
             role: None,
         };
-        _ = root_attributes.insert(attr_name.to_owned(), (attr_v1.clone(), "group1".to_owned()));
+        _ = root_attributes.insert(
+            attr_name.to_owned(),
+            RootAttribute {
+                attribute: attr_v1.clone(),
+                source_group: "group1".to_owned(),
+                is_definition: true,
+            },
+        );
 
         let schema_v1 = V1Schema {
             file_format: "resolved/1.0".to_owned(),

--- a/crates/weaver_resolver/src/attribute.rs
+++ b/crates/weaver_resolver/src/attribute.rs
@@ -283,6 +283,7 @@ impl AttributeCatalog {
         group_prefix: &str,
         group_excluded: bool,
         attr: &AttributeSpec,
+        origin: Option<&SchemaUrl>,
         lineage: Option<&mut GroupLineage>,
         dependencies: &Vec<ResolvedDependency>,
         cache_lookup: &C,
@@ -449,15 +450,23 @@ impl AttributeCatalog {
                     role: role.clone(),
                 };
 
-                _ = self.root_attributes.insert(
-                    id.to_owned(),
-                    AttributeWithSource {
-                        attribute: attr.clone(),
-                        source: AttributeSource::Local {
-                            group_id: group_id.to_owned(),
-                        },
+                let source = match origin {
+                    Some(schema_url) => AttributeSource::Dependency {
+                        schema_url: schema_url.clone(),
                     },
-                );
+                    None => AttributeSource::Local {
+                        group_id: group_id.to_owned(),
+                    },
+                };
+                let root_attr = AttributeWithSource {
+                    attribute: attr.clone(),
+                    source,
+                };
+                let root_attr = match self.root_attributes.get(id) {
+                    Some(existing) => resolve_conflict(id, root_attr, existing.clone())?,
+                    None => root_attr,
+                };
+                _ = self.root_attributes.insert(id.to_owned(), root_attr);
                 Ok(Some(self.attribute_ref(attr)))
             }
         }

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -640,11 +640,12 @@ impl ImportableDependency for V2Schema {
     ) -> Result<Vec<GroupWithProvenance>, Error> {
         let mut result = vec![];
         let mut exclusion_errors: Vec<Error> = vec![];
+        let deps: Vec<_> = self.dependencies.iter().cloned().collect();
 
         // Helper to map V2 provenance to V1 provenance.
         let get_source_provenance = |prov: &weaver_resolved_schema::v2::provenance::Provenance| -> weaver_semconv::provenance::Provenance {
             let url = if let Some(dep_ref) = &prov.source {
-                self.dependencies.iter().nth(dep_ref.0 as usize).cloned().unwrap_or_else(|| self.schema_url.clone())
+                deps.get(dep_ref.0 as usize).cloned().unwrap_or_else(|| self.schema_url.clone())
             } else {
                 self.schema_url.clone()
             };
@@ -656,10 +657,8 @@ impl ImportableDependency for V2Schema {
             |attr: &weaver_resolved_schema::v2::attribute::Attribute| -> AttributeSource {
                 if let Some(dep_ref) = &attr.provenance.source {
                     AttributeSource::Dependency {
-                        schema_url: self
-                            .dependencies
-                            .iter()
-                            .nth(dep_ref.0 as usize)
+                        schema_url: deps
+                            .get(dep_ref.0 as usize)
                             .cloned()
                             .unwrap_or_else(|| self.schema_url.clone()),
                     }
@@ -1201,11 +1200,12 @@ impl GroupRefinementLookup for V1Schema {
 /// when the attribute was inherited, otherwise `schema` itself.
 fn attr_origin(
     schema: &V2Schema,
+    deps: &[SchemaUrl],
     a: &weaver_resolved_schema::v2::attribute::Attribute,
 ) -> SchemaUrl {
     a.provenance
         .source
-        .and_then(|dep| schema.dependencies.iter().nth(dep.0 as usize).cloned())
+        .and_then(|dep| deps.get(dep.0 as usize).cloned())
         .unwrap_or_else(|| schema.schema_url.clone())
 }
 
@@ -1214,13 +1214,14 @@ fn attr_origin(
 /// signal's attribute reference.
 fn attr_spec(
     schema: &V2Schema,
+    deps: &[SchemaUrl],
     a: &weaver_resolved_schema::v2::attribute::Attribute,
     requirement_level: RequirementLevel,
     sampling_relevant: Option<bool>,
     role: Option<AttributeRole>,
 ) -> UnresolvedAttribute {
     UnresolvedAttribute {
-        origin: Some(attr_origin(schema, a)),
+        origin: Some(attr_origin(schema, deps, a)),
         spec: weaver_semconv::attribute::AttributeSpec::Id {
             id: a.key.clone(),
             r#type: a.r#type.clone(),
@@ -1267,7 +1268,7 @@ fn signal_summary(
 /// Builds a group summary for an entity, with identity attributes tagged
 /// with the identifying role and description attributes with the
 /// descriptive role, so refinements inherit them correctly.
-fn entity_group_summary(schema: &V2Schema, e: &Entity) -> GroupSummary {
+fn entity_group_summary(schema: &V2Schema, deps: &[SchemaUrl], e: &Entity) -> GroupSummary {
     let attributes = e
         .identity
         .iter()
@@ -1281,7 +1282,7 @@ fn entity_group_summary(schema: &V2Schema, e: &Entity) -> GroupSummary {
             schema
                 .attribute_catalog
                 .get(ar.base.0 as usize)
-                .map(|a| attr_spec(schema, a, ar.requirement_level.clone(), None, Some(role)))
+                .map(|a| attr_spec(schema, deps, a, ar.requirement_level.clone(), None, Some(role)))
         })
         .collect();
     signal_summary(
@@ -1294,6 +1295,8 @@ fn entity_group_summary(schema: &V2Schema, e: &Entity) -> GroupSummary {
 
 impl GroupRefinementLookup for V2Schema {
     fn lookup_group_summary(&self, id: &str) -> Option<GroupSummary> {
+        let deps: Vec<_> = self.dependencies.iter().cloned().collect();
+
         // An `extends` clause references either the v1 group id
         // (`entity.host`, written by v2 refinements over prefix-stripped
         // published signals) or the raw published signal id
@@ -1307,7 +1310,7 @@ impl GroupRefinementLookup for V2Schema {
         }
 
         if let Some(e) = find(&self.registry.entities, id, "entity.") {
-            return Some(entity_group_summary(self, e));
+            return Some(entity_group_summary(self, &deps, e));
         }
         if let Some(m) = find(&self.registry.metrics, id, "metric.") {
             let attributes = m
@@ -1316,7 +1319,7 @@ impl GroupRefinementLookup for V2Schema {
                 .filter_map(|ar| {
                     self.attribute_catalog
                         .get(ar.base.0 as usize)
-                        .map(|a| attr_spec(self, a, ar.requirement_level.clone(), None, None))
+                        .map(|a| attr_spec(self, &deps, a, ar.requirement_level.clone(), None, None))
                 })
                 .collect();
             let mut summary = signal_summary(
@@ -1337,7 +1340,7 @@ impl GroupRefinementLookup for V2Schema {
                 .filter_map(|ar| {
                     self.attribute_catalog
                         .get(ar.base.0 as usize)
-                        .map(|a| attr_spec(self, a, ar.requirement_level.clone(), None, None))
+                        .map(|a| attr_spec(self, &deps, a, ar.requirement_level.clone(), None, None))
                 })
                 .collect();
             return Some(signal_summary(
@@ -1355,6 +1358,7 @@ impl GroupRefinementLookup for V2Schema {
                     self.attribute_catalog.get(ar.base.0 as usize).map(|a| {
                         attr_spec(
                             self,
+                            &deps,
                             a,
                             ar.requirement_level.clone(),
                             ar.sampling_relevant,

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -1161,12 +1161,19 @@ pub(crate) trait GroupRefinementLookup {
 
 impl GroupRefinementLookup for V1Schema {
     fn lookup_group_summary(&self, id: &str) -> Option<GroupSummary> {
+        let my_schema_url = SchemaUrl::try_from(self.schema_url.as_str()).ok();
         self.group(id).map(|g| {
             let attributes: Vec<UnresolvedAttribute> = g
                 .attributes
                 .iter()
                 .filter_map(|ar| self.catalog.attribute(ar))
                 .map(|a| UnresolvedAttribute {
+                    origin: my_schema_url.as_ref().map(|url| {
+                        match find_attribute_source(self, &a.name, url) {
+                            AttributeSource::Dependency { schema_url } => schema_url,
+                            AttributeSource::Local { .. } => url.clone(),
+                        }
+                    }),
                     spec: weaver_semconv::attribute::AttributeSpec::Id {
                         id: a.name.clone(),
                         r#type: a.r#type.clone(),
@@ -1190,16 +1197,30 @@ impl GroupRefinementLookup for V1Schema {
     }
 }
 
+/// The registry that defines a v2 attribute: one of `schema`'s own dependencies
+/// when the attribute was inherited, otherwise `schema` itself.
+fn attr_origin(
+    schema: &V2Schema,
+    a: &weaver_resolved_schema::v2::attribute::Attribute,
+) -> SchemaUrl {
+    a.provenance
+        .source
+        .and_then(|dep| schema.dependencies.iter().nth(dep.0 as usize).cloned())
+        .unwrap_or_else(|| schema.schema_url.clone())
+}
+
 /// Converts a v2 catalog attribute into an unresolved attribute spec with
 /// the given requirement level, sampling relevance and role taken from the
 /// signal's attribute reference.
 fn attr_spec(
+    schema: &V2Schema,
     a: &weaver_resolved_schema::v2::attribute::Attribute,
     requirement_level: RequirementLevel,
     sampling_relevant: Option<bool>,
     role: Option<AttributeRole>,
 ) -> UnresolvedAttribute {
     UnresolvedAttribute {
+        origin: Some(attr_origin(schema, a)),
         spec: weaver_semconv::attribute::AttributeSpec::Id {
             id: a.key.clone(),
             r#type: a.r#type.clone(),
@@ -1260,7 +1281,7 @@ fn entity_group_summary(schema: &V2Schema, e: &Entity) -> GroupSummary {
             schema
                 .attribute_catalog
                 .get(ar.base.0 as usize)
-                .map(|a| attr_spec(a, ar.requirement_level.clone(), None, Some(role)))
+                .map(|a| attr_spec(schema, a, ar.requirement_level.clone(), None, Some(role)))
         })
         .collect();
     signal_summary(
@@ -1295,7 +1316,7 @@ impl GroupRefinementLookup for V2Schema {
                 .filter_map(|ar| {
                     self.attribute_catalog
                         .get(ar.base.0 as usize)
-                        .map(|a| attr_spec(a, ar.requirement_level.clone(), None, None))
+                        .map(|a| attr_spec(self, a, ar.requirement_level.clone(), None, None))
                 })
                 .collect();
             let mut summary = signal_summary(
@@ -1316,7 +1337,7 @@ impl GroupRefinementLookup for V2Schema {
                 .filter_map(|ar| {
                     self.attribute_catalog
                         .get(ar.base.0 as usize)
-                        .map(|a| attr_spec(a, ar.requirement_level.clone(), None, None))
+                        .map(|a| attr_spec(self, a, ar.requirement_level.clone(), None, None))
                 })
                 .collect();
             return Some(signal_summary(
@@ -1332,7 +1353,13 @@ impl GroupRefinementLookup for V2Schema {
                 .iter()
                 .filter_map(|ar| {
                     self.attribute_catalog.get(ar.base.0 as usize).map(|a| {
-                        attr_spec(a, ar.requirement_level.clone(), ar.sampling_relevant, None)
+                        attr_spec(
+                            self,
+                            a,
+                            ar.requirement_level.clone(),
+                            ar.sampling_relevant,
+                            None,
+                        )
                     })
                 })
                 .collect();

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -1279,10 +1279,16 @@ fn entity_group_summary(schema: &V2Schema, deps: &[SchemaUrl], e: &Entity) -> Gr
                 .map(|ar| (ar, AttributeRole::Descriptive)),
         )
         .filter_map(|(ar, role)| {
-            schema
-                .attribute_catalog
-                .get(ar.base.0 as usize)
-                .map(|a| attr_spec(schema, deps, a, ar.requirement_level.clone(), None, Some(role)))
+            schema.attribute_catalog.get(ar.base.0 as usize).map(|a| {
+                attr_spec(
+                    schema,
+                    deps,
+                    a,
+                    ar.requirement_level.clone(),
+                    None,
+                    Some(role),
+                )
+            })
         })
         .collect();
     signal_summary(
@@ -1295,8 +1301,6 @@ fn entity_group_summary(schema: &V2Schema, deps: &[SchemaUrl], e: &Entity) -> Gr
 
 impl GroupRefinementLookup for V2Schema {
     fn lookup_group_summary(&self, id: &str) -> Option<GroupSummary> {
-        let deps: Vec<_> = self.dependencies.iter().cloned().collect();
-
         // An `extends` clause references either the v1 group id
         // (`entity.host`, written by v2 refinements over prefix-stripped
         // published signals) or the raw published signal id
@@ -1309,6 +1313,8 @@ impl GroupRefinementLookup for V2Schema {
                 .or_else(|| by_id(id))
         }
 
+        let deps: Vec<_> = self.dependencies.iter().cloned().collect();
+
         if let Some(e) = find(&self.registry.entities, id, "entity.") {
             return Some(entity_group_summary(self, &deps, e));
         }
@@ -1317,9 +1323,9 @@ impl GroupRefinementLookup for V2Schema {
                 .attributes
                 .iter()
                 .filter_map(|ar| {
-                    self.attribute_catalog
-                        .get(ar.base.0 as usize)
-                        .map(|a| attr_spec(self, &deps, a, ar.requirement_level.clone(), None, None))
+                    self.attribute_catalog.get(ar.base.0 as usize).map(|a| {
+                        attr_spec(self, &deps, a, ar.requirement_level.clone(), None, None)
+                    })
                 })
                 .collect();
             let mut summary = signal_summary(
@@ -1338,9 +1344,9 @@ impl GroupRefinementLookup for V2Schema {
                 .attributes
                 .iter()
                 .filter_map(|ar| {
-                    self.attribute_catalog
-                        .get(ar.base.0 as usize)
-                        .map(|a| attr_spec(self, &deps, a, ar.requirement_level.clone(), None, None))
+                    self.attribute_catalog.get(ar.base.0 as usize).map(|a| {
+                        attr_spec(self, &deps, a, ar.requirement_level.clone(), None, None)
+                    })
                 })
                 .collect();
             return Some(signal_summary(

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -992,6 +992,34 @@ mod tests {
         Ok(())
     }
 
+    /// Same as above, but resolving the dependency from source rather than from
+    /// a published artifact. Both forms must refuse the reference - otherwise a
+    /// registry resolves differently depending on how it was delivered.
+    #[test]
+    fn test_inherited_attribute_is_not_a_definition_from_source(
+    ) -> Result<(), weaver_semconv::Error> {
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/inherited-ref-test/refiner_user".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let mut resolver = WeaverResolver::new(WeaverResolverConfig::default());
+
+        match resolver
+            .load_and_resolve_schema(registry_repo, DefaultSchemaVisitor)
+            .into_result_failing_non_fatal()
+        {
+            Ok(_) => panic!("expected `base.attr` to be unresolvable in `refiner.user.metric`"),
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("metric.refiner.user.metric") && msg.contains("base.attr"),
+                    "Expected an unresolved attribute reference, got: {msg}"
+                );
+            }
+        }
+        Ok(())
+    }
+
     /// Refinement over a v1 dependency: attributes defined by the dependency
     /// and attributes it inherited from its own dependency must be attributed
     /// to different registries.

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -933,6 +933,34 @@ mod tests {
         assert_resolved_v2_schema("data/registry-test-v2-dep/deep_registry")
     }
 
+    /// An attribute a dependency inherited rather than defined reaches this
+    /// registry only through the signals that carry it. Refining such a signal
+    /// must not turn the attribute into something a bare `ref` can resolve
+    /// against - that would resolve to the refinement's own copy.
+    #[test]
+    fn test_inherited_attribute_is_not_a_definition() -> Result<(), weaver_semconv::Error> {
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/inherited-ref-test/user".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let mut resolver = WeaverResolver::new(WeaverResolverConfig::default());
+
+        match resolver
+            .load_and_resolve_schema(registry_repo, DefaultSchemaVisitor)
+            .into_result_failing_non_fatal()
+        {
+            Ok(_) => panic!("expected `base.attr` to be unresolvable in `user.metric`"),
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("metric.user.metric") && msg.contains("base.attr"),
+                    "Expected an unresolved attribute reference, got: {msg}"
+                );
+            }
+        }
+        Ok(())
+    }
+
     /// Refinement over a v1 dependency: attributes defined by the dependency
     /// and attributes it inherited from its own dependency must be attributed
     /// to different registries.
@@ -2237,6 +2265,7 @@ groups:
         let orig_aws = AttributeWithSource {
             attribute: attr.clone(),
             source: orig_source.clone(),
+            is_definition: true,
         };
 
         let result_aws = AttributeCatalog::upgrade_attribute_with_source(orig_aws, &lookup_ctx)?;

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -956,6 +956,22 @@ mod tests {
         assert_resolved_v2_schema("data/registry-test-v2-dep/entity_registry")
     }
 
+    /// Refinements over two dependencies, where the attributes of one of them
+    /// are defined a level deeper. Provenance must name the registry that
+    /// defines an attribute, not the one it was reached through.
+    #[test]
+    fn test_v2_transitive_dependency_attribute_provenance() -> Result<(), weaver_semconv::Error> {
+        assert_resolved_v2_schema("data/registry-test-v2-dep/deep_registry")
+    }
+
+    /// Refinement over a v1 dependency: attributes defined by the dependency
+    /// and attributes it inherited from its own dependency must be attributed
+    /// to different registries.
+    #[test]
+    fn test_v1_dependency_attribute_provenance() -> Result<(), weaver_semconv::Error> {
+        assert_resolved_v2_schema("data/registry-test-v2-dep/v1_dep_registry")
+    }
+
     /// Can't demote an identity attribute of a base entity.
     #[test]
     fn test_v2_dependency_entity_identity_demotion_rejected() -> Result<(), weaver_semconv::Error> {

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -964,6 +964,34 @@ mod tests {
         assert_resolved_v2_schema("data/registry-test-v2-dep/deep_registry")
     }
 
+    /// An attribute a dependency inherited rather than defined reaches this
+    /// registry only through the signals that carry it. Refining such a signal
+    /// must not turn the attribute into something a bare `ref` can resolve
+    /// against - that would resolve to the refinement's own copy.
+    #[test]
+    fn test_inherited_attribute_is_not_a_definition() -> Result<(), weaver_semconv::Error> {
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/inherited-ref-test/user".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let mut resolver = WeaverResolver::new(WeaverResolverConfig::default());
+
+        match resolver
+            .load_and_resolve_schema(registry_repo, DefaultSchemaVisitor)
+            .into_result_failing_non_fatal()
+        {
+            Ok(_) => panic!("expected `base.attr` to be unresolvable in `user.metric`"),
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("metric.user.metric") && msg.contains("base.attr"),
+                    "Expected an unresolved attribute reference, got: {msg}"
+                );
+            }
+        }
+        Ok(())
+    }
+
     /// Refinement over a v1 dependency: attributes defined by the dependency
     /// and attributes it inherited from its own dependency must be attributed
     /// to different registries.
@@ -2268,6 +2296,7 @@ groups:
         let orig_aws = AttributeWithSource {
             attribute: attr.clone(),
             source: orig_source.clone(),
+            is_definition: true,
         };
 
         let result_aws = AttributeCatalog::upgrade_attribute_with_source(orig_aws, &lookup_ctx)?;

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -961,6 +961,34 @@ mod tests {
         Ok(())
     }
 
+    /// Same as above, but resolving the dependency from source rather than from
+    /// a published artifact. Both forms must refuse the reference - otherwise a
+    /// registry resolves differently depending on how it was delivered.
+    #[test]
+    fn test_inherited_attribute_is_not_a_definition_from_source(
+    ) -> Result<(), weaver_semconv::Error> {
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/inherited-ref-test/refiner_user".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let mut resolver = WeaverResolver::new(WeaverResolverConfig::default());
+
+        match resolver
+            .load_and_resolve_schema(registry_repo, DefaultSchemaVisitor)
+            .into_result_failing_non_fatal()
+        {
+            Ok(_) => panic!("expected `base.attr` to be unresolvable in `refiner.user.metric`"),
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("metric.refiner.user.metric") && msg.contains("base.attr"),
+                    "Expected an unresolved attribute reference, got: {msg}"
+                );
+            }
+        }
+        Ok(())
+    }
+
     /// Refinement over a v1 dependency: attributes defined by the dependency
     /// and attributes it inherited from its own dependency must be attributed
     /// to different registries.

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -925,6 +925,22 @@ mod tests {
         assert_resolved_v2_schema("data/registry-test-v2-dep/entity_registry")
     }
 
+    /// Refinements over two dependencies, where the attributes of one of them
+    /// are defined a level deeper. Provenance must name the registry that
+    /// defines an attribute, not the one it was reached through.
+    #[test]
+    fn test_v2_transitive_dependency_attribute_provenance() -> Result<(), weaver_semconv::Error> {
+        assert_resolved_v2_schema("data/registry-test-v2-dep/deep_registry")
+    }
+
+    /// Refinement over a v1 dependency: attributes defined by the dependency
+    /// and attributes it inherited from its own dependency must be attributed
+    /// to different registries.
+    #[test]
+    fn test_v1_dependency_attribute_provenance() -> Result<(), weaver_semconv::Error> {
+        assert_resolved_v2_schema("data/registry-test-v2-dep/v1_dep_registry")
+    }
+
     /// Can't demote an identity attribute of a base entity.
     #[test]
     fn test_v2_dependency_entity_identity_demotion_rejected() -> Result<(), weaver_semconv::Error> {

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -23,6 +23,7 @@ use weaver_semconv::group::{
 };
 use weaver_semconv::provenance::Provenance;
 use weaver_semconv::registry_repo::RegistryRepo;
+use weaver_semconv::schema_url::SchemaUrl;
 use weaver_semconv::semconv::{SemConvSpecV1WithProvenance, SemConvSpecWithProvenance};
 use weaver_semconv::v2::attribute_group::AttributeGroupVisibilitySpec;
 
@@ -324,7 +325,10 @@ fn group_from_spec(group: GroupSpecWithProvenance) -> UnresolvedGroup {
         .spec
         .attributes
         .into_iter()
-        .map(|attr| UnresolvedAttribute { spec: attr })
+        .map(|attr| UnresolvedAttribute {
+            spec: attr,
+            origin: None,
+        })
         .collect::<Vec<UnresolvedAttribute>>();
 
     UnresolvedGroup {
@@ -465,6 +469,7 @@ fn resolve_attribute_references<C: crate::SchemaCacheLookup>(
                     &unresolved_group.group.prefix,
                     group_excluded,
                     &attr.spec,
+                    attr.origin.as_ref(),
                     unresolved_group.group.lineage.as_mut(),
                     &ureg.dependencies,
                     cache_lookup,
@@ -860,6 +865,7 @@ fn resolve_inheritance_attrs_unified(
     struct AttrWithLineage {
         spec: AttributeSpec,
         lineage: AttributeLineage,
+        origin: Option<SchemaUrl>,
     }
 
     // A map attribute_id -> attribute_spec + lineage.
@@ -878,6 +884,7 @@ fn resolve_inheritance_attrs_unified(
                     &mut existing.lineage,
                 );
                 existing.lineage.source_group = parent_group_id.to_owned();
+                existing.origin = parent_attr.origin.clone();
             } else {
                 let lineage = AttributeLineage::inherit_from(parent_group_id, &parent_attr.spec);
                 log::debug!(
@@ -891,6 +898,7 @@ fn resolve_inheritance_attrs_unified(
                     AttrWithLineage {
                         spec: parent_attr.spec.clone(),
                         lineage,
+                        origin: parent_attr.origin.clone(),
                     },
                 );
             }
@@ -904,6 +912,7 @@ fn resolve_inheritance_attrs_unified(
                 if let Some(AttrWithLineage {
                     spec: parent_attr,
                     lineage,
+                    ..
                 }) = inherited_attrs.get_mut(r#ref)
                 {
                     *parent_attr = resolve_inheritance_attr(&attr.spec, parent_attr, lineage);
@@ -913,6 +922,7 @@ fn resolve_inheritance_attrs_unified(
                         AttrWithLineage {
                             spec: attr.spec.clone(),
                             lineage: AttributeLineage::new(group_id),
+                            origin: attr.origin.clone(),
                         },
                     );
                 }
@@ -923,6 +933,7 @@ fn resolve_inheritance_attrs_unified(
                     AttrWithLineage {
                         spec: attr.spec.clone(),
                         lineage: AttributeLineage::new(group_id),
+                        origin: attr.origin.clone(),
                     },
                 );
             }
@@ -941,6 +952,7 @@ fn resolve_inheritance_attrs_unified(
                 }
                 UnresolvedAttribute {
                     spec: attr_with_lineage.spec,
+                    origin: attr_with_lineage.origin,
                 }
             })
             .collect()
@@ -948,6 +960,7 @@ fn resolve_inheritance_attrs_unified(
         inherited_attrs
             .map(|attr_with_lineage| UnresolvedAttribute {
                 spec: attr_with_lineage.spec,
+                origin: attr_with_lineage.origin,
             })
             .collect()
     }
@@ -1871,6 +1884,7 @@ groups:
         examples: Option<Examples>,
     ) -> UnresolvedAttribute {
         UnresolvedAttribute {
+            origin: None,
             spec: AttributeSpec::Ref {
                 r#ref: id.to_owned(),
                 brief: None,


### PR DESCRIPTION
Related to https://github.com/open-telemetry/weaver/issues/1658

1. Provenance was lost on attributes inherited through a refinement

```diff
# b/main.yaml — b depends on a, refines a's metric
metric_refinements:
  - id: b.refined
    ref: a.metric
    brief: refined

  # b's resolved.yaml
  attribute_catalog:
  - key: foo
    brief: the foo
+   provenance:
+     source: 0      # → a
```

2. A bare ref resolved against the refinement's own copy

```diff
# c/main.yaml — refines b.metric, and has its own metric
metric_refinements:
  - id: c.refined
    ref: b.metric
    attributes:
      - ref: foo
        brief: foo as used by c     # signal-local wording
metrics:
  - name: c.metric
    attributes:
      - ref: foo                    # unrelated metric

  - name: c.metric
    attributes:
-   - base: 0        # brief: foo as used by c
+   - base: 1        # brief: the foo
```

3. A dependency re-exported an attribute it never defined, as its own

```diff
# b/main.yaml — b defines nothing, only refines
metric_refinements:
  - id: b.refined
    ref: a.metric

# c/main.yaml — c depends on b only
metrics:
  - name: c.metric
    attributes:
      - ref: foo

  # c's resolved.yaml
- - key: foo
-   provenance:
-     source: 1      # ← b, but a defines it
+ × attribute reference is not resolved: foo
```

Case 3 only happened when the dependency was consumed from source; a published one already refused. Now both behave the same.