### PR TITLE
Add nightly check against known semantic convention repos and examples

### DIFF
--- a/.github/workflows/downstream-check.yml
+++ b/.github/workflows/downstream-check.yml
@@ -45,6 +45,25 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      # The weaver binary embeds ui/dist via include_dir!, and it is not checked
+      # in, so it has to be built before anything compiles weaver.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        with:
+          package_json_file: ui/package.json
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+          cache-dependency-path: ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: ./ui
+      - name: Build UI
+        run: pnpm build
+        working-directory: ./ui
+
       # semantic-conventions only knows how to run weaver as a container. Build
       # the image here with a layer cache rather than letting the xtask do a cold
       # `docker build`; WEAVER_IMAGE makes it pick this one up.

--- a/.github/workflows/downstream-check.yml
+++ b/.github/workflows/downstream-check.yml
@@ -1,0 +1,109 @@
+name: Downstream Check
+
+# Nightly: run weaver built from main against the CI checks of the repos that
+# consume it, so breaking changes surface before they are released.
+#
+# The repos and their checks are declared in downstream-check.yaml - this
+# workflow deliberately does not list them, so there is only one place to edit.
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      repos:
+        description: 'Space-separated <url>[@<ref>] to check (empty = all of them)'
+        required: false
+        default: ''
+
+concurrency:
+  group: downstream-check
+  cancel-in-progress: false
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+
+jobs:
+  downstream:
+    name: Downstream checks
+    runs-on: ubuntu-latest
+    # All repos run in one job, so this covers the whole set, not a single repo.
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      # semantic-conventions only knows how to run weaver as a container. Build
+      # the image here with a layer cache rather than letting the xtask do a cold
+      # `docker build`; WEAVER_IMAGE makes it pick this one up.
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - name: Build weaver image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          load: true
+          tags: weaver-downstream-check:local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run downstream checks
+        env:
+          WEAVER_IMAGE: weaver-downstream-check:local
+          REPOS: ${{ github.event.inputs.repos }}
+        # Unquoted on purpose: REPOS is a space-separated list of repo arguments.
+        run: cargo xtask downstream-check $REPOS
+
+  # Nightly failures are only useful if someone sees them: keep a single open
+  # issue that tracks the latest failing run, and close it once things are green.
+  report:
+    name: Report
+    needs: downstream
+    if: ${{ !cancelled() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        if: needs.downstream.result != 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Downstream check is failing"
+          body="The nightly [Downstream Check]($RUN_URL) run failed.
+          Check the job summary for which repo and check broke."
+          gh label create downstream-check --color B60205 \
+            --description "Nightly downstream check failures" 2>/dev/null || true
+          existing=$(gh issue list --state open --label downstream-check --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body" \
+              --label downstream-check
+          fi
+      - name: Close the tracking issue
+        if: needs.downstream.result == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --state open --label downstream-check --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" --comment "Downstream checks passed in [this run]($RUN_URL)."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,33 @@ cargo run -- --quiet registry json-schema -j policy-finding -o ./schemas/policy.
 
 **Run `just` before any push to pre-validate all the steps performed by CI.**
 
+### Checking downstream repositories
+
+The `Downstream Check` workflow runs nightly against the repositories that consume
+Weaver, so that breaking changes surface before they are released.
+
+Repositories, the ref to check out and the checks to run in each of them are
+declared in [downstream-check.yaml](downstream-check.yaml) - the only place they
+are listed, for both the workflow and local runs. Only weaver-driven
+checks are listed there - linting, link checking and language tooling are left
+to those repositories' own CI.
+
+To run it against your working tree:
+
+```bash
+just downstream-check
+```
+
+Pass one or more `<url>[@<ref>]` to run a subset. The repositories are checked out under `target/downstream/`. Repositories that
+only run Weaver as a container (semantic-conventions) require Docker, and the
+image is built from this repository's `Dockerfile`. `WEAVER_BIN` and
+`WEAVER_IMAGE` can be set to reuse a prebuilt binary or image.
+
+The run ends with a summary of every check; on GitHub it is also written to the
+job summary, so a failing nightly says which repo and check broke without
+opening the logs. A failing nightly also opens (or comments on) an issue
+labeled `downstream-check`, which is closed again once the run is green.
+
 ### How to send Pull Request
 
 TODO - add any special care/comments we want for clean repo.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7083,7 +7083,9 @@ dependencies = [
  "assert_cmd",
  "gix",
  "semver",
+ "serde",
  "serde_json",
+ "serde_yaml",
  "toml",
 ]
 

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -11,7 +11,9 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 assert_cmd.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 gix = { version = "0.85.0", default-features = false, features = [
     "comfort",
     "blocking-http-transport-reqwest",

--- a/crates/xtask/src/downstream.rs
+++ b/crates/xtask/src/downstream.rs
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runs the weaver built from this working tree against the CI checks of the
+//! downstream repositories that consume weaver.
+//!
+//! The repos and the checks to run in each of them are declared in
+//! `downstream-check.yaml` at the workspace root; the command line selects
+//! which of them to run.
+
+use anyhow::{bail, Context};
+use serde::Deserialize;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Declares the downstream repos and their checks.
+const CONFIG_FILE: &str = "downstream-check.yaml";
+/// Ref to check out when neither the config nor the command line pins one.
+const DEFAULT_REF: &str = "main";
+/// Where the downstream repos are cloned, relative to the workspace root.
+const CHECKOUT_DIR: &str = "target/downstream";
+/// Tag of the locally built image, used by repos that only run weaver in Docker.
+const LOCAL_IMAGE: &str = "weaver-downstream-check:local";
+/// Wall clock a single check gets before it is killed, unless it sets its own.
+const DEFAULT_TIMEOUT_MINUTES: u64 = 20;
+/// How often a running check is polled for completion.
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Config {
+    repos: Vec<Repo>,
+}
+
+/// Repos that have no way to run a local weaver binary, so the checks must run
+/// against a container image built from this working tree instead.
+///
+/// TODO: teach semantic-conventions to use a local weaver when one is present,
+/// the way semantic-conventions-genai does, and drop this special case.
+const IMAGE_ONLY_REPOS: &[&str] = &["github.com/open-telemetry/semantic-conventions"];
+
+/// How weaver is handed to a downstream repo.
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum WeaverKind {
+    /// The repo invokes a `weaver` binary; `PATH` and `$WEAVER` point at ours.
+    Binary,
+    /// The repo only knows how to run weaver as a container image.
+    Image,
+}
+
+/// A downstream repository and the checks to run against it.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Repo {
+    /// Clone URL, optionally suffixed with `@<ref>`. Also how the repo is named
+    /// on the command line, where the ref suffix overrides the one configured here.
+    url: String,
+    checks: Vec<Check>,
+}
+
+impl Repo {
+    fn clone_url(&self) -> &str {
+        split_ref(&self.url).0
+    }
+
+    fn git_ref(&self) -> &str {
+        split_ref(&self.url).1.unwrap_or(DEFAULT_REF)
+    }
+
+    fn weaver(&self) -> WeaverKind {
+        let url = normalize_url(self.clone_url());
+        if IMAGE_ONLY_REPOS.iter().any(|r| normalize_url(r) == url) {
+            WeaverKind::Image
+        } else {
+            WeaverKind::Binary
+        }
+    }
+}
+
+/// Strips the scheme and the `.git` suffix so URLs can be compared.
+fn normalize_url(url: &str) -> String {
+    url.trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .trim_end_matches('/')
+        .to_owned()
+}
+
+/// Splits `<url>[@<ref>]`. Only an `@` after the last `/` separates a ref, so
+/// scp-style URLs (`git@github.com:org/repo`) are left alone.
+fn split_ref(url_and_ref: &str) -> (&str, Option<&str>) {
+    match url_and_ref.rfind('@') {
+        Some(i) if !url_and_ref[i..].contains('/') => {
+            (&url_and_ref[..i], Some(&url_and_ref[i + 1..]))
+        }
+        _ => (url_and_ref, None),
+    }
+}
+
+/// One command to run in a checked-out downstream repo.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Check {
+    name: String,
+    /// Working directory, relative to the repo root.
+    #[serde(default = "default_dir")]
+    dir: String,
+    /// Shell command. `{weaver}` expands to the weaver binary path or image tag.
+    /// Run through `sh -c`, so it can chain a generation step with the
+    /// `git diff` that asserts the committed output is in sync.
+    run: String,
+    /// Overrides `DEFAULT_TIMEOUT_MINUTES` for checks that legitimately take longer.
+    timeout_minutes: Option<u64>,
+}
+
+fn default_dir() -> String {
+    ".".to_owned()
+}
+
+/// Outcome of a single downstream check.
+#[derive(PartialEq, Eq)]
+enum Status {
+    Ok,
+    Failed,
+}
+
+impl Status {
+    fn label(&self) -> &'static str {
+        match self {
+            Status::Ok => "OK",
+            Status::Failed => "FAILED",
+        }
+    }
+}
+
+struct Outcome {
+    repo: String,
+    check: String,
+    status: Status,
+    detail: String,
+}
+
+/// A repo selected on the command line, with the ref to check out resolved.
+struct Selection<'a> {
+    repo: &'a Repo,
+    git_ref: String,
+}
+
+impl Selection<'_> {
+    /// `<url>@<ref>`, as printed in the output and accepted on the command line.
+    fn id(&self) -> String {
+        format!("{}@{}", self.repo.clone_url(), self.git_ref)
+    }
+
+    /// Directory to check the repo out into, e.g. `open-telemetry_semantic-conventions`.
+    fn dir_name(&self) -> String {
+        let mut parts: Vec<_> = self
+            .repo
+            .clone_url()
+            .trim_end_matches(".git")
+            .rsplit('/')
+            .take(2)
+            .collect();
+        parts.reverse();
+        parts.join("_")
+    }
+}
+
+/// Runs the downstream checks. Each argument is the `<url>[@<ref>]` of a repo
+/// declared in the config; with no arguments, every repo runs at its configured ref.
+#[cfg(not(tarpaulin_include))]
+pub fn run(repos: Vec<String>) -> anyhow::Result<()> {
+    let config: Config = serde_yaml::from_str(
+        &std::fs::read_to_string(CONFIG_FILE)
+            .with_context(|| format!("Failed to read {CONFIG_FILE}"))?,
+    )
+    .with_context(|| format!("Failed to parse {CONFIG_FILE}"))?;
+
+    let selected: Vec<Selection<'_>> = if repos.is_empty() {
+        config
+            .repos
+            .iter()
+            .map(|repo| Selection {
+                repo,
+                git_ref: repo.git_ref().to_owned(),
+            })
+            .collect()
+    } else {
+        repos
+            .iter()
+            .map(|arg| select(&config, arg))
+            .collect::<anyhow::Result<_>>()?
+    };
+
+    let checkout_root = PathBuf::from(CHECKOUT_DIR);
+    std::fs::create_dir_all(&checkout_root)?;
+
+    let needs_binary = selected
+        .iter()
+        .any(|s| s.repo.weaver() == WeaverKind::Binary);
+    let needs_image = selected
+        .iter()
+        .any(|s| s.repo.weaver() == WeaverKind::Image);
+    let weaver_bin = needs_binary.then(build_weaver_binary).transpose()?;
+    let weaver_image = needs_image.then(build_weaver_image).transpose()?;
+
+    let mut outcomes = Vec::new();
+    for selection in &selected {
+        println!("\n{:=<70}\n=== {}\n{:=<70}", "", selection.id(), "");
+        let dir = checkout_root.join(selection.dir_name());
+        if let Err(e) = checkout(selection, &dir) {
+            outcomes.push(Outcome {
+                repo: selection.id(),
+                check: "checkout".to_owned(),
+                status: Status::Failed,
+                detail: format!("{e:#}"),
+            });
+            continue;
+        }
+
+        // Repos that call `weaver` directly, or that read $WEAVER, must see ours.
+        // Never fall back to a `weaver` on PATH or a published image: that would
+        // silently check a released weaver and report it as a pass.
+        let bin = match selection.repo.weaver() {
+            WeaverKind::Binary => Some(
+                weaver_bin
+                    .as_deref()
+                    .context("internal error: no weaver binary was built")?,
+            ),
+            WeaverKind::Image => None,
+        };
+        let weaver = match bin {
+            Some(bin) => bin.display().to_string(),
+            None => weaver_image
+                .as_deref()
+                .context("internal error: no weaver image was built")?
+                .to_owned(),
+        };
+
+        for check in &selection.repo.checks {
+            let command = check.run.replace("{weaver}", &weaver);
+            outcomes.push(run_check(
+                selection,
+                check,
+                &dir.join(&check.dir),
+                &command,
+                bin,
+            ));
+        }
+    }
+
+    report(&outcomes)
+}
+
+/// Resolves a `<url>[@<ref>]` argument against the configured repos. The URL may
+/// omit the scheme and the `.git` suffix.
+#[cfg(not(tarpaulin_include))]
+fn select<'a>(config: &'a Config, arg: &str) -> anyhow::Result<Selection<'a>> {
+    let (url, git_ref) = split_ref(arg);
+
+    let wanted = normalize_url(url);
+    let repo = config
+        .repos
+        .iter()
+        .find(|r| normalize_url(r.clone_url()) == wanted)
+        .with_context(|| {
+            let known: Vec<_> = config.repos.iter().map(|r| r.url.as_str()).collect();
+            format!(
+                "Unknown repo `{url}`. Repos declared in {CONFIG_FILE}:\n  {}",
+                known.join("\n  ")
+            )
+        })?;
+
+    Ok(Selection {
+        repo,
+        git_ref: git_ref.unwrap_or_else(|| repo.git_ref()).to_owned(),
+    })
+}
+
+/// Builds weaver from this working tree and returns the absolute binary path.
+#[cfg(not(tarpaulin_include))]
+fn build_weaver_binary() -> anyhow::Result<PathBuf> {
+    if let Ok(bin) = std::env::var("WEAVER_BIN") {
+        println!("=== Using weaver binary from WEAVER_BIN: {bin}");
+        return Ok(PathBuf::from(bin));
+    }
+    println!("=== Building weaver (cargo build --release)");
+    let status = Command::new("cargo")
+        .args(["build", "--release", "--locked", "--bin", "weaver"])
+        .status()?;
+    if !status.success() {
+        bail!("Failed to build weaver: {status}");
+    }
+    let bin = std::fs::canonicalize("target/release/weaver")
+        .context("weaver binary not found after build")?;
+    println!("=== weaver under test: {}", bin.display());
+    Ok(bin)
+}
+
+/// Builds the weaver container image from this working tree and returns its tag.
+#[cfg(not(tarpaulin_include))]
+fn build_weaver_image() -> anyhow::Result<String> {
+    if let Ok(image) = std::env::var("WEAVER_IMAGE") {
+        println!("=== Using weaver image from WEAVER_IMAGE: {image}");
+        return Ok(image);
+    }
+    println!("=== Building {LOCAL_IMAGE} (docker build)");
+    let status = Command::new("docker")
+        .args(["build", "-t", LOCAL_IMAGE, "."])
+        .status()
+        .context("Failed to run `docker build`. Is docker installed and running?")?;
+    if !status.success() {
+        bail!("Failed to build the weaver image: {status}");
+    }
+    Ok(LOCAL_IMAGE.to_owned())
+}
+
+/// Checks the repo out at the selected ref, reusing an existing checkout.
+#[cfg(not(tarpaulin_include))]
+fn checkout(selection: &Selection<'_>, dir: &Path) -> anyhow::Result<()> {
+    let git = |args: &[&str]| -> anyhow::Result<()> {
+        let status = Command::new("git").args(args).status()?;
+        if !status.success() {
+            bail!("`git {}` failed: {status}", args.join(" "));
+        }
+        Ok(())
+    };
+    let dir = dir.display().to_string();
+    println!("=== Checking out {} into {dir}", selection.id());
+    if !Path::new(&dir).join(".git").exists() {
+        std::fs::create_dir_all(&dir)?;
+        git(&["-C", &dir, "init", "--quiet"])?;
+        git(&[
+            "-C",
+            &dir,
+            "remote",
+            "add",
+            "origin",
+            selection.repo.clone_url(),
+        ])?;
+    }
+    // Fetching the ref explicitly works for branches, tags and commit shas alike.
+    git(&[
+        "-C",
+        &dir,
+        "fetch",
+        "--quiet",
+        "--depth",
+        "1",
+        "origin",
+        &selection.git_ref,
+    ])?;
+    git(&["-C", &dir, "reset", "--quiet", "--hard", "FETCH_HEAD"])?;
+    git(&["-C", &dir, "clean", "-qfdx"])?;
+    Ok(())
+}
+
+/// Runs one check, streaming its output, and classifies the result.
+#[cfg(not(tarpaulin_include))]
+fn run_check(
+    selection: &Selection<'_>,
+    check: &Check,
+    workdir: &Path,
+    command: &str,
+    weaver_bin: Option<&Path>,
+) -> Outcome {
+    let title = format!("{}: {}", selection.repo.clone_url(), check.name);
+    group_start(&title);
+    println!("--- in {}", workdir.display());
+    println!("--- $ {command}");
+
+    let mut cmd = Command::new("sh");
+    let _ = cmd
+        .arg("-c")
+        .arg(command)
+        .current_dir(workdir)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    // Own process group, so a timeout can take the whole check down: several of
+    // them background a long-running weaver that would outlive the `sh` alone.
+    let _ = std::os::unix::process::CommandExt::process_group(&mut cmd, 0);
+
+    if let Some(bin) = weaver_bin {
+        let _ = cmd.env("WEAVER", bin);
+        if let Some(bin_dir) = bin.parent() {
+            let path = std::env::var("PATH").unwrap_or_default();
+            let _ = cmd.env("PATH", format!("{}:{path}", bin_dir.display()));
+        }
+    }
+
+    let timeout =
+        Duration::from_secs(check.timeout_minutes.unwrap_or(DEFAULT_TIMEOUT_MINUTES) * 60);
+    let result = cmd
+        .spawn()
+        .and_then(|child| wait_with_timeout(child, timeout));
+    group_end();
+
+    let (status, detail) = match result {
+        Err(e) => (Status::Failed, format!("could not start: {e}")),
+        Ok(None) => (
+            Status::Failed,
+            format!("timed out after {} minutes", timeout.as_secs() / 60),
+        ),
+        Ok(Some(exit)) => match exit.code() {
+            Some(0) => (Status::Ok, String::new()),
+            Some(code) => (Status::Failed, format!("exit {code}")),
+            // No exit code means the process was killed by a signal.
+            None => (Status::Failed, "killed by signal".to_owned()),
+        },
+    };
+
+    if status != Status::Ok {
+        eprintln!("!!! [{title}] {} ({detail})", status.label());
+        if std::env::var("GITHUB_ACTIONS").is_ok() {
+            println!(
+                "::error title={title}::{} ({detail}) - see the '{title}' group above",
+                status.label()
+            );
+        }
+    }
+
+    Outcome {
+        repo: selection.id(),
+        check: check.name.clone(),
+        status,
+        detail,
+    }
+}
+
+/// Waits for a check to finish, returning `None` if it had to be killed on timeout.
+#[cfg(not(tarpaulin_include))]
+fn wait_with_timeout(
+    mut child: Child,
+    timeout: Duration,
+) -> std::io::Result<Option<std::process::ExitStatus>> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(exit) = child.try_wait()? {
+            return Ok(Some(exit));
+        }
+        if Instant::now() >= deadline {
+            eprintln!("!!! timed out, killing the check");
+            kill_group(child.id());
+            let _ = child.wait();
+            return Ok(None);
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Signals the whole process group of a check, so anything it spawned dies too.
+#[cfg(not(tarpaulin_include))]
+fn kill_group(pid: u32) {
+    for signal in ["-TERM", "-KILL"] {
+        let _ = Command::new("kill")
+            .args([signal, &format!("-{pid}")])
+            .status();
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Prints the summary and fails if any check did not pass.
+#[cfg(not(tarpaulin_include))]
+fn report(outcomes: &[Outcome]) -> anyhow::Result<()> {
+    let mut summary = String::new();
+    for o in outcomes {
+        let _ = writeln!(
+            summary,
+            "{:<9} {}: {} {}",
+            o.status.label(),
+            o.repo,
+            o.check,
+            o.detail
+        );
+    }
+    println!("\n{:=<70}\n=== Summary\n{:=<70}\n{summary}", "", "");
+    write_step_summary(outcomes);
+
+    if outcomes.iter().any(|o| o.status != Status::Ok) {
+        bail!("Some downstream checks did not pass; see the output above.");
+    }
+    println!("All downstream checks passed.");
+    Ok(())
+}
+
+/// Appends the summary as a markdown table to the GitHub job summary, so a failed
+/// run says which repo and check broke without opening the logs.
+#[cfg(not(tarpaulin_include))]
+fn write_step_summary(outcomes: &[Outcome]) {
+    let Ok(path) = std::env::var("GITHUB_STEP_SUMMARY") else {
+        return;
+    };
+    let mut md = String::from("| | Repo | Check | Detail |\n|---|---|---|---|\n");
+    for o in outcomes {
+        let icon = if o.status == Status::Ok { "✅" } else { "❌" };
+        let _ = writeln!(md, "| {icon} | {} | {} | {} |", o.repo, o.check, o.detail);
+    }
+    if let Err(e) = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .and_then(|mut f| std::io::Write::write_all(&mut f, md.as_bytes()))
+    {
+        eprintln!("Failed to write {path}: {e}");
+    }
+}
+
+/// Collapses a check's output into a foldable group when running on GitHub.
+#[cfg(not(tarpaulin_include))]
+fn group_start(title: &str) {
+    if std::env::var("GITHUB_ACTIONS").is_ok() {
+        println!("::group::{title}");
+    } else {
+        println!("\n--- [{title}]");
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+fn group_end() {
+    if std::env::var("GITHUB_ACTIONS").is_ok() {
+        println!("::endgroup::");
+    }
+}

--- a/crates/xtask/src/downstream.rs
+++ b/crates/xtask/src/downstream.rs
@@ -380,6 +380,7 @@ fn run_check(
         .stderr(Stdio::inherit());
     // Own process group, so a timeout can take the whole check down: several of
     // them background a long-running weaver that would outlive the `sh` alone.
+    #[cfg(unix)]
     let _ = std::os::unix::process::CommandExt::process_group(&mut cmd, 0);
 
     if let Some(bin) = weaver_bin {
@@ -442,7 +443,7 @@ fn wait_with_timeout(
         }
         if Instant::now() >= deadline {
             eprintln!("!!! timed out, killing the check");
-            kill_group(child.id());
+            kill_check(&mut child);
             let _ = child.wait();
             return Ok(None);
         }
@@ -451,14 +452,22 @@ fn wait_with_timeout(
 }
 
 /// Signals the whole process group of a check, so anything it spawned dies too.
-#[cfg(not(tarpaulin_include))]
-fn kill_group(pid: u32) {
+#[cfg(all(unix, not(tarpaulin_include)))]
+fn kill_check(child: &mut Child) {
+    let pid = child.id();
     for signal in ["-TERM", "-KILL"] {
         let _ = Command::new("kill")
             .args([signal, &format!("-{pid}")])
             .status();
         std::thread::sleep(POLL_INTERVAL);
     }
+}
+
+/// The checks are `sh` commands, so this task only really runs on unix; keep it
+/// compiling elsewhere by killing just the child we spawned.
+#[cfg(all(not(unix), not(tarpaulin_include)))]
+fn kill_check(child: &mut Child) {
+    let _ = child.kill();
 }
 
 /// Prints the summary and fails if any check did not pass.

--- a/crates/xtask/src/downstream.rs
+++ b/crates/xtask/src/downstream.rs
@@ -78,6 +78,17 @@ impl Repo {
     }
 }
 
+/// Quotes a value for `sh -c`; checkout and `WEAVER_BIN` paths may contain spaces.
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r#"'\''"#))
+}
+
+/// Collapses a value to a single line so it cannot break an annotation or a
+/// markdown table row. Check details carry multi-line anyhow errors.
+fn one_line(value: &str) -> String {
+    value.replace(['\r', '\n'], " ").replace('|', "\\|")
+}
+
 /// Strips the scheme and the `.git` suffix so URLs can be compared.
 fn normalize_url(url: &str) -> String {
     url.trim_start_matches("https://")
@@ -240,7 +251,7 @@ pub fn run(repos: Vec<String>) -> anyhow::Result<()> {
         };
 
         for check in &selection.repo.checks {
-            let command = check.run.replace("{weaver}", &weaver);
+            let command = check.run.replace("{weaver}", &shell_quote(&weaver));
             outcomes.push(run_check(
                 selection,
                 check,
@@ -416,8 +427,9 @@ fn run_check(
         eprintln!("!!! [{title}] {} ({detail})", status.label());
         if std::env::var("GITHUB_ACTIONS").is_ok() {
             println!(
-                "::error title={title}::{} ({detail}) - see the '{title}' group above",
-                status.label()
+                "::error title={title}::{} ({}) - see the '{title}' group above",
+                status.label(),
+                one_line(&detail)
             );
         }
     }
@@ -504,7 +516,13 @@ fn write_step_summary(outcomes: &[Outcome]) {
     let mut md = String::from("| | Repo | Check | Detail |\n|---|---|---|---|\n");
     for o in outcomes {
         let icon = if o.status == Status::Ok { "✅" } else { "❌" };
-        let _ = writeln!(md, "| {icon} | {} | {} | {} |", o.repo, o.check, o.detail);
+        let _ = writeln!(
+            md,
+            "| {icon} | {} | {} | {} |",
+            o.repo,
+            o.check,
+            one_line(&o.detail)
+        );
     }
     if let Err(e) = std::fs::OpenOptions::new()
         .append(true)

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::print_stdout)]
 #![allow(clippy::print_stderr)]
 
+mod downstream;
 mod fix_release_permissions;
 mod history;
 mod schema_compat;
@@ -26,6 +27,7 @@ fn main() -> anyhow::Result<()> {
             "validate" => validate::run(),
             "history" => history::run(std::env::args().nth(2)),
             "schema-compat" => schema_compat::run(),
+            "downstream-check" => downstream::run(std::env::args().skip(2).collect()),
             "help" => print_help(),
             _ => {
                 eprintln!("Unknown task: {task}");
@@ -48,6 +50,11 @@ Tasks:
   - history: Run registry check on semconv models within back compatibility range.
              Optionally provide a start semver e.g. `history 1.29.0`.
   - schema-compat: Check JSON schema backwards and forwards compatibility against the latest release.
+  - downstream-check: Run the weaver from this working tree against the CI checks of the downstream
+                      repos declared in downstream-check.yaml. Optionally provide the repos to check
+                      as `<url>[@<ref>]`, e.g.
+                      `downstream-check https://github.com/open-telemetry/semantic-conventions.git@main`.
+                      No repos = all of them.
 "
     );
     Ok(())

--- a/downstream-check.yaml
+++ b/downstream-check.yaml
@@ -1,0 +1,117 @@
+# Downstream repos checked by `just downstream-check` (and the nightly
+# Downstream Check workflow). Each entry lists the weaver-driven checks of that
+# repo's CI; non-weaver checks (linting, link checking, language tooling) are
+# deliberately not run here.
+#
+# The `@<ref>` suffix on the url pins the branch, tag or commit to check out;
+# it defaults to `main` and can be overridden on the command line.
+#
+# `{weaver}` in a command expands to the weaver under test: the binary we built,
+# or the image tag for the repos that only run weaver in a container (see
+# IMAGE_ONLY_REPOS in crates/xtask/src/downstream.rs).
+# `dir` is relative to the repo root and defaults to `.`; `timeout_minutes`
+# overrides the default per-check timeout.
+
+repos:
+  - url: https://github.com/open-telemetry/semantic-conventions.git@main
+    # WEAVER_CONTAINER is a plain make variable, so the command line wins over
+    # the version pinned in dependencies.Dockerfile.
+    checks:
+      - name: table-check
+        run: make WEAVER_CONTAINER={weaver} table-check
+      - name: registry-generation
+        # TODO: add make check-registry-generation in semconv
+        # `git add -A` first, so files the generator newly created also show up.
+        run: >-
+          make WEAVER_CONTAINER={weaver} registry-generation &&
+          git add -A ./docs/registry &&
+          git diff --cached --exit-code -- ./docs/registry
+      - name: check-policies
+        run: make WEAVER_CONTAINER={weaver} check-policies
+      # NOTE: this one only runs on Linux; its find-dead-yaml.sh needs bash >= 4.
+      - name: check-dead-yaml
+        run: make WEAVER_CONTAINER={weaver} check-dead-yaml
+      - name: generate-gh-issue-templates
+        # TODO: add make check-gh-issue-templates in semconv      
+        run: >-
+          make WEAVER_CONTAINER={weaver} generate-gh-issue-templates &&
+          git add -A .github/ISSUE_TEMPLATE &&
+          git diff --cached --exit-code -- .github/ISSUE_TEMPLATE
+
+  - url: https://github.com/open-telemetry/semantic-conventions-genai.git@main
+    # Passing WEAVER bypasses the Makefile's "fall back to the pinned container
+    # if the local weaver is older than the pin" logic, which would otherwise
+    # silently test the released weaver instead of ours.
+    checks:
+      - name: check-policies
+        run: make WEAVER={weaver} check-policies
+      - name: generated-docs
+        # TODO: add make check-generation in semconv-genai
+        run: >-
+          make WEAVER={weaver} generate-registry &&
+          make WEAVER={weaver} generate-docs &&
+          git add -A ./docs &&
+          git diff --cached --exit-code -- ./docs
+
+  - url: https://github.com/open-telemetry/opentelemetry-weaver-packages.git@main
+    # The buildscripts pick weaver up from $WEAVER.
+    checks:
+      - name: test-templates
+        run: make test-templates
+      - name: test-policies
+        run: make test-policies
+
+  - url: https://github.com/open-telemetry/opentelemetry-weaver-examples.git@main
+    # The Makefiles call a bare `weaver`, which resolves to ours via PATH.
+    # TODO: `resolve` and `live-check otlp` below are spelled out here because
+    # the examples repo drives them from workflow yaml rather than a make
+    # target. Add `make resolve` and `make live-check` there and collapse these
+    # two entries into them, the way every other check works.
+    checks:
+      - name: basic - check-model
+        dir: basic
+        run: make check-model
+      - name: basic - check-generated
+        dir: basic
+        run: make check-generated
+      - name: basic - check-generated-docs
+        dir: basic
+        run: make check-generated-docs
+      # From validate-examples.yml, which resolves the registry after checking it.
+      - name: basic - resolve
+        dir: basic
+        run: >-
+          out="$(mktemp -d)/resolved.json" &&
+          {weaver} registry resolve -r ./model -o "$out"
+      # From live-check-basic.yml: start the OTLP listener, run the example
+      # against it, stop it, and fail on any violation. That workflow drives this
+      # through the weaver-live-check-{start,stop} actions in this repo; the same
+      # calls are inlined here so it runs outside GitHub Actions too.
+      - name: basic - live-check otlp
+        dir: basic
+        run: |
+          set -e
+          state=$(mktemp -d)
+          make build
+          {weaver} registry live-check --registry ./model --input-source otlp \
+            --otlp-grpc-port 4317 --admin-port 4320 --inactivity-timeout 30 \
+            --format json --output http >"$state/weaver.log" 2>&1 &
+          pid=$!
+          trap 'kill $pid 2>/dev/null || true; cat "$state/weaver.log" || true' EXIT
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:4320/health >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317 cargo run -- "Hello, World!"
+          curl -fsS -X POST http://127.0.0.1:4320/stop -o "$state/report.json"
+          python3 -c 'import json,sys
+          counts = json.load(open(sys.argv[1]))["statistics"]["advice_level_counts"]
+          violations = counts.get("violation", 0)
+          print(f"live-check violations: {violations}")
+          sys.exit(1 if violations else 0)' "$state/report.json"
+      - name: custom_advisor - check-model
+        dir: custom_advisor
+        run: make check-model
+      - name: custom_advisor - test
+        dir: custom_advisor
+        run: make test

--- a/downstream-check.yaml
+++ b/downstream-check.yaml
@@ -98,10 +98,12 @@ repos:
             --format json --output http >"$state/weaver.log" 2>&1 &
           pid=$!
           trap 'kill $pid 2>/dev/null || true; cat "$state/weaver.log" || true' EXIT
+          ready=""
           for _ in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:4320/health >/dev/null 2>&1; then break; fi
+            if curl -fsS http://127.0.0.1:4320/health >/dev/null 2>&1; then ready=1; break; fi
             sleep 1
           done
+          if [ -z "$ready" ]; then echo "live-check never became healthy"; exit 1; fi
           OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317 cargo run -- "Hello, World!"
           curl -fsS -X POST http://127.0.0.1:4320/stop -o "$state/report.json"
           python3 -c 'import json,sys

--- a/justfile
+++ b/justfile
@@ -65,6 +65,12 @@ fuzz-all seconds="30":
 check-external-types:
   scripts/check_external_types.sh
 
+# Run the weaver from this working tree against the CI checks of the downstream
+# repos declared in downstream-check.yaml. Args are `<url>[@<ref>]`; no args
+# runs all of them. Repos that only run weaver in docker require docker.
+downstream-check *repos:
+    cargo xtask downstream-check {{repos}}
+
 # Vulnerabilities check (OSV). Honors the osv-scanner.toml ignore files.
 # Install: `brew install osv-scanner` (or see https://google.github.io/osv-scanner/installation/)
 # Scan both lockfiles for known vulnerabilities, mirroring the OSSF Scorecard


### PR DESCRIPTION
Runs the weaver built from this working tree against the weaver-driven CI checks of the repos that consume it, so breaking changes surface before a release. Repos and checks are declared in downstream-check.yaml, used by both `just downstream-check` and the nightly workflow.