### PR TITLE
Disallow stability and deprecated on v2 attribute refs

### DIFF
--- a/crates/weaver_infer/src/lib.rs
+++ b/crates/weaver_infer/src/lib.rs
@@ -516,8 +516,6 @@ fn attribute_ref(name: &str) -> AttributeRef {
         examples: None,
         requirement_level: None,
         note: None,
-        stability: None,
-        deprecated: None,
         annotations: BTreeMap::new(),
     }
 }

--- a/crates/weaver_semconv/src/v2/attribute.rs
+++ b/crates/weaver_semconv/src/v2/attribute.rs
@@ -9,8 +9,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     attribute::{AttributeRole, AttributeSpec, AttributeType, Examples, RequirementLevel},
-    deprecated::Deprecated,
-    stability::Stability,
     v2::{signal_id::SignalId, CommonFields},
     YamlValue,
 };
@@ -43,14 +41,6 @@ pub struct AttributeRef {
     /// Refines the more elaborate description of the attribute.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
-    /// Refines the stability of the attribute.
-    /// This denotes whether an attribute is stable for a specific
-    /// signal.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stability: Option<Stability>,
-    /// Specifies if the attribute is deprecated for this signal.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deprecated: Option<Deprecated>,
     /// Additional annotations for the attribute. These will be
     /// merged with annotations from the definition.
     #[serde(default)]
@@ -70,8 +60,8 @@ impl AttributeRef {
             requirement_level: self.requirement_level,
             sampling_relevant: None,
             note: self.note,
-            stability: self.stability,
-            deprecated: self.deprecated,
+            stability: None,
+            deprecated: None,
             prefix: false,
             annotations: if self.annotations.is_empty() {
                 None
@@ -92,8 +82,8 @@ impl AttributeRef {
             requirement_level: self.requirement_level,
             sampling_relevant: None,
             note: self.note,
-            stability: self.stability,
-            deprecated: self.deprecated,
+            stability: None,
+            deprecated: None,
             prefix: false,
             annotations: if self.annotations.is_empty() {
                 None
@@ -190,4 +180,19 @@ pub fn split_attributes_and_groups(
     }
 
     (attributes, groups)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_attribute_ref_rejects_stability_and_deprecated() {
+        for field in ["stability: stable", "deprecated:\n  reason: obsoleted"] {
+            let yaml = format!("ref: my.attribute\n{field}\n");
+            let err = serde_yaml::from_str::<AttributeRef>(&yaml)
+                .expect_err("stability/deprecated must not be allowed on attribute refs");
+            assert!(err.to_string().contains("unknown field"), "{err}");
+        }
+    }
 }

--- a/crates/weaver_semconv/src/v2/span.rs
+++ b/crates/weaver_semconv/src/v2/span.rs
@@ -252,8 +252,8 @@ impl SpanAttributeRef {
             requirement_level: self.base.requirement_level,
             sampling_relevant: self.sampling_relevant,
             note: self.base.note,
-            stability: self.base.stability,
-            deprecated: self.base.deprecated,
+            stability: None,
+            deprecated: None,
             prefix: false,
             annotations: if self.base.annotations.is_empty() {
                 None

--- a/schemas/semconv-syntax.v2.md
+++ b/schemas/semconv-syntax.v2.md
@@ -241,8 +241,8 @@ You can refine the following properties of the attribute (for the scope of the s
 - `note`
 - `examples`
 - `annotations`
-- `stability` can be changed from stable to unstable, but not the other way around
-- `deprecated` can be changed from not-deprecated to deprecated, but not the other way around
+
+`stability` and `deprecated` cannot be refined - they always come from the attribute definition.
 
 The following properties can be defined on the attribute references only:
 

--- a/schemas/semconv.schema.v2.json
+++ b/schemas/semconv.schema.v2.json
@@ -275,17 +275,6 @@
             "null"
           ]
         },
-        "deprecated": {
-          "description": "Specifies if the attribute is deprecated for this signal.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Deprecated"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "examples": {
           "description": "Refined sequence of example values for the attribute or single example\nvalue. They are required only for string and string array\nattributes. Example values must be of the same type of the\nattribute. If only a single example is provided, it can directly\nbe reported without encapsulating it into a sequence/dictionary.",
           "anyOf": [
@@ -313,17 +302,6 @@
           "anyOf": [
             {
               "$ref": "#/$defs/RequirementLevel"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "stability": {
-          "description": "Refines the stability of the attribute.\nThis denotes whether an attribute is stable for a specific\nsignal.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Stability"
             },
             {
               "type": "null"
@@ -1468,17 +1446,6 @@
             "null"
           ]
         },
-        "deprecated": {
-          "description": "Specifies if the attribute is deprecated for this signal.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Deprecated"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "examples": {
           "description": "Refined sequence of example values for the attribute or single example\nvalue. They are required only for string and string array\nattributes. Example values must be of the same type of the\nattribute. If only a single example is provided, it can directly\nbe reported without encapsulating it into a sequence/dictionary.",
           "anyOf": [
@@ -1517,17 +1484,6 @@
           "type": [
             "boolean",
             "null"
-          ]
-        },
-        "stability": {
-          "description": "Refines the stability of the attribute.\nThis denotes whether an attribute is stable for a specific\nsignal.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Stability"
-            },
-            {
-              "type": "null"
-            }
           ]
         }
       },


### PR DESCRIPTION
These always come from the attribute definition. Using them on a ref is now a failure.

Related to #1658 

- we don't have tests for it
- we don't have a use-case for it
- since we don't always have original attribute definition and only know ref properties, we might be limited in weaver live checks

We can add them in some other form that does not hide original deprecation and stability.