### PR TITLE
Drop refinements from forge v1

### DIFF
--- a/crates/weaver_forge/src/registry.rs
+++ b/crates/weaver_forge/src/registry.rs
@@ -194,6 +194,11 @@ impl ResolvedGroup {
 
 impl ResolvedRegistry {
     /// Create a new template registry from a resolved registry.
+    ///
+    /// V2 refinements are dropped: v1 has no notion of a refinement, and one resolves
+    /// into an extra group carrying the same signal name as the signal it refines, so
+    /// consumers selecting groups by type see it as a duplicate signal. Consumers that
+    /// need refinements use the v2 registry, where they are modelled explicitly.
     pub fn try_from_resolved_registry(
         registry: &Registry,
         catalog: &Catalog,
@@ -203,6 +208,7 @@ impl ResolvedRegistry {
         let groups = registry
             .groups
             .iter()
+            .filter(|group| !group.is_v2_refinement())
             .map(|group| {
                 let id = group.id.clone();
                 let group_type = group.r#type.clone();
@@ -272,8 +278,11 @@ mod tests {
     use schemars::schema_for;
     use serde_json::to_string_pretty;
     use weaver_resolved_schema::catalog::Catalog;
+    use weaver_resolved_schema::lineage::GroupLineage;
     use weaver_resolved_schema::registry::{Group, Registry};
     use weaver_semconv::group::GroupType;
+    use weaver_semconv::provenance::Provenance;
+    use weaver_semconv::schema_url::SchemaUrl;
 
     #[test]
     fn test_json_schema_gen() {
@@ -387,5 +396,57 @@ mod tests {
         let resolved2 = ResolvedRegistry::try_from_resolved_registry(&registry, &catalog)
             .expect("Failed to create resolved registry");
         assert_eq!(resolved.groups, resolved2.groups);
+    }
+
+    #[test]
+    fn test_v2_refinements_excluded_from_v1_output() {
+        fn metric_group(id: &str, is_v2: bool, extends: Option<&str>) -> Group {
+            let mut lineage = GroupLineage::new(Provenance::new(SchemaUrl::new_unknown(), ""));
+            if let Some(extends) = extends {
+                lineage.extends(extends, GroupType::Metric);
+            }
+            Group {
+                id: id.to_owned(),
+                r#type: GroupType::Metric,
+                brief: String::new(),
+                note: String::new(),
+                prefix: String::new(),
+                extends: extends.map(str::to_owned),
+                stability: None,
+                deprecated: None,
+                attributes: vec![],
+                span_kind: None,
+                events: vec![],
+                metric_name: Some("hw.errors".to_owned()),
+                instrument: None,
+                unit: None,
+                requirement_level: None,
+                name: None,
+                lineage: Some(lineage),
+                display_name: None,
+                body: None,
+                entity_associations: vec![],
+                annotations: None,
+                visibility: None,
+                is_v2,
+                span_name: None,
+            }
+        }
+
+        let registry = Registry {
+            registry_url: "test".to_owned(),
+            groups: vec![
+                metric_group("metric.hw.errors", true, None),
+                metric_group("hw.errors.host", true, Some("metric.hw.errors")),
+                // A v1 group that extends another one is not a refinement.
+                metric_group("v1.derived.metric", false, Some("metric.hw.errors")),
+            ],
+        };
+        let catalog = Catalog::default();
+
+        let resolved = ResolvedRegistry::try_from_resolved_registry(&registry, &catalog)
+            .expect("Failed to create resolved registry");
+        let ids: Vec<_> = resolved.groups.iter().map(|g| g.id.as_str()).collect();
+        assert_eq!(ids, vec!["metric.hw.errors", "v1.derived.metric"]);
     }
 }

--- a/crates/weaver_semconv_gen/data_v2_to_v1/templates.md
+++ b/crates/weaver_semconv_gen/data_v2_to_v1/templates.md
@@ -1,0 +1,3 @@
+<!-- semconv metric.refined.metric(metric_table) -->
+metric_table: metric.refined.metric 
+<!-- endsemconv -->

--- a/crates/weaver_semconv_gen/data_v2_to_v1/test.yaml
+++ b/crates/weaver_semconv_gen/data_v2_to_v1/test.yaml
@@ -1,0 +1,21 @@
+file_format: definition/2
+attributes:
+  - key: test.attr
+    type: string
+    brief: 'Test attribute'
+    stability: stable
+
+metrics:
+  - name: base.metric
+    instrument: counter
+    unit: '{error}'
+    brief: Base metric
+    stability: stable
+
+metric_refinements:
+  - id: metric.refined.metric
+    ref: base.metric
+    brief: Refined metric
+    attributes:
+      - ref: test.attr
+        requirement_level: recommended

--- a/crates/weaver_semconv_gen/src/v1.rs
+++ b/crates/weaver_semconv_gen/src/v1.rs
@@ -209,4 +209,30 @@ mod tests {
         force_print_error(generator.update_markdown(test, true, Some(attribute_registry_url)));
         Ok(())
     }
+
+    #[test]
+    fn test_v2_to_v1_refinement_rendering() -> Result<(), Error> {
+        let loader = FileSystemFileLoader::try_new("templates/registry".into(), "markdown")?;
+        let config = WeaverConfig::try_from_loader(&loader)?;
+        let params = Params::default();
+        let output =
+            OutputProcessor::from_template_config(config, loader, params, OutputTarget::Stdout)?;
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data_v2_to_v1".to_owned(),
+        };
+        let mut diag_msgs = DiagnosticMessages::empty();
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let generator = SnippetGenerator::try_from_registry_repo(
+            &registry_repo,
+            output,
+            &mut diag_msgs,
+            false,
+            false,
+        )?;
+        let attribute_registry_url = "/docs/attributes-registry";
+        let test = "data_v2_to_v1/templates.md";
+        println!("--- Running template engine test for V2 to V1 refinements: {test} ---");
+        force_print_error(generator.update_markdown(test, true, Some(attribute_registry_url)));
+        Ok(())
+    }
 }


### PR DESCRIPTION
refinements defined in v2 translate into a duplicate metric in v1 forge.
We didn't catch it in semconv because we switched to v2 policies, but it's breaking codegen - see https://github.com/open-telemetry/semantic-conventions-java/pull/549#discussion_r3716151890

```yaml
file_format: definition/2
attributes:
  - key: demo.type
    type: string
    stability: development
    brief: "Component type."
metrics:
  - name: demo.errors
    stability: development
    brief: "Number of errors."
    instrument: counter
    unit: "{error}"
    attributes: [{ref: demo.type, requirement_level: required}]
metric_refinements:
  - id: metric.demo.disk.errors
    ref: demo.errors
    brief: "Number of errors on this disk."
    attributes: [{ref: demo.type, note: "MUST be set to `disk`."}]
```

Resolved output of semconv_grouped_metrics — two entries, same metric_name:

```
{"id":"metric.demo.disk.errors","metric_name":"demo.errors","type":"metric","brief":"Number of errors on this disk.","unit":"{error}","instrument":"counter"}
{"id":"metric.demo.errors",     "metric_name":"demo.errors","type":"metric","brief":"Number of errors.",           "unit":"{error}","instrument":"counter"}
```

while we could resolve refinements with `group.type == metric_refinement`, I think it's reasonable to drop them from v1 forge completely and ask users who want refinements to use --v2 to get them in resolved/forge