### PR TITLE
Entity dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
+- Entities referenced in entity associations are now resolved similarly to attributes. The entity is verified to exist, it's pulled in from dependencies if needed and the provenance is recorded. Entities are held as refinements in the resolved schema for future development. Fix bug for all imported signals where imports of unknown signals were silently dropped - they now produce a warning. ([#1684](https://github.com/open-telemetry/weaver/pull/1684) by @jerbly)
+- Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#1655](https://github.com/open-telemetry/weaver/pull/1655) by @jerbly)
 - Live-check: preserve instrumentation scope through OTLP ingestion, expose it to Rego policies, and render it in standard output. ([#1605](https://github.com/open-telemetry/weaver/pull/1605) by @McGluut)
 
 # [0.25.1] - 2026-07-28

--- a/crates/weaver_forge/data/registry/entities.yaml
+++ b/crates/weaver_forge/data/registry/entities.yaml
@@ -1,0 +1,12 @@
+groups:
+  - id: entity.service
+    type: entity
+    name: service
+    stability: stable
+    brief: "A service, named in the `entity_associations` of this registry."
+    attributes:
+      - id: service.name
+        type: string
+        stability: stable
+        brief: "Service name"
+        requirement_level: required

--- a/crates/weaver_forge/expected_output/registry/markdown/entities.md
+++ b/crates/weaver_forge/expected_output/registry/markdown/entities.md
@@ -40,3 +40,20 @@ Attributes used by non-OTLP exporters to represent OpenTelemetry Scope's concept
 | `otel.scope.version` | `string` | Recommended | The version of the instrumentation scope - (`InstrumentationScope.Version` in OTLP).
  |
 
+## Namespace: `service`
+
+### `entity.service`
+
+A service, named in the `entity_associations` of this registry.
+
+| Property | Value |
+|----------|-------|
+| Stability | Stable |
+
+#### Attributes
+
+| Attribute | Type | Requirement Level | Description |
+|-----------|------|-------------------|-------------|
+| `service.name` | `string` | Required | Service name
+ |
+

--- a/crates/weaver_forge/expected_output/test/registry.md
+++ b/crates/weaver_forge/expected_output/test/registry.md
@@ -41,6 +41,7 @@ Url:
 
 # Resource
 
+- [entity.service](resource/entity_service.md)
 - [otel.library](resource/otel_library.md)
 - [otel.scope](resource/otel_scope.md)
 

--- a/crates/weaver_forge/expected_output/test/resource/service.md
+++ b/crates/weaver_forge/expected_output/test/resource/service.md
@@ -1,0 +1,25 @@
+## Namespace Resource `service`
+
+
+
+## Resource `entity.service`
+
+Note: 
+Brief: A service, named in the `entity_associations` of this registry.
+
+### Attributes
+
+
+#### Attribute `service.name`
+
+Service name
+
+
+- Requirement Level: Required
+  
+- Type: string
+  
+- Stability: Stable
+  
+  
+  

--- a/crates/weaver_forge/expected_output/test/resources.md
+++ b/crates/weaver_forge/expected_output/test/resources.md
@@ -92,3 +92,29 @@ The version of the instrumentation scope - (`InstrumentationScope.Version` in OT
   
   
 - 
+## Namespace Resource `service`
+
+
+
+## Resource `entity.service`
+
+Note: 
+Brief: A service, named in the `entity_associations` of this registry.
+
+### Attributes
+
+
+#### Attribute `service.name`
+
+Service name
+
+
+- Requirement Level: Required
+  
+- Type: string
+  
+- Stability: Stable
+  
+  
+  
+- 

--- a/crates/weaver_forge/expected_output/whitespace_control/registry.md
+++ b/crates/weaver_forge/expected_output/whitespace_control/registry.md
@@ -40,6 +40,7 @@ Url:
 
 ## Resource
 
+- [entity.service](resource/entity_service.md)
 - [otel.library](resource/otel_library.md)
 - [otel.scope](resource/otel_scope.md)
 

--- a/crates/weaver_forge/src/error.rs
+++ b/crates/weaver_forge/src/error.rs
@@ -208,6 +208,17 @@ pub enum Error {
         attr_ref: AttributeRef,
     },
 
+    /// Entity association reference not found in the entity refinements.
+    #[error(
+        "Entity reference {entity_ref} (group: {group_id}) not found in the entity refinements"
+    )]
+    EntityNotFound {
+        /// Group id.
+        group_id: String,
+        /// Entity reference.
+        entity_ref: u32,
+    },
+
     /// Filter error.
     #[error("Filter '{filter}' failed: {}", format_details(.details))]
     FilterError {

--- a/crates/weaver_forge/src/v2/registry.rs
+++ b/crates/weaver_forge/src/v2/registry.rs
@@ -108,6 +108,9 @@ impl ForgeResolvedRegistry {
         let attribute_lookup = |r: &weaver_resolved_schema::v2::attribute::AttributeRef| {
             schema.attribute_catalog.attribute(r)
         };
+        // A resolved schema holds an association as an index into its entity
+        // refinements. Templates read names, so materialize the names here.
+        let entity_refinements = schema.refinements.entities.clone();
         // We create an attribute lookup map.
         let mut attributes: Vec<Attribute> = schema
             .registry
@@ -148,12 +151,18 @@ impl ForgeResolvedRegistry {
                     attr
                 })
                 .collect();
+            let entity_associations = materialize_entity_associations(
+                &metric.entity_associations,
+                &entity_refinements,
+                &format!("metric.{}", &metric.name),
+                &mut errors,
+            );
             metrics.push(Metric {
                 name: metric.name,
                 instrument: metric.instrument,
                 unit: metric.unit,
                 attributes,
-                entity_associations: metric.entity_associations,
+                entity_associations,
                 requirement_level: metric.requirement_level,
                 common: metric.common,
                 provenance: resolve_provenance(&metric.provenance),
@@ -187,6 +196,12 @@ impl ForgeResolvedRegistry {
                     attr
                 })
                 .collect();
+            let entity_associations = materialize_entity_associations(
+                &metric.metric.entity_associations,
+                &entity_refinements,
+                &format!("metric.{}", &metric.metric.name),
+                &mut errors,
+            );
             metric_refinements.push(MetricRefinement {
                 id: metric.id.clone(),
                 metric: Metric {
@@ -194,7 +209,7 @@ impl ForgeResolvedRegistry {
                     instrument: metric.metric.instrument,
                     unit: metric.metric.unit,
                     attributes,
-                    entity_associations: metric.metric.entity_associations,
+                    entity_associations,
                     requirement_level: metric.metric.requirement_level,
                     common: metric.metric.common,
                     provenance: resolve_provenance(&metric.metric.provenance),
@@ -229,12 +244,18 @@ impl ForgeResolvedRegistry {
                     attr
                 })
                 .collect();
+            let entity_associations = materialize_entity_associations(
+                &span.entity_associations,
+                &entity_refinements,
+                &format!("span.{}", &span.r#type),
+                &mut errors,
+            );
             spans.push(Span {
                 r#type: span.r#type,
                 kind: span.kind,
                 name: span.name,
                 attributes,
-                entity_associations: span.entity_associations,
+                entity_associations,
                 requirement_level: span.requirement_level,
                 common: span.common,
                 provenance: resolve_provenance(&span.provenance),
@@ -268,6 +289,12 @@ impl ForgeResolvedRegistry {
                     attr
                 })
                 .collect();
+            let entity_associations = materialize_entity_associations(
+                &span.span.entity_associations,
+                &entity_refinements,
+                &format!("span.{}", &span.id),
+                &mut errors,
+            );
             span_refinements.push(SpanRefinement {
                 id: span.id,
                 span: Span {
@@ -275,7 +302,7 @@ impl ForgeResolvedRegistry {
                     kind: span.span.kind,
                     name: span.span.name,
                     attributes,
-                    entity_associations: span.span.entity_associations,
+                    entity_associations,
                     requirement_level: span.span.requirement_level,
                     common: span.span.common,
                     provenance: resolve_provenance(&span.span.provenance),
@@ -309,10 +336,16 @@ impl ForgeResolvedRegistry {
                     attr
                 })
                 .collect();
+            let entity_associations = materialize_entity_associations(
+                &event.entity_associations,
+                &entity_refinements,
+                &format!("event.{}", &event.name),
+                &mut errors,
+            );
             events.push(Event {
                 name: event.name,
                 attributes,
-                entity_associations: event.entity_associations,
+                entity_associations,
                 requirement_level: event.requirement_level,
                 common: event.common,
                 provenance: resolve_provenance(&event.provenance),
@@ -347,12 +380,18 @@ impl ForgeResolvedRegistry {
                     attr
                 })
                 .collect();
+            let entity_associations = materialize_entity_associations(
+                &event.event.entity_associations,
+                &entity_refinements,
+                &format!("event.{}", &event.id),
+                &mut errors,
+            );
             event_refinements.push(EventRefinement {
                 id: event.id,
                 event: Event {
                     name: event.event.name,
                     attributes,
-                    entity_associations: event.event.entity_associations,
+                    entity_associations,
                     requirement_level: event.event.requirement_level,
                     common: event.event.common,
                     provenance: resolve_provenance(&event.event.provenance),
@@ -481,6 +520,26 @@ impl ForgeResolvedRegistry {
                 entities: entity_refinements,
             },
         })
+    }
+}
+
+/// Turns entity refinement indices back into names for the templates. An index
+/// that names no refinement is collected as an error.
+fn materialize_entity_associations(
+    associations: &[weaver_resolved_schema::v2::entity::EntityAssociation],
+    refinements: &[weaver_resolved_schema::v2::entity::EntityRefinement],
+    group_id: &str,
+    errors: &mut Vec<Error>,
+) -> Vec<weaver_semconv::entity_association::EntityAssociation> {
+    match weaver_resolved_schema::v2::entity::to_named_associations(associations, refinements) {
+        Ok(named) => named,
+        Err(entity_ref) => {
+            errors.push(Error::EntityNotFound {
+                group_id: group_id.to_owned(),
+                entity_ref: entity_ref.0,
+            });
+            vec![]
+        }
     }
 }
 

--- a/crates/weaver_resolved_schema/src/error.rs
+++ b/crates/weaver_resolved_schema/src/error.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::attribute::AttributeRef;
 use crate::error::Error::{
-    AttributeNotFound, CompoundError, EventNameNotFound, InvalidSchemaUrl, RefinementBaseNotFound,
+    AttributeNotFound, CompoundError, EntityAssociationNotFound, EventNameNotFound,
+    InvalidSchemaUrl, RefinementBaseNotFound,
 };
 
 /// Errors emitted by this crate.
@@ -33,6 +34,15 @@ pub enum Error {
     RefinementBaseNotFound {
         /// Group id.
         group_id: String,
+    },
+
+    /// An entity association names an entity that the registry does not hold.
+    #[error("Group {group_id} is associated with entity {entity_type}, which this registry does not define or import")]
+    EntityAssociationNotFound {
+        /// Group id.
+        group_id: String,
+        /// The entity type that nothing defines.
+        entity_type: String,
     },
 
     /// Cannot convert from V1 to V2 schema due to invalid schema URL.
@@ -73,6 +83,7 @@ impl Error {
                     e @ AttributeNotFound { .. } => vec![e],
                     e @ EventNameNotFound { .. } => vec![e],
                     e @ RefinementBaseNotFound { .. } => vec![e],
+                    e @ EntityAssociationNotFound { .. } => vec![e],
                     e @ InvalidSchemaUrl { .. } => vec![e],
                 })
                 .collect(),

--- a/crates/weaver_resolved_schema/src/v2/catalog.rs
+++ b/crates/weaver_resolved_schema/src/v2/catalog.rs
@@ -68,11 +68,14 @@ impl Catalog {
                         && a.common.brief == attribute.brief
                         && a.common.note == attribute.note
                         && a.common.deprecated == attribute.deprecated
-                        && attribute
-                            .stability
-                            .as_ref()
-                            .map(|s| a.common.stability == *s)
-                            .unwrap_or(false)
+                        // A v1 attribute can carry no stability. The catalog
+                        // stores it as `Alpha`, so this test applies the same
+                        // default. The annotations test below does the same.
+                        && a.common.stability
+                            == *attribute
+                                .stability
+                                .as_ref()
+                                .unwrap_or(&weaver_semconv::stability::Stability::Alpha)
                         && attribute
                             .annotations
                             .as_ref()
@@ -182,5 +185,49 @@ mod test {
             role: None,
         });
         assert!(result2.is_some());
+    }
+
+    /// A catalog entry stores a missing stability as `Alpha`. A lookup for an
+    /// attribute with no stability must find that entry.
+    #[test]
+    fn test_lookup_defaults_missing_stability() {
+        let key = "test.key".to_owned();
+        let atype = AttributeType::PrimitiveOrArray(
+            weaver_semconv::attribute::PrimitiveOrArrayTypeSpec::String,
+        );
+        let catalog = Catalog::from_attributes(vec![Attribute {
+            key: key.clone(),
+            r#type: atype.clone(),
+            examples: None,
+            common: CommonFields {
+                brief: "brief".to_owned(),
+                note: "note".to_owned(),
+                // What `convert_v1_to_v2` stores for an attribute with no
+                // stability.
+                stability: Stability::Alpha,
+                deprecated: None,
+                annotations: BTreeMap::new(),
+            },
+            provenance: Default::default(),
+        }]);
+
+        let result = catalog.convert_ref(&crate::attribute::Attribute {
+            name: key,
+            r#type: atype,
+            brief: "brief".to_owned(),
+            examples: None,
+            tag: None,
+            requirement_level: RequirementLevel::Basic(BasicRequirementLevelSpec::Required),
+            sampling_relevant: Some(true),
+            note: "note".to_owned(),
+            stability: None,
+            deprecated: None,
+            prefix: false,
+            tags: None,
+            annotations: None,
+            value: None,
+            role: None,
+        });
+        assert!(result.is_some());
     }
 }

--- a/crates/weaver_resolved_schema/src/v2/entity.rs
+++ b/crates/weaver_resolved_schema/src/v2/entity.rs
@@ -39,6 +39,93 @@ pub struct Entity {
     pub provenance: Provenance,
 }
 
+/// A reference, by index, to an entity refinement of the schema.
+#[derive(
+    Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq, Hash, JsonSchema, PartialOrd, Ord,
+)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct EntityRef(pub u32);
+
+impl std::fmt::Display for EntityRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EntityRef({})", self.0)
+    }
+}
+
+/// An entity association expression in a resolved schema.
+///
+/// The leaf is an index into the entity refinements, not a name. Every entity
+/// definition also has a base refinement, so an index can reach a definition or
+/// a refinement of one.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, JsonSchema)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(untagged)]
+pub enum EntityAssociation {
+    /// A reference to one entity refinement.
+    Ref(EntityRef),
+    /// Satisfied when at least one of the contained expressions is satisfied.
+    OneOf {
+        /// The candidate expressions.
+        // `no_recursion` stops utoipa from inlining the self-referential schema
+        // forever (it would otherwise overflow the stack at generation time).
+        #[cfg_attr(feature = "openapi", schema(no_recursion))]
+        one_of: Vec<EntityAssociation>,
+    },
+    /// Satisfied when every contained expression is satisfied.
+    AllOf {
+        /// The required expressions.
+        #[cfg_attr(feature = "openapi", schema(no_recursion))]
+        all_of: Vec<EntityAssociation>,
+    },
+}
+
+impl EntityAssociation {
+    /// Returns every entity reference anywhere in this expression tree.
+    pub fn refs(&self) -> impl Iterator<Item = EntityRef> + '_ {
+        // A small explicit stack keeps this allocation-light and avoids
+        // recursion in a hot path.
+        let mut stack = vec![self];
+        std::iter::from_fn(move || {
+            while let Some(node) = stack.pop() {
+                match node {
+                    EntityAssociation::Ref(r) => return Some(*r),
+                    EntityAssociation::OneOf { one_of: children }
+                    | EntityAssociation::AllOf { all_of: children } => stack.extend(children),
+                }
+            }
+            None
+        })
+    }
+}
+
+/// Turns the indices of association expressions back into names, using the
+/// entity refinements of the schema. Returns the first index that names no
+/// refinement.
+///
+/// A resolved schema holds an index. A v1 group and a template both read a
+/// name, so every consumer of the two needs this.
+pub fn to_named_associations(
+    associations: &[EntityAssociation],
+    refinements: &[EntityRefinement],
+) -> Result<Vec<weaver_semconv::entity_association::EntityAssociation>, EntityRef> {
+    use weaver_semconv::entity_association::EntityAssociation as SpecAssociation;
+    associations
+        .iter()
+        .map(|assoc| match assoc {
+            EntityAssociation::Ref(entity_ref) => refinements
+                .get(entity_ref.0 as usize)
+                .map(|refinement| SpecAssociation::Ref(refinement.id.to_string()))
+                .ok_or(*entity_ref),
+            EntityAssociation::OneOf { one_of } => Ok(SpecAssociation::OneOf {
+                one_of: to_named_associations(one_of, refinements)?,
+            }),
+            EntityAssociation::AllOf { all_of } => Ok(SpecAssociation::AllOf {
+                all_of: to_named_associations(all_of, refinements)?,
+            }),
+        })
+        .collect()
+}
+
 /// A special type of reference to attributes that remembers entity-specicific information.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash, JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/crates/weaver_resolved_schema/src/v2/event.rs
+++ b/crates/weaver_resolved_schema/src/v2/event.rs
@@ -4,12 +4,13 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_semconv::{
     attribute::RequirementLevel,
-    entity_association::EntityAssociation,
     signal_requirement_level::SignalRequirementLevel,
     v2::{signal_id::SignalId, CommonFields},
 };
 
-use crate::v2::{attribute::AttributeRef, provenance::Provenance, Signal};
+use crate::v2::{
+    attribute::AttributeRef, entity::EntityAssociation, provenance::Provenance, Signal,
+};
 
 /// The definition of an Event signal.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]

--- a/crates/weaver_resolved_schema/src/v2/metric.rs
+++ b/crates/weaver_resolved_schema/src/v2/metric.rs
@@ -1,11 +1,12 @@
 //! Metric related definitions structs.
 
-use crate::v2::{attribute::AttributeRef, provenance::Provenance, Signal};
+use crate::v2::{
+    attribute::AttributeRef, entity::EntityAssociation, provenance::Provenance, Signal,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_semconv::{
     attribute::RequirementLevel,
-    entity_association::EntityAssociation,
     group::InstrumentSpec,
     signal_requirement_level::SignalRequirementLevel,
     v2::{signal_id::SignalId, CommonFields},

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -153,12 +153,56 @@ impl TryFrom<crate::ResolvedTelemetrySchema> for ResolvedTelemetrySchema {
     }
 }
 
-fn fix_group_id(prefix: &'static str, group_id: &str) -> SignalId {
-    if group_id.starts_with(prefix) {
-        group_id.trim_start_matches(prefix).to_owned().into()
-    } else {
-        group_id.to_owned().into()
+/// Turns the names in an association expression into entity refinement
+/// indices. The shape of the expression does not change, only the leaves.
+fn convert_entity_associations(
+    associations: &[weaver_semconv::entity_association::EntityAssociation],
+    entity_refs: &HashMap<SignalId, entity::EntityRef>,
+    group_id: &str,
+) -> Result<Vec<entity::EntityAssociation>, crate::error::Error> {
+    associations
+        .iter()
+        .map(|assoc| convert_entity_association(assoc, entity_refs, group_id))
+        .collect()
+}
+
+fn convert_entity_association(
+    association: &weaver_semconv::entity_association::EntityAssociation,
+    entity_refs: &HashMap<SignalId, entity::EntityRef>,
+    group_id: &str,
+) -> Result<entity::EntityAssociation, crate::error::Error> {
+    use weaver_semconv::entity_association::EntityAssociation as SpecAssociation;
+    match association {
+        SpecAssociation::Ref(name) => entity_refs
+            .get(&SignalId::from(name.clone()))
+            .map(|r| entity::EntityAssociation::Ref(*r))
+            .ok_or_else(|| crate::error::Error::EntityAssociationNotFound {
+                group_id: group_id.to_owned(),
+                entity_type: name.clone(),
+            }),
+        SpecAssociation::OneOf { one_of } => Ok(entity::EntityAssociation::OneOf {
+            one_of: convert_entity_associations(one_of, entity_refs, group_id)?,
+        }),
+        SpecAssociation::AllOf { all_of } => Ok(entity::EntityAssociation::AllOf {
+            all_of: convert_entity_associations(all_of, entity_refs, group_id)?,
+        }),
     }
+}
+
+/// Strips the group-type prefix that a v2 definition adds to a group id.
+///
+/// A v2 definition names a signal by type alone, and the v1 group model holds
+/// every signal type in one flat id space, so reading a v2 file mints an id
+/// like `entity.host`. This undoes that.
+///
+/// Strips one prefix only. `trim_start_matches` would strip a repeat, so
+/// `entity.entity.host` would lose both.
+fn fix_group_id(prefix: &'static str, group_id: &str) -> SignalId {
+    group_id
+        .strip_prefix(prefix)
+        .unwrap_or(group_id)
+        .to_owned()
+        .into()
 }
 
 fn fix_span_group_id(group_id: &str) -> SignalId {
@@ -258,6 +302,88 @@ pub fn convert_v1_to_v2(
     let mut entities = Vec::new();
     let mut entity_refinements = Vec::new();
     let mut attribute_groups = Vec::new();
+    // Entities come first. A signal names an entity, and the association is
+    // stored as an index into the entity refinements, so the refinements must
+    // exist before any signal is converted.
+    for g in r.groups.iter().filter(|g| g.r#type == GroupType::Entity) {
+        // Check if we refine another entity.
+        let is_refinement = g
+            .lineage
+            .as_ref()
+            .map(|l| l.extends_group_type == Some(GroupType::Entity))
+            .unwrap_or(false);
+        let mut id_attrs = Vec::new();
+        let mut desc_attrs = Vec::new();
+        for attr in g.attributes.iter().filter_map(|a| c.attribute(a)) {
+            if let Some(a) = v2_catalog.convert_ref(attr) {
+                match attr.role {
+                    Some(weaver_semconv::attribute::AttributeRole::Identifying) => {
+                        id_attrs.push(entity::EntityAttributeRef {
+                            base: a,
+                            requirement_level: attr.requirement_level.clone(),
+                        });
+                    }
+                    _ => {
+                        desc_attrs.push(entity::EntityAttributeRef {
+                            base: a,
+                            requirement_level: attr.requirement_level.clone(),
+                        });
+                    }
+                }
+            } else {
+                // TODO logic error!
+            }
+        }
+        let entity_type = if is_refinement {
+            let Some(extends_group) = g.lineage.as_ref().and_then(|l| l.extends_group.as_ref())
+            else {
+                return Err(crate::error::Error::RefinementBaseNotFound {
+                    group_id: g.id.clone(),
+                });
+            };
+            fix_group_id("entity.", extends_group)
+        } else {
+            fix_group_id("entity.", &g.id)
+        };
+        let entity = Entity {
+            r#type: entity_type,
+            identity: id_attrs,
+            description: desc_attrs,
+            requirement_level: g.requirement_level.clone(),
+            common: CommonFields {
+                brief: g.brief.clone(),
+                note: g.note.clone(),
+                stability: g
+                    .stability
+                    .clone()
+                    .unwrap_or(weaver_semconv::stability::Stability::Alpha),
+                deprecated: g.deprecated.clone(),
+                annotations: g.annotations.clone().unwrap_or_default(),
+            },
+            provenance: get_provenance(g),
+        };
+        if is_refinement {
+            entity_refinements.push(entity::EntityRefinement {
+                id: fix_group_id("entity.", &g.id),
+                entity,
+            });
+        } else {
+            entities.push(entity.clone());
+            entity_refinements.push(entity::EntityRefinement {
+                id: entity.r#type.clone(),
+                entity,
+            });
+        }
+    }
+
+    // Read the indices back off the refinements. Deriving the ids a second
+    // time here would let this map and that list disagree.
+    let entity_refs: HashMap<SignalId, entity::EntityRef> = entity_refinements
+        .iter()
+        .enumerate()
+        .map(|(index, refinement)| (refinement.id.clone(), entity::EntityRef(index as u32)))
+        .collect();
+
     for g in r.groups.iter() {
         match g.r#type {
             GroupType::Span => {
@@ -292,7 +418,11 @@ pub fn convert_v1_to_v2(
                         name: g.span_name.clone().unwrap_or_else(|| SpanName {
                             note: g.name.clone().unwrap_or_default(),
                         }),
-                        entity_associations: g.entity_associations.clone(),
+                        entity_associations: convert_entity_associations(
+                            &g.entity_associations,
+                            &entity_refs,
+                            &g.id,
+                        )?,
                         requirement_level: g.requirement_level.clone(),
                         common: CommonFields {
                             brief: g.brief.clone(),
@@ -333,7 +463,11 @@ pub fn convert_v1_to_v2(
                             name: g.span_name.clone().unwrap_or_else(|| SpanName {
                                 note: g.name.clone().unwrap_or_default(),
                             }),
-                            entity_associations: g.entity_associations.clone(),
+                            entity_associations: convert_entity_associations(
+                                &g.entity_associations,
+                                &entity_refs,
+                                &g.id,
+                            )?,
                             requirement_level: g.requirement_level.clone(),
                             common: CommonFields {
                                 brief: g.brief.clone(),
@@ -374,7 +508,11 @@ pub fn convert_v1_to_v2(
                     let event = event::Event {
                         name: name.into(),
                         attributes: event_attributes,
-                        entity_associations: g.entity_associations.clone(),
+                        entity_associations: convert_entity_associations(
+                            &g.entity_associations,
+                            &entity_refs,
+                            &g.id,
+                        )?,
                         requirement_level: g.requirement_level.clone(),
                         common: CommonFields {
                             brief: g.brief.clone(),
@@ -442,7 +580,11 @@ pub fn convert_v1_to_v2(
                         .clone()
                         .expect("unit must exist on metrics prior to translation to v2"),
                     attributes: metric_attributes,
-                    entity_associations: g.entity_associations.clone(),
+                    entity_associations: convert_entity_associations(
+                        &g.entity_associations,
+                        &entity_refs,
+                        &g.id,
+                    )?,
                     requirement_level: g.requirement_level.clone(),
                     common: CommonFields {
                         brief: g.brief.clone(),
@@ -466,77 +608,6 @@ pub fn convert_v1_to_v2(
                     metric_refinements.push(metric::MetricRefinement {
                         id: metric.name.clone(),
                         metric,
-                    });
-                }
-            }
-            GroupType::Entity => {
-                // Check if we refine another entity.
-                let is_refinement = g
-                    .lineage
-                    .as_ref()
-                    .map(|l| l.extends_group_type == Some(GroupType::Entity))
-                    .unwrap_or(false);
-                let mut id_attrs = Vec::new();
-                let mut desc_attrs = Vec::new();
-                for attr in g.attributes.iter().filter_map(|a| c.attribute(a)) {
-                    if let Some(a) = v2_catalog.convert_ref(attr) {
-                        match attr.role {
-                            Some(weaver_semconv::attribute::AttributeRole::Identifying) => {
-                                id_attrs.push(entity::EntityAttributeRef {
-                                    base: a,
-                                    requirement_level: attr.requirement_level.clone(),
-                                });
-                            }
-                            _ => {
-                                desc_attrs.push(entity::EntityAttributeRef {
-                                    base: a,
-                                    requirement_level: attr.requirement_level.clone(),
-                                });
-                            }
-                        }
-                    } else {
-                        // TODO logic error!
-                    }
-                }
-                let entity_type = if is_refinement {
-                    let Some(extends_group) =
-                        g.lineage.as_ref().and_then(|l| l.extends_group.as_ref())
-                    else {
-                        return Err(crate::error::Error::RefinementBaseNotFound {
-                            group_id: g.id.clone(),
-                        });
-                    };
-                    fix_group_id("entity.", extends_group)
-                } else {
-                    fix_group_id("entity.", &g.id)
-                };
-                let entity = Entity {
-                    r#type: entity_type,
-                    identity: id_attrs,
-                    description: desc_attrs,
-                    requirement_level: g.requirement_level.clone(),
-                    common: CommonFields {
-                        brief: g.brief.clone(),
-                        note: g.note.clone(),
-                        stability: g
-                            .stability
-                            .clone()
-                            .unwrap_or(weaver_semconv::stability::Stability::Alpha),
-                        deprecated: g.deprecated.clone(),
-                        annotations: g.annotations.clone().unwrap_or_default(),
-                    },
-                    provenance: get_provenance(g),
-                };
-                if is_refinement {
-                    entity_refinements.push(entity::EntityRefinement {
-                        id: fix_group_id("entity.", &g.id),
-                        entity,
-                    });
-                } else {
-                    entities.push(entity.clone());
-                    entity_refinements.push(entity::EntityRefinement {
-                        id: entity.r#type.clone(),
-                        entity,
                     });
                 }
             }
@@ -574,6 +645,9 @@ pub fn convert_v1_to_v2(
                         provenance: get_provenance(g),
                     });
                 }
+            }
+            GroupType::Entity => {
+                // Converted by the pass above.
             }
             GroupType::MetricGroup | GroupType::Scope | GroupType::Undefined => {
                 // Ignored for now, we should probably issue warnings.

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -209,6 +209,26 @@ fn fix_span_group_id(group_id: &str) -> SignalId {
     fix_group_id("span.", group_id)
 }
 
+/// Converts one attribute reference of a v1 group into the v1 definition and
+/// the v2 catalog reference.
+///
+/// A lookup that finds nothing is an error. A silent miss removes the attribute
+/// from the signal. An entity keeps its identity in these attributes.
+fn convert_attribute_ref<'a>(
+    group_id: &str,
+    attr_ref: &crate::attribute::AttributeRef,
+    c: &'a crate::catalog::Catalog,
+    v2_catalog: &Catalog,
+) -> Result<(&'a crate::attribute::Attribute, attribute::AttributeRef), crate::error::Error> {
+    let not_found = || crate::error::Error::AttributeNotFound {
+        group_id: group_id.to_owned(),
+        attr_ref: *attr_ref,
+    };
+    let attr = c.attribute(attr_ref).ok_or_else(not_found)?;
+    let v2_ref = v2_catalog.convert_ref(attr).ok_or_else(not_found)?;
+    Ok((attr, v2_ref))
+}
+
 /// Converts a V1 registry + catalog to V2.
 pub fn convert_v1_to_v2(
     c: crate::catalog::Catalog,
@@ -314,24 +334,21 @@ pub fn convert_v1_to_v2(
             .unwrap_or(false);
         let mut id_attrs = Vec::new();
         let mut desc_attrs = Vec::new();
-        for attr in g.attributes.iter().filter_map(|a| c.attribute(a)) {
-            if let Some(a) = v2_catalog.convert_ref(attr) {
-                match attr.role {
-                    Some(weaver_semconv::attribute::AttributeRole::Identifying) => {
-                        id_attrs.push(entity::EntityAttributeRef {
-                            base: a,
-                            requirement_level: attr.requirement_level.clone(),
-                        });
-                    }
-                    _ => {
-                        desc_attrs.push(entity::EntityAttributeRef {
-                            base: a,
-                            requirement_level: attr.requirement_level.clone(),
-                        });
-                    }
+        for attr_ref in g.attributes.iter() {
+            let (attr, a) = convert_attribute_ref(&g.id, attr_ref, &c, &v2_catalog)?;
+            match attr.role {
+                Some(weaver_semconv::attribute::AttributeRole::Identifying) => {
+                    id_attrs.push(entity::EntityAttributeRef {
+                        base: a,
+                        requirement_level: attr.requirement_level.clone(),
+                    });
                 }
-            } else {
-                // TODO logic error!
+                _ => {
+                    desc_attrs.push(entity::EntityAttributeRef {
+                        base: a,
+                        requirement_level: attr.requirement_level.clone(),
+                    });
+                }
             }
         }
         let entity_type = if is_refinement {
@@ -1287,6 +1304,80 @@ mod tests {
             assert_eq!(entity.provenance.source, Some(provenance::DependencyRef(0)));
             assert_eq!(entity.provenance.path, "/path/to/source.yaml");
         }
+    }
+
+    /// An attribute with no stability must reach the entity that holds it. A
+    /// registry with such an attribute resolves, because the missing field is
+    /// only a warning. An entity with no identity attribute has no identity.
+    #[test]
+    fn test_convert_entity_keeps_attribute_without_stability() {
+        let mut builder = crate::catalog::test_utils::CatalogBuilder::default();
+        let ref0 = builder.add(
+            Attribute {
+                name: "test.key".to_owned(),
+                r#type: weaver_semconv::attribute::AttributeType::PrimitiveOrArray(
+                    weaver_semconv::attribute::PrimitiveOrArrayTypeSpec::String,
+                ),
+                brief: "".to_owned(),
+                examples: None,
+                tag: None,
+                requirement_level: weaver_semconv::attribute::RequirementLevel::Basic(
+                    weaver_semconv::attribute::BasicRequirementLevelSpec::Required,
+                ),
+                sampling_relevant: None,
+                note: "".to_owned(),
+                // The point of this test.
+                stability: None,
+                deprecated: None,
+                prefix: false,
+                tags: None,
+                annotations: None,
+                value: None,
+                role: Some(weaver_semconv::attribute::AttributeRole::Identifying),
+            },
+            None,
+        );
+        let v1_catalog = builder.build();
+        let v1_registry = crate::registry::Registry {
+            registry_url: "my.schema.url".to_owned(),
+            groups: vec![Group {
+                id: "entity.my-entity".to_owned(),
+                r#type: GroupType::Entity,
+                brief: "".to_owned(),
+                note: "".to_owned(),
+                prefix: "".to_owned(),
+                extends: None,
+                stability: Some(Stability::Stable),
+                deprecated: None,
+                attributes: vec![ref0],
+                span_kind: None,
+                events: vec![],
+                metric_name: None,
+                instrument: None,
+                unit: None,
+                requirement_level: None,
+                name: Some("my-entity".to_owned()),
+                lineage: None,
+                display_name: None,
+                body: None,
+                annotations: None,
+                entity_associations: vec![],
+                visibility: None,
+                is_v2: false,
+                span_name: None,
+            }],
+        };
+        let (_, v2_registry, _, _) =
+            convert_v1_to_v2(v1_catalog, v1_registry, BTreeSet::new()).expect("conversion failed");
+        let entity = v2_registry
+            .entities
+            .first()
+            .expect("the entity is in the v2 registry");
+        assert_eq!(
+            entity.identity.len(),
+            1,
+            "an identity attribute with no stability must not be dropped"
+        );
     }
 
     #[test]

--- a/crates/weaver_resolved_schema/src/v2/span.rs
+++ b/crates/weaver_resolved_schema/src/v2/span.rs
@@ -4,13 +4,14 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_semconv::{
     attribute::RequirementLevel,
-    entity_association::EntityAssociation,
     group::SpanKindSpec,
     signal_requirement_level::SignalRequirementLevel,
     v2::{signal_id::SignalId, span::SpanName, CommonFields},
 };
 
-use crate::v2::{attribute::AttributeRef, provenance::Provenance, Signal};
+use crate::v2::{
+    attribute::AttributeRef, entity::EntityAssociation, provenance::Provenance, Signal,
+};
 
 /// The definition of a Span signal.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]

--- a/crates/weaver_resolver/data/entity-assoc-imports/base/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/base/manifest.yaml
@@ -1,0 +1,3 @@
+name: base
+description: This registry defines the `host` entity and its attributes.
+schema_url: https://example.com/base/1.0.0

--- a/crates/weaver_resolver/data/entity-assoc-imports/base/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/base/registry.yaml
@@ -1,0 +1,21 @@
+file_format: definition/2
+attributes:
+  - key: host.id
+    type: string
+    stability: stable
+    brief: Unique host ID, defined in base.
+    examples: ["abc123"]
+  - key: host.name
+    type: string
+    stability: stable
+    brief: Host name, defined in base.
+    examples: ["myhost"]
+entities:
+  - type: host
+    requirement_level: recommended
+    stability: stable
+    brief: A host, defined in base.
+    identity:
+      - ref: host.id
+    description:
+      - ref: host.name

--- a/crates/weaver_resolver/data/entity-assoc-imports/base_excluded/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/base_excluded/manifest.yaml
@@ -1,0 +1,5 @@
+name: base
+description: >
+  The same as `base`, but the `host` entity is excluded from dependency
+  resolution. A dependent must not use it by any route.
+schema_url: https://example.com/base/1.0.0

--- a/crates/weaver_resolver/data/entity-assoc-imports/base_excluded/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/base_excluded/registry.yaml
@@ -1,0 +1,24 @@
+file_format: definition/2
+attributes:
+  - key: host.id
+    type: string
+    stability: stable
+    brief: Unique host ID, defined in base.
+    examples: ["abc123"]
+  - key: host.name
+    type: string
+    stability: stable
+    brief: Host name, defined in base.
+    examples: ["myhost"]
+entities:
+  - type: host
+    requirement_level: recommended
+    stability: stable
+    brief: A host, defined in base and kept private.
+    annotations:
+      dependency_resolution:
+        exclude: true
+    identity:
+      - ref: host.id
+    description:
+      - ref: host.name

--- a/crates/weaver_resolver/data/entity-assoc-imports/legacy_resource/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/legacy_resource/manifest.yaml
@@ -1,0 +1,6 @@
+name: legacy_resource
+description: >
+  A v1 registry with a legacy `type: resource` group. Such a group carries its
+  entity type in the id and leaves `name` unset. A metric in the same registry
+  is associated with it by that id.
+schema_url: https://example.com/legacy-resource/1.0.0

--- a/crates/weaver_resolver/data/entity-assoc-imports/legacy_resource/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/legacy_resource/registry.yaml
@@ -1,0 +1,23 @@
+groups:
+  # The legacy spelling, as published registries still carry it. The group is an
+  # entity, its type is `browser`, and it has no `name`.
+  - id: browser
+    type: resource
+    stability: stable
+    brief: The web browser in which the application is running.
+    attributes:
+      - id: browser.brands
+        type: string[]
+        stability: stable
+        brief: Array of brand name and version separated by a space.
+        examples: [["Not A;Brand 99"], ["Chromium 99"]]
+
+  - id: metric.legacy.request.count
+    type: metric
+    metric_name: legacy.request.count
+    instrument: counter
+    unit: "{request}"
+    stability: stable
+    brief: Count of requests.
+    entity_associations:
+      - browser

--- a/crates/weaver_resolver/data/entity-assoc-imports/middle/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/middle/manifest.yaml
@@ -1,0 +1,11 @@
+name: middle
+description: >
+  This registry defines a metric. The metric holds a `ref` to an attribute from
+  base. The metric is also associated with the `host` entity of base. The
+  registry imports neither one explicitly. The `ref` resolves. The association
+  does not resolve.
+schema_url: https://example.com/middle/1.0.0
+dependencies:
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/entity-assoc-imports/base

--- a/crates/weaver_resolver/data/entity-assoc-imports/middle/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/middle/registry.yaml
@@ -1,0 +1,14 @@
+file_format: definition/2
+metrics:
+  - name: middle.request.count
+    brief: Count of requests, defined in middle.
+    requirement_level: recommended
+    instrument: counter
+    unit: "{request}"
+    stability: stable
+    attributes:
+      # Defined in base, not imported here — and resolved anyway.
+      - ref: host.id
+    # Also defined in base, also not imported here — and never resolved.
+    entity_associations:
+      - host

--- a/crates/weaver_resolver/data/entity-assoc-imports/middle_bad_assoc/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/middle_bad_assoc/manifest.yaml
@@ -1,0 +1,10 @@
+name: middle
+description: >
+  A control case. The metric is associated with an entity that exists nowhere in
+  the dependency graph. If this registry resolves without an error, nothing
+  tests `entity_associations` against the resolved set of entities.
+schema_url: https://example.com/middle/1.0.0
+dependencies:
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/entity-assoc-imports/base

--- a/crates/weaver_resolver/data/entity-assoc-imports/middle_bad_assoc/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/middle_bad_assoc/registry.yaml
@@ -1,0 +1,10 @@
+file_format: definition/2
+metrics:
+  - name: middle.request.count
+    brief: Count of requests, defined in middle.
+    requirement_level: recommended
+    instrument: counter
+    unit: "{request}"
+    stability: stable
+    entity_associations:
+      - no.such.entity

--- a/crates/weaver_resolver/data/entity-assoc-imports/middle_excluded_assoc/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/middle_excluded_assoc/manifest.yaml
@@ -1,0 +1,9 @@
+name: middle
+description: >
+  The metric is associated with the `host` entity of `base_excluded`, which
+  excludes it. Naming a private entity in an association must fail.
+schema_url: https://example.com/middle/1.0.0
+dependencies:
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/entity-assoc-imports/base_excluded

--- a/crates/weaver_resolver/data/entity-assoc-imports/middle_excluded_assoc/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/middle_excluded_assoc/registry.yaml
@@ -1,0 +1,10 @@
+file_format: definition/2
+metrics:
+  - name: middle.request.count
+    brief: Count of requests, defined in middle.
+    requirement_level: recommended
+    instrument: counter
+    unit: "{request}"
+    stability: stable
+    entity_associations:
+      - host

--- a/crates/weaver_resolver/data/entity-assoc-imports/middle_reexport/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/middle_reexport/manifest.yaml
@@ -1,0 +1,9 @@
+name: middle
+description: >
+  The same as `middle`, but this registry imports the `host` entity from base.
+  It therefore re-exports the entity to its own consumers.
+schema_url: https://example.com/middle/1.0.0
+dependencies:
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/entity-assoc-imports/base

--- a/crates/weaver_resolver/data/entity-assoc-imports/middle_reexport/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/middle_reexport/registry.yaml
@@ -1,0 +1,15 @@
+file_format: definition/2
+imports:
+  entities:
+    - host
+metrics:
+  - name: middle.request.count
+    brief: Count of requests, defined in middle.
+    requirement_level: recommended
+    instrument: counter
+    unit: "{request}"
+    stability: stable
+    attributes:
+      - ref: host.id
+    entity_associations:
+      - host

--- a/crates/weaver_resolver/data/entity-assoc-imports/top/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top/manifest.yaml
@@ -1,0 +1,9 @@
+name: top
+description: >
+  This registry depends on `middle`, which does not re-export the `host` entity.
+  `top` imports the entity anyway.
+schema_url: https://example.com/top/1.0.0
+dependencies:
+  - name: middle
+    schema_url: https://example.com/middle/1.0.0
+    registry_path: data/entity-assoc-imports/middle

--- a/crates/weaver_resolver/data/entity-assoc-imports/top/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top/registry.yaml
@@ -1,0 +1,6 @@
+file_format: definition/2
+imports:
+  metrics:
+    - middle.request.count
+  entities:
+    - host

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_bad_import/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_bad_import/manifest.yaml
@@ -1,0 +1,10 @@
+name: top
+description: >
+  This registry imports an entity that no declared dependency offers.
+  `middle_reexport` does export `host`. So the import fails for one reason only.
+  No entity has the name `no.such.entity`.
+schema_url: https://example.com/top/1.0.0
+dependencies:
+  - name: middle
+    schema_url: https://example.com/middle/1.0.0
+    registry_path: data/entity-assoc-imports/middle_reexport

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_bad_import/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_bad_import/registry.yaml
@@ -1,0 +1,6 @@
+file_format: definition/2
+imports:
+  metrics:
+    - middle.request.count
+  entities:
+    - no.such.entity

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_bad_imports_all_types/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_bad_imports_all_types/manifest.yaml
@@ -1,0 +1,9 @@
+name: top
+description: >
+  An import of every signal type that no dependency offers. The resolver must
+  report all five, not only the entity.
+schema_url: https://example.com/top/1.0.0
+dependencies:
+  - name: middle
+    schema_url: https://example.com/middle/1.0.0
+    registry_path: data/entity-assoc-imports/middle_reexport

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_bad_imports_all_types/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_bad_imports_all_types/registry.yaml
@@ -1,0 +1,14 @@
+file_format: definition/2
+imports:
+  metrics:
+    - middle.request.count
+    - no.such.metric
+  events:
+    - no.such.event
+  spans:
+    - no.such.span
+  entities:
+    - host
+    - no.such.entity
+  attribute_groups:
+    - no.such.attribute_group

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_diamond/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_diamond/manifest.yaml
@@ -1,0 +1,12 @@
+name: top
+description: >
+  This registry is `top_reexport` plus a direct dependency on `base`. That one
+  extra line is the whole difference. `host` becomes reachable by two paths.
+schema_url: https://example.com/top/1.0.0
+dependencies:
+  - name: middle
+    schema_url: https://example.com/middle/1.0.0
+    registry_path: data/entity-assoc-imports/middle_reexport
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/entity-assoc-imports/base

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_diamond/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_diamond/registry.yaml
@@ -1,0 +1,6 @@
+file_format: definition/2
+imports:
+  metrics:
+    - middle.request.count
+  entities:
+    - host

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_excluded_import/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_excluded_import/manifest.yaml
@@ -1,0 +1,9 @@
+name: top
+description: >
+  An explicit import of the `host` entity of `base_excluded`, which excludes
+  it. Naming a private entity in `imports` must fail.
+schema_url: https://example.com/top/1.0.0
+dependencies:
+  - name: base
+    schema_url: https://example.com/base/1.0.0
+    registry_path: data/entity-assoc-imports/base_excluded

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_excluded_import/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_excluded_import/registry.yaml
@@ -1,0 +1,4 @@
+file_format: definition/2
+imports:
+  entities:
+    - host

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_legacy_import/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_legacy_import/manifest.yaml
@@ -1,0 +1,9 @@
+name: top_legacy_import
+description: >
+  Imports the legacy `type: resource` entity of `legacy_resource` by the id that
+  carries its type. The group has no name, so the id is the only name it has.
+schema_url: https://example.com/top-legacy-import/1.0.0
+dependencies:
+  - name: legacy_resource
+    schema_url: https://example.com/legacy-resource/1.0.0
+    registry_path: data/entity-assoc-imports/legacy_resource

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_legacy_import/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_legacy_import/registry.yaml
@@ -1,0 +1,4 @@
+file_format: definition/2
+imports:
+  entities:
+    - browser

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_reexport/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_reexport/manifest.yaml
@@ -1,0 +1,10 @@
+name: top
+description: >
+  This registry depends on `middle_reexport`, which does re-export the `host`
+  entity. This is the working case. It is also the minimal pair for
+  `top_diamond`.
+schema_url: https://example.com/top/1.0.0
+dependencies:
+  - name: middle
+    schema_url: https://example.com/middle/1.0.0
+    registry_path: data/entity-assoc-imports/middle_reexport

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_reexport/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_reexport/registry.yaml
@@ -1,0 +1,6 @@
+file_format: definition/2
+imports:
+  metrics:
+    - middle.request.count
+  entities:
+    - host

--- a/crates/weaver_resolver/data/registry-test-published-1/published/resolved_schema.yaml
+++ b/crates/weaver_resolver/data/registry-test-published-1/published/resolved_schema.yaml
@@ -18,7 +18,7 @@ registry:
       - base: 0
         requirement_level: required
       entity_associations:
-      - imported.entity.a
+      - 0
       brief: a fun metric
       note: a metric note
       stability: stable
@@ -28,7 +28,7 @@ registry:
       - base: 0
         requirement_level: recommended
       entity_associations:
-      - imported.entity.a
+      - 0
       brief: a fun event
       note: an event note
       stability: stable
@@ -51,8 +51,17 @@ refinements:
     - base: 0
       requirement_level: required
     entity_associations:
-    - service
+    - 0
     brief: a fun metric
     note: a metric note
     stability: stable
   events:
+  entities:
+  - id: imported.entity.a
+    type: imported.entity.a
+    identity:
+    - base: 0
+      requirement_level: required
+    brief: a fun entity
+    note: an entity note
+    stability: stable

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -180,7 +180,8 @@ impl ImportField {
 ///
 /// A group from a v2 definition answers to its id, to its signal name, and to
 /// its id without the group-type prefix. A v1 group answers to its signal name,
-/// or to its id for a span or an attribute group.
+/// or to its id for a span or an attribute group. A v1 entity answers to both,
+/// because a legacy `resource` group has no name.
 fn import_match_keys(g: &Group) -> Vec<&str> {
     let name = g.name.as_deref();
     let metric_name = g.metric_name.as_deref();
@@ -205,7 +206,18 @@ fn import_match_keys(g: &Group) -> Vec<&str> {
     } else {
         match g.r#type {
             GroupType::AttributeGroup | GroupType::Span => vec![g.id.as_str()],
-            GroupType::Event | GroupType::Entity => name.into_iter().collect(),
+            GroupType::Event => name.into_iter().collect(),
+            // A legacy `resource` group carries its type in the id and leaves
+            // the name unset. The name alone gives it no key at all, so no
+            // import can reach it.
+            GroupType::Entity => {
+                let mut keys = vec![g.id.as_str()];
+                keys.extend(g.id.strip_prefix("entity."));
+                if let Some(name) = name.filter(|n| !keys.contains(n)) {
+                    keys.push(name);
+                }
+                keys
+            }
             GroupType::Metric => metric_name.into_iter().collect(),
             GroupType::MetricGroup | GroupType::Scope | GroupType::Undefined => vec![],
         }

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -110,6 +110,13 @@ impl ResolvedDependency {
     }
 }
 
+/// Whether the resolver added this import itself, rather than a user naming
+/// the groups. A bulk import must skip an excluded group in silence, because
+/// nobody asked for that group by name.
+fn is_implicit_import(import: &ImportsWithProvenance) -> bool {
+    import.provenance.path == "--include-unreferenced"
+}
+
 /// A group with its source provenance.
 pub struct GroupWithProvenance {
     /// The group definition.
@@ -136,10 +143,8 @@ impl ImportableDependency for V1Schema {
         attribute_catalog: &mut AttributeCatalog,
         cache_lookup: &C,
     ) -> Result<Vec<GroupWithProvenance>, Error> {
-        let explicit_imports: Vec<&ImportsWithProvenance> = imports
-            .iter()
-            .filter(|i| i.provenance.path != "--include-unreferenced")
-            .collect();
+        let explicit_imports: Vec<&ImportsWithProvenance> =
+            imports.iter().filter(|i| !is_implicit_import(i)).collect();
 
         let explicit_metrics_matcher = build_globset(
             explicit_imports
@@ -668,10 +673,8 @@ impl ImportableDependency for V2Schema {
                 }
             };
 
-        let explicit_imports: Vec<&ImportsWithProvenance> = imports
-            .iter()
-            .filter(|i| i.provenance.path != "--include-unreferenced")
-            .collect();
+        let explicit_imports: Vec<&ImportsWithProvenance> =
+            imports.iter().filter(|i| !is_implicit_import(i)).collect();
 
         let explicit_metrics_matcher = build_globset(
             explicit_imports

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -3,6 +3,7 @@
 //! Helpers to handle reading from dependencies.
 
 use globset::GlobSet;
+use std::collections::HashMap;
 use weaver_resolved_schema::attribute::Attribute;
 use weaver_resolved_schema::registry::Group;
 use weaver_resolved_schema::v2::catalog::AttributeCatalog as V2Catalog;
@@ -429,10 +430,7 @@ fn upgrade_imported_group<C: crate::SchemaCacheLookup>(
     attribute_catalog: &mut AttributeCatalog,
     cache_lookup: &C,
 ) -> Result<Option<Group>, Error> {
-    let origin_url = group
-        .provenance()
-        .map(|prov| prov.schema_url)
-        .unwrap_or_else(|| fallback_url.clone());
+    let origin_url = origin_url(group, fallback_url);
     let Some(chosen_url) = cache_lookup.chosen_version(origin_url.name()) else {
         return Ok(None);
     };
@@ -1142,13 +1140,45 @@ impl ImportableDependency for Vec<ResolvedDependency> {
         attribute_catalog: &mut AttributeCatalog,
         cache_lookup: &C,
     ) -> Result<Vec<GroupWithProvenance>, Error> {
-        self.iter()
-            .map(|d| d.import_groups(imports, attribute_catalog, cache_lookup))
-            .try_fold(vec![], |mut result, next| {
-                result.extend(next?);
-                Ok(result)
-            })
+        // A diamond in the dependency graph reaches one definition by more than
+        // one path. Keep only the first copy of each definition. The registry
+        // then holds no duplicates for `check_uniqueness` to report.
+        //
+        // `AttributeCatalog` keys its map on the definition itself, but
+        // `Group` has no `Hash` and `is_same_imported_group` is a pairwise
+        // test. So the map buckets on origin and type, and the test runs
+        // inside one bucket.
+        let mut result: Vec<GroupWithProvenance> = vec![];
+        let mut buckets: HashMap<(String, GroupType), Vec<usize>> = HashMap::new();
+        for dependency in self {
+            for candidate in dependency.import_groups(imports, attribute_catalog, cache_lookup)? {
+                let key = (
+                    origin_url(&candidate.group, &candidate.schema_url).to_string(),
+                    candidate.group.r#type.clone(),
+                );
+                let bucket = buckets.entry(key).or_default();
+                let is_duplicate = bucket
+                    .iter()
+                    .any(|&kept| is_same_imported_group(&result[kept].group, &candidate.group));
+                if !is_duplicate {
+                    bucket.push(result.len());
+                    result.push(candidate);
+                }
+            }
+        }
+        Ok(result)
     }
+}
+
+/// The registry that a group comes from. A group that was itself imported
+/// carries the provenance of its origin. A re-exported definition therefore
+/// keeps the url of the registry that declared it. A group with no provenance
+/// comes from the dependency it arrived through, which is `fallback_url`.
+fn origin_url(group: &Group, fallback_url: &SchemaUrl) -> SchemaUrl {
+    group
+        .provenance()
+        .map(|prov| prov.schema_url)
+        .unwrap_or_else(|| fallback_url.clone())
 }
 
 /// Helper trait for abstracting over V1 and V2 schema.

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -791,7 +791,11 @@ impl ImportableDependency for V2Schema {
                 display_name: None,
                 body: None,
                 annotations: Some(m.common.annotations.clone()),
-                entity_associations: m.entity_associations.clone(),
+                entity_associations: entity_association_names(
+                    &m.entity_associations,
+                    &self.refinements.entities,
+                    &self.schema_url,
+                )?,
                 visibility: None,
                 is_v2: true,
                 span_name: None,
@@ -857,7 +861,11 @@ impl ImportableDependency for V2Schema {
                 display_name: None,
                 body: None,
                 annotations: Some(e.common.annotations.clone()),
-                entity_associations: e.entity_associations.clone(),
+                entity_associations: entity_association_names(
+                    &e.entity_associations,
+                    &self.refinements.entities,
+                    &self.schema_url,
+                )?,
                 visibility: None,
                 is_v2: true,
                 span_name: None,
@@ -1013,7 +1021,11 @@ impl ImportableDependency for V2Schema {
                 display_name: None,
                 body: None,
                 annotations: Some(s.common.annotations.clone()),
-                entity_associations: s.entity_associations.clone(),
+                entity_associations: entity_association_names(
+                    &s.entity_associations,
+                    &self.refinements.entities,
+                    &self.schema_url,
+                )?,
                 visibility: None,
                 is_v2: true,
                 span_name: Some(s.name.clone()),
@@ -1171,6 +1183,21 @@ impl ImportableDependency for Vec<ResolvedDependency> {
         }
         Ok(result)
     }
+}
+
+/// Turns the entity refinement indices of a published v2 schema back into
+/// names. A v1 group names the entity that it is associated with.
+fn entity_association_names(
+    associations: &[weaver_resolved_schema::v2::entity::EntityAssociation],
+    refinements: &[weaver_resolved_schema::v2::entity::EntityRefinement],
+    schema_url: &SchemaUrl,
+) -> Result<Vec<weaver_semconv::entity_association::EntityAssociation>, Error> {
+    weaver_resolved_schema::v2::entity::to_named_associations(associations, refinements).map_err(
+        |entity_ref| Error::InvalidEntityAssociationRef {
+            schema_url: schema_url.to_string(),
+            entity_ref: entity_ref.0,
+        },
+    )
 }
 
 /// The registry that a group comes from. A group that was itself imported

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -3,7 +3,7 @@
 //! Helpers to handle reading from dependencies.
 
 use globset::GlobSet;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use weaver_resolved_schema::attribute::Attribute;
 use weaver_resolved_schema::registry::Group;
 use weaver_resolved_schema::v2::catalog::AttributeCatalog as V2Catalog;
@@ -117,6 +117,198 @@ fn is_implicit_import(import: &ImportsWithProvenance) -> bool {
     import.provenance.path == "--include-unreferenced"
 }
 
+/// The `imports` field that a signal type is named under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ImportField {
+    Metrics,
+    Events,
+    Spans,
+    Entities,
+    AttributeGroups,
+}
+
+impl ImportField {
+    /// The field that imports a group of this type, or `None` when a group of
+    /// this type cannot be imported at all.
+    fn of(group_type: &GroupType) -> Option<Self> {
+        match group_type {
+            GroupType::Metric | GroupType::MetricGroup => Some(Self::Metrics),
+            GroupType::Event => Some(Self::Events),
+            GroupType::Span => Some(Self::Spans),
+            GroupType::Entity => Some(Self::Entities),
+            GroupType::AttributeGroup => Some(Self::AttributeGroups),
+            GroupType::Scope | GroupType::Undefined => None,
+        }
+    }
+
+    /// The name of the field, for a diagnostic.
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Metrics => "metrics",
+            Self::Events => "events",
+            Self::Spans => "spans",
+            Self::Entities => "entities",
+            Self::AttributeGroups => "attribute_groups",
+        }
+    }
+
+    /// The patterns under this field of one `imports` block.
+    fn patterns<'a>(&self, imports: &'a weaver_semconv::semconv::Imports) -> &'a [GroupWildcard] {
+        let field = match self {
+            Self::Metrics => &imports.metrics,
+            Self::Events => &imports.events,
+            Self::Spans => &imports.spans,
+            Self::Entities => &imports.entities,
+            Self::AttributeGroups => &imports.attribute_groups,
+        };
+        field.as_deref().unwrap_or_default()
+    }
+
+    /// Every field, in a stable order.
+    fn all() -> [Self; 5] {
+        [
+            Self::Metrics,
+            Self::Events,
+            Self::Spans,
+            Self::Entities,
+            Self::AttributeGroups,
+        ]
+    }
+}
+
+/// The strings that an import pattern can name a group by.
+///
+/// A group from a v2 definition answers to its id, to its signal name, and to
+/// its id without the group-type prefix. A v1 group answers to its signal name,
+/// or to its id for a span or an attribute group.
+fn import_match_keys(g: &Group) -> Vec<&str> {
+    let name = g.name.as_deref();
+    let metric_name = g.metric_name.as_deref();
+    if g.is_v2 {
+        let (signal_name, prefix) = match g.r#type {
+            GroupType::AttributeGroup => (None, "attribute_group."),
+            GroupType::Span => (name, "span."),
+            GroupType::Event => (name, "event."),
+            GroupType::Metric | GroupType::MetricGroup => (metric_name, "metric."),
+            GroupType::Entity => (name, "entity."),
+            GroupType::Scope | GroupType::Undefined => return vec![],
+        };
+        let mut keys = vec![g.id.as_str()];
+        keys.extend(signal_name);
+        // An attribute group also answers to its id without the `registry.`
+        // prefix, which is the older spelling.
+        if g.r#type == GroupType::AttributeGroup {
+            keys.extend(g.id.strip_prefix("registry."));
+        }
+        keys.extend(g.id.strip_prefix(prefix));
+        keys
+    } else {
+        match g.r#type {
+            GroupType::AttributeGroup | GroupType::Span => vec![g.id.as_str()],
+            GroupType::Event | GroupType::Entity => name.into_iter().collect(),
+            GroupType::Metric => metric_name.into_iter().collect(),
+            GroupType::MetricGroup | GroupType::Scope | GroupType::Undefined => vec![],
+        }
+    }
+}
+
+/// One compiled matcher per `imports` field.
+pub(crate) struct ImportMatchers {
+    metrics: GlobSet,
+    events: GlobSet,
+    spans: GlobSet,
+    entities: GlobSet,
+    attribute_groups: GlobSet,
+}
+
+impl ImportMatchers {
+    fn build<'a>(
+        imports: impl Iterator<Item = &'a ImportsWithProvenance> + Clone,
+    ) -> Result<Self, Error> {
+        let for_field = |field: ImportField| {
+            build_globset(
+                imports
+                    .clone()
+                    .flat_map(move |i| field.patterns(&i.imports)),
+            )
+        };
+        Ok(Self {
+            metrics: for_field(ImportField::Metrics)?,
+            events: for_field(ImportField::Events)?,
+            spans: for_field(ImportField::Spans)?,
+            entities: for_field(ImportField::Entities)?,
+            attribute_groups: for_field(ImportField::AttributeGroups)?,
+        })
+    }
+
+    fn field(&self, field: ImportField) -> &GlobSet {
+        match field {
+            ImportField::Metrics => &self.metrics,
+            ImportField::Events => &self.events,
+            ImportField::Spans => &self.spans,
+            ImportField::Entities => &self.entities,
+            ImportField::AttributeGroups => &self.attribute_groups,
+        }
+    }
+
+    /// Whether any pattern names this group.
+    fn matches(&self, g: &Group) -> bool {
+        let Some(field) = ImportField::of(&g.r#type) else {
+            return false;
+        };
+        let matcher = self.field(field);
+        import_match_keys(g)
+            .into_iter()
+            .any(|k| matcher.is_match(k))
+    }
+}
+
+/// Reports every explicit import pattern that named none of the imported
+/// groups.
+///
+/// An unmatched pattern is nearly always a typo or a stale name, and the
+/// resolver used to drop it in silence. This runs across all dependencies at
+/// once, because a pattern can name nothing in one dependency and still be
+/// satisfied by another.
+pub(crate) fn unmatched_import_errors(
+    imports: &[ImportsWithProvenance],
+    groups: &[GroupWithProvenance],
+) -> Result<Vec<Error>, Error> {
+    let explicit: Vec<&ImportsWithProvenance> =
+        imports.iter().filter(|i| !is_implicit_import(i)).collect();
+    let mut errors = vec![];
+    for field in ImportField::all() {
+        let patterns: Vec<&GroupWildcard> = explicit
+            .iter()
+            .flat_map(|i| field.patterns(&i.imports))
+            .collect();
+        if patterns.is_empty() {
+            continue;
+        }
+        // Built from the same list, in the same order, so a match index is an
+        // index into `patterns`.
+        let matcher = build_globset(patterns.iter().copied())?;
+        let mut matched: HashSet<usize> = HashSet::new();
+        for group in groups {
+            if ImportField::of(&group.group.r#type) != Some(field) {
+                continue;
+            }
+            for key in import_match_keys(&group.group) {
+                matched.extend(matcher.matches(key));
+            }
+        }
+        for (index, pattern) in patterns.iter().enumerate() {
+            if !matched.contains(&index) {
+                errors.push(Error::UnmatchedImport {
+                    pattern: pattern.0.glob().to_owned(),
+                    signal: field.name().to_owned(),
+                });
+            }
+        }
+    }
+    Ok(errors)
+}
+
 /// A group with its source provenance.
 pub struct GroupWithProvenance {
     /// The group definition.
@@ -146,206 +338,10 @@ impl ImportableDependency for V1Schema {
         let explicit_imports: Vec<&ImportsWithProvenance> =
             imports.iter().filter(|i| !is_implicit_import(i)).collect();
 
-        let explicit_metrics_matcher = build_globset(
-            explicit_imports
-                .iter()
-                .flat_map(|i| i.imports.metrics.as_deref().unwrap_or_default()),
-        )?;
-        let all_metrics_matcher = build_globset(
-            imports
-                .iter()
-                .flat_map(|i| i.imports.metrics.as_deref().unwrap_or_default()),
-        )?;
-
-        let explicit_events_matcher = build_globset(
-            explicit_imports
-                .iter()
-                .flat_map(|i| i.imports.events.as_deref().unwrap_or_default()),
-        )?;
-        let all_events_matcher = build_globset(
-            imports
-                .iter()
-                .flat_map(|i| i.imports.events.as_deref().unwrap_or_default()),
-        )?;
-
-        let explicit_entities_matcher = build_globset(
-            explicit_imports
-                .iter()
-                .flat_map(|i| i.imports.entities.as_deref().unwrap_or_default()),
-        )?;
-        let all_entities_matcher = build_globset(
-            imports
-                .iter()
-                .flat_map(|i| i.imports.entities.as_deref().unwrap_or_default()),
-        )?;
-
-        let explicit_spans_matcher = build_globset(
-            explicit_imports
-                .iter()
-                .flat_map(|i| i.imports.spans.as_deref().unwrap_or_default()),
-        )?;
-        let all_spans_matcher = build_globset(
-            imports
-                .iter()
-                .flat_map(|i| i.imports.spans.as_deref().unwrap_or_default()),
-        )?;
-
-        let explicit_attribute_groups_matcher = build_globset(
-            explicit_imports
-                .iter()
-                .flat_map(|i| i.imports.attribute_groups.as_deref().unwrap_or_default()),
-        )?;
-        let all_attribute_groups_matcher = build_globset(
-            imports
-                .iter()
-                .flat_map(|i| i.imports.attribute_groups.as_deref().unwrap_or_default()),
-        )?;
-
-        let matches_explicitly = move |g: &Group| {
-            if g.is_v2 {
-                match g.r#type {
-                    GroupType::AttributeGroup => {
-                        explicit_attribute_groups_matcher.is_match(&g.id)
-                            || g.id
-                                .strip_prefix("registry.")
-                                .is_some_and(|s| explicit_attribute_groups_matcher.is_match(s))
-                            || g.id
-                                .strip_prefix("attribute_group.")
-                                .is_some_and(|s| explicit_attribute_groups_matcher.is_match(s))
-                    }
-                    GroupType::Span => {
-                        explicit_spans_matcher.is_match(&g.id)
-                            || g.name
-                                .as_ref()
-                                .is_some_and(|name| explicit_spans_matcher.is_match(name.as_str()))
-                            || g.id
-                                .strip_prefix("span.")
-                                .is_some_and(|s| explicit_spans_matcher.is_match(s))
-                    }
-                    GroupType::Event => {
-                        explicit_events_matcher.is_match(&g.id)
-                            || g.name
-                                .as_ref()
-                                .is_some_and(|name| explicit_events_matcher.is_match(name.as_str()))
-                            || g.id
-                                .strip_prefix("event.")
-                                .is_some_and(|s| explicit_events_matcher.is_match(s))
-                    }
-                    GroupType::Metric | GroupType::MetricGroup => {
-                        explicit_metrics_matcher.is_match(&g.id)
-                            || g.metric_name.as_ref().is_some_and(|metric_name| {
-                                explicit_metrics_matcher.is_match(metric_name.as_str())
-                            })
-                            || g.id
-                                .strip_prefix("metric.")
-                                .is_some_and(|s| explicit_metrics_matcher.is_match(s))
-                    }
-                    GroupType::Entity => {
-                        explicit_entities_matcher.is_match(&g.id)
-                            || g.name.as_ref().is_some_and(|name| {
-                                explicit_entities_matcher.is_match(name.as_str())
-                            })
-                            || g.id
-                                .strip_prefix("entity.")
-                                .is_some_and(|s| explicit_entities_matcher.is_match(s))
-                    }
-                    GroupType::Scope => false,
-                    GroupType::Undefined => false,
-                }
-            } else {
-                match g.r#type {
-                    GroupType::AttributeGroup => explicit_attribute_groups_matcher.is_match(&g.id),
-                    GroupType::Span => explicit_spans_matcher.is_match(&g.id),
-                    GroupType::Event => g
-                        .name
-                        .as_ref()
-                        .is_some_and(|name| explicit_events_matcher.is_match(name.as_str())),
-                    GroupType::Metric => g.metric_name.as_ref().is_some_and(|metric_name| {
-                        explicit_metrics_matcher.is_match(metric_name.as_str())
-                    }),
-                    GroupType::MetricGroup => false,
-                    GroupType::Entity => g
-                        .name
-                        .as_ref()
-                        .is_some_and(|name| explicit_entities_matcher.is_match(name.as_str())),
-                    GroupType::Scope => false,
-                    GroupType::Undefined => false,
-                }
-            }
-        };
-
-        let matches_by_any = move |g: &Group| {
-            if g.is_v2 {
-                match g.r#type {
-                    GroupType::AttributeGroup => {
-                        all_attribute_groups_matcher.is_match(&g.id)
-                            || g.id
-                                .strip_prefix("registry.")
-                                .is_some_and(|s| all_attribute_groups_matcher.is_match(s))
-                            || g.id
-                                .strip_prefix("attribute_group.")
-                                .is_some_and(|s| all_attribute_groups_matcher.is_match(s))
-                    }
-                    GroupType::Span => {
-                        all_spans_matcher.is_match(&g.id)
-                            || g.name
-                                .as_ref()
-                                .is_some_and(|name| all_spans_matcher.is_match(name.as_str()))
-                            || g.id
-                                .strip_prefix("span.")
-                                .is_some_and(|s| all_spans_matcher.is_match(s))
-                    }
-                    GroupType::Event => {
-                        all_events_matcher.is_match(&g.id)
-                            || g.name
-                                .as_ref()
-                                .is_some_and(|name| all_events_matcher.is_match(name.as_str()))
-                            || g.id
-                                .strip_prefix("event.")
-                                .is_some_and(|s| all_events_matcher.is_match(s))
-                    }
-                    GroupType::Metric | GroupType::MetricGroup => {
-                        all_metrics_matcher.is_match(&g.id)
-                            || g.metric_name.as_ref().is_some_and(|metric_name| {
-                                all_metrics_matcher.is_match(metric_name.as_str())
-                            })
-                            || g.id
-                                .strip_prefix("metric.")
-                                .is_some_and(|s| all_metrics_matcher.is_match(s))
-                    }
-                    GroupType::Entity => {
-                        all_entities_matcher.is_match(&g.id)
-                            || g.name
-                                .as_ref()
-                                .is_some_and(|name| all_entities_matcher.is_match(name.as_str()))
-                            || g.id
-                                .strip_prefix("entity.")
-                                .is_some_and(|s| all_entities_matcher.is_match(s))
-                    }
-                    GroupType::Scope => false,
-                    GroupType::Undefined => false,
-                }
-            } else {
-                match g.r#type {
-                    GroupType::AttributeGroup => all_attribute_groups_matcher.is_match(&g.id),
-                    GroupType::Span => all_spans_matcher.is_match(&g.id),
-                    GroupType::Event => g
-                        .name
-                        .as_ref()
-                        .is_some_and(|name| all_events_matcher.is_match(name.as_str())),
-                    GroupType::Metric => g.metric_name.as_ref().is_some_and(|metric_name| {
-                        all_metrics_matcher.is_match(metric_name.as_str())
-                    }),
-                    GroupType::MetricGroup => false,
-                    GroupType::Entity => g
-                        .name
-                        .as_ref()
-                        .is_some_and(|name| all_entities_matcher.is_match(name.as_str())),
-                    GroupType::Scope => false,
-                    GroupType::Undefined => false,
-                }
-            }
-        };
+        let explicit = ImportMatchers::build(explicit_imports.iter().copied())?;
+        let any = ImportMatchers::build(imports.iter())?;
+        let matches_explicitly = |g: &Group| explicit.matches(g);
+        let matches_by_any = |g: &Group| any.matches(g);
 
         let mut exclusion_errors: Vec<Error> = vec![];
         let mut result: Vec<GroupWithProvenance> = vec![];

--- a/crates/weaver_resolver/src/error.rs
+++ b/crates/weaver_resolver/src/error.rs
@@ -150,6 +150,19 @@ pub enum Error {
         // TODO: plumb provenance?
     },
 
+    /// An import pattern that named nothing in any dependency.
+    #[error("The import `{pattern}` under `{signal}` matched nothing in any dependency")]
+    #[diagnostic(severity(Warning))]
+    #[diagnostic(help(
+        "Check the spelling, and check that a dependency exports it. Imports are not transitive: a registry further down the chain is reachable only when the registry in between re-exports it."
+    ))]
+    UnmatchedImport {
+        /// The pattern that matched nothing.
+        pattern: String,
+        /// The `imports` field the pattern is under.
+        signal: String,
+    },
+
     /// An invalid Schema path.
     #[error("Invalid Schema path: {path}")]
     InvalidSchemaPath {

--- a/crates/weaver_resolver/src/error.rs
+++ b/crates/weaver_resolver/src/error.rs
@@ -238,6 +238,18 @@ pub enum Error {
         error: String,
     },
 
+    /// An entity association of a published schema points outside its own
+    /// entity refinements.
+    #[error(
+        "Invalid schema: {schema_url}. Unable to find entity refinement by index: {entity_ref}"
+    )]
+    InvalidEntityAssociationRef {
+        /// The schema with the issue.
+        schema_url: String,
+        /// The entity index that does not exist in the schema.
+        entity_ref: u32,
+    },
+
     /// We
     #[error(
         "Invalid registry: {registry_name}. Unable to find attribute by index: {attribute_ref}"

--- a/crates/weaver_resolver/src/error.rs
+++ b/crates/weaver_resolver/src/error.rs
@@ -100,6 +100,20 @@ pub enum Error {
         provenance: Option<Box<Provenance>>,
     },
 
+    /// An unresolved entity association.
+    #[error("The following entity association is not resolved for the group '{group_id}'.\nEntity association: {entity_type}\nProvenance: {provenance:?}")]
+    #[diagnostic(help(
+        "Define the entity locally, or depend on a registry that defines it. An entity named in `entity_associations` is imported implicitly."
+    ))]
+    UnresolvedEntityAssociation {
+        /// The id of the group containing the entity association.
+        group_id: String,
+        /// The unresolved entity type.
+        entity_type: String,
+        /// The provenance of the association (URL or path).
+        provenance: Option<Box<Provenance>>,
+    },
+
     /// An unresolved `extends` clause reference.
     #[error("The following `extends` clause reference is not resolved for the group '{group_id}'.\n`extends` clause reference: {extends_ref}\nProvenance: {provenance:?}")]
     UnresolvedExtendsRef {

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -2074,6 +2074,305 @@ groups:
         Ok(())
     }
 
+    /// True for the "`definition/2` is not yet stable" warning. Every file in
+    /// these fixtures gives this warning. These tests do not test for it.
+    fn is_unstable_format_warning(e: &Error) -> bool {
+        matches!(
+            e,
+            Error::FailToResolveDefinition(weaver_semconv::Error::UnstableFileFormat { .. })
+        )
+    }
+
+    /// Resolves one of the `entity-assoc-imports` registries. Returns the
+    /// resolved schema and the non-fatal errors.
+    fn resolve_entity_assoc_fixture(name: &str) -> (V2Schema, Vec<Error>) {
+        let (resolved, nfes) = match load_entity_assoc_fixture(name) {
+            WResult::Ok(r) => (r, vec![]),
+            WResult::OkWithNFEs(r, nfes) => (r, nfes),
+            WResult::FatalErr(e) => panic!("Failed to resolve `{name}`: {e}"),
+        };
+        let v1 = resolved
+            .as_v1()
+            .unwrap_or_else(|| panic!("Expected a V1 schema for `{name}`"))
+            .clone();
+        let v2: V2Schema = v1
+            .try_into()
+            .unwrap_or_else(|e| panic!("v1 -> v2 conversion for `{name}`: {e}"));
+        let nfes = nfes
+            .into_iter()
+            .filter(|e| !is_unstable_format_warning(e))
+            .collect();
+        (v2, nfes)
+    }
+
+    /// Resolves a fixture and returns every error it reports, fatal or not.
+    /// This function is for tests that expect an error and not a schema. Such a
+    /// test accepts either severity from the fix.
+    fn entity_assoc_fixture_errors(name: &str) -> Vec<Error> {
+        let errors = match load_entity_assoc_fixture(name) {
+            WResult::Ok(_) => vec![],
+            WResult::OkWithNFEs(_, nfes) => nfes,
+            WResult::FatalErr(e) => vec![e],
+        };
+        errors
+            .into_iter()
+            .filter(|e| !is_unstable_format_warning(e))
+            .collect()
+    }
+
+    fn load_entity_assoc_fixture(name: &str) -> WResult<WeaverResolvedSchema, Error> {
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: format!("data/entity-assoc-imports/{name}"),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])
+            .expect("failed to create registry repo");
+        WeaverResolver::new(WeaverResolverConfig::default())
+            .load_and_resolve_schema(registry_repo, DefaultSchemaVisitor)
+    }
+
+    /// The registry that defines the `host` entity.
+    const BASE_URL: &str = "https://example.com/base/1.0.0";
+
+    /// Entity types in the resolved registry, in registry order.
+    fn entity_types(schema: &V2Schema) -> Vec<&str> {
+        schema
+            .registry
+            .entities
+            .iter()
+            .map(|e| e.r#type.as_ref())
+            .collect()
+    }
+
+    /// The `middle.request.count` metric of a resolved registry.
+    fn middle_metric(schema: &V2Schema) -> &weaver_resolved_schema::v2::metric::Metric {
+        schema
+            .registry
+            .metrics
+            .iter()
+            .find(|m| &*m.name == "middle.request.count")
+            .expect("`middle.request.count` is in the resolved registry")
+    }
+
+    /// The schema url that an entity comes from. Returns `None` when the
+    /// resolver reports the entity as local to this registry.
+    fn entity_source<'a>(schema: &'a V2Schema, entity_type: &str) -> Option<&'a str> {
+        let deps: Vec<&SchemaUrl> = schema.dependencies.iter().collect();
+        let entity = schema
+            .registry
+            .entities
+            .iter()
+            .find(|e| &*e.r#type == entity_type)
+            .expect("entity is in the resolved registry");
+        entity
+            .provenance
+            .source
+            .and_then(|r| deps.get(r.0 as usize))
+            .map(|url| url.as_str())
+    }
+
+    /// A snapshot of an entity for comparison. The snapshot holds the brief and
+    /// the attribute keys under `identity` and `description`. The keys come from
+    /// the attribute catalog of the schema, so a test can compare two
+    /// registries.
+    fn entity_snapshot(schema: &V2Schema, entity_type: &str) -> (String, Vec<String>, Vec<String>) {
+        use weaver_resolved_schema::v2::catalog::AttributeCatalog;
+        let entity = schema
+            .registry
+            .entities
+            .iter()
+            .find(|e| &*e.r#type == entity_type)
+            .unwrap_or_else(|| panic!("`{entity_type}` is in the resolved registry"));
+        let keys = |refs: &[weaver_resolved_schema::v2::entity::EntityAttributeRef]| {
+            refs.iter()
+                .map(|r| {
+                    schema
+                        .attribute_catalog
+                        .attribute(&r.base)
+                        .expect("attribute is in the catalog")
+                        .key
+                        .to_string()
+                })
+                .collect::<Vec<_>>()
+        };
+        (
+            entity.common.brief.clone(),
+            keys(&entity.identity),
+            keys(&entity.description),
+        )
+    }
+
+    /// An entity named in `entity_associations` must be imported implicitly. An
+    /// attribute named in a `ref` already works this way.
+    ///
+    /// The metric in `middle` names the `host` entity of base. Beside it, the
+    /// same metric holds a `ref` to the `host.id` attribute of base. `middle`
+    /// imports neither one explicitly. The attribute arrives from the
+    /// dependency, fully populated. The entity must arrive the same way. A
+    /// consumer of `middle` can then see the entity that the metric is
+    /// associated with.
+    ///
+    /// Entities are immutable. The copy must be the definition from base,
+    /// without change. It must keep the same brief and the same identity and
+    /// description attributes. It must also keep `base` as its source. A
+    /// registry must not fork an entity when it names the entity.
+    ///
+    /// This test fails now. An `entity_associations` entry is an opaque string
+    /// that nothing resolves, so `host` never arrives.
+    #[test]
+    fn test_entity_association_implicitly_imports_entity() {
+        use weaver_resolved_schema::v2::catalog::AttributeCatalog;
+
+        let (middle, nfes) = resolve_entity_assoc_fixture("middle");
+        assert!(nfes.is_empty(), "unexpected errors: {nfes:?}");
+        let metric = middle_metric(&middle);
+
+        // The precedent. The attribute ref comes from base with its wording
+        // intact.
+        let attr = middle
+            .attribute_catalog
+            .attribute(&metric.attributes[0].base)
+            .expect("`host.id` resolved from the base dependency");
+        assert_eq!(&*attr.key, "host.id");
+        assert_eq!(attr.common.brief, "Unique host ID, defined in base.");
+
+        // The association in the same metric must behave the same way.
+        assert_eq!(metric.entity_associations.len(), 1);
+        assert_eq!(
+            entity_types(&middle),
+            ["host"],
+            "the resolver must import the associated entity implicitly, the way \
+             it imports the attribute ref beside it"
+        );
+        assert_eq!(entity_source(&middle, "host"), Some(BASE_URL));
+
+        // Immutable. The entity that arrived is the definition from base, not
+        // a variant of that definition.
+        let (base, _) = resolve_entity_assoc_fixture("base");
+        assert_eq!(
+            entity_snapshot(&middle, "host"),
+            entity_snapshot(&base, "host"),
+            "an implicitly imported entity must match its definition in `base`"
+        );
+
+        // `middle_reexport` names `host` in an association and also imports it
+        // explicitly. That is one entity, not two.
+        let (reexport, nfes) = resolve_entity_assoc_fixture("middle_reexport");
+        assert!(nfes.is_empty(), "unexpected errors: {nfes:?}");
+        assert_eq!(
+            entity_types(&reexport),
+            ["host"],
+            "an explicit import and an association that name the same entity \
+             must not import that entity twice"
+        );
+        assert_eq!(
+            entity_snapshot(&reexport, "host"),
+            entity_snapshot(&base, "host"),
+            "an explicitly imported entity must match its definition too"
+        );
+    }
+
+    /// An `entity_associations` entry that nothing in scope satisfies must be
+    /// reported. The resolver already reports an attribute ref that it cannot
+    /// resolve.
+    ///
+    /// This test fails now. Nothing tests associations against anything, so
+    /// `no.such.entity` passes without a report.
+    #[test]
+    fn test_entity_association_is_validated() {
+        // The fix must add a dedicated error for this case. Until then, any
+        // error counts.
+        let errors = entity_assoc_fixture_errors("middle_bad_assoc");
+        assert!(
+            !errors.is_empty(),
+            "`no.such.entity` is not in scope anywhere, and the resolver must \
+             report it"
+        );
+    }
+
+    /// An explicit import must bind against everything that its dependency
+    /// exports. This includes what the dependency imported implicitly.
+    ///
+    /// Imports are not transitive. They match the resolved surface of the
+    /// registries in the manifest. A registry further down the chain is
+    /// reachable only when the registry in between re-exports it.
+    ///
+    /// `top` depends on `middle` alone. So `top` can import `host` only because
+    /// the association in `middle` pulls the entity in. This is what makes the
+    /// implicit import worth having. `top_reexport` reaches `host` by the
+    /// explicit route. Both fixtures must give the same answer.
+    ///
+    /// This test fails now for `top`. `middle` imports nothing, so the import
+    /// binds to nothing.
+    #[test]
+    fn test_entity_import_binds_against_dependency_surface() {
+        for fixture in ["top", "top_reexport"] {
+            let (top, nfes) = resolve_entity_assoc_fixture(fixture);
+            assert!(
+                nfes.is_empty(),
+                "unexpected errors in `{fixture}`: {nfes:?}"
+            );
+            assert_eq!(middle_metric(&top).entity_associations.len(), 1);
+            assert_eq!(entity_types(&top), ["host"], "`{fixture}` imported `host`");
+            assert_eq!(entity_source(&top, "host"), Some(BASE_URL));
+        }
+    }
+
+    /// An import that binds to nothing must be reported.
+    ///
+    /// `top_bad_import` depends on `middle_reexport`, which does export `host`.
+    /// The import asks for `no.such.entity`. So the import fails for one reason
+    /// only: no dependency offers anything with that name.
+    ///
+    /// This test fails now. The resolver drops the unmatched import in silence
+    /// and reports success.
+    #[test]
+    fn test_import_that_binds_to_nothing_is_reported() {
+        let errors = entity_assoc_fixture_errors("top_bad_import");
+        assert!(
+            !errors.is_empty(),
+            "no dependency offers `no.such.entity`, and the resolver must report \
+             this import"
+        );
+    }
+
+    /// A definition that two dependency paths reach must be imported one time.
+    ///
+    /// `top_diamond` sees `host` directly from `base` and also through
+    /// `middle_reexport`. Both paths lead to the same definition in `base`.
+    /// There is no conflict to resolve and nothing to report. The entity must
+    /// appear one time only, with `base` as its source.
+    ///
+    /// This test fails now. The resolver applies imports for each dependency
+    /// and joins the results without deduplication. As a result, the registry
+    /// holds two identical copies. The resolver also reports duplicate id and
+    /// name warnings. Both warnings name the same single origin, `base`.
+    #[test]
+    fn test_entity_reachable_by_two_paths_is_imported_once() {
+        let (top, nfes) = resolve_entity_assoc_fixture("top_diamond");
+
+        assert_eq!(
+            entity_types(&top),
+            ["host"],
+            "two paths reach one definition in `base`, so the result is still \
+             one entity"
+        );
+        assert_eq!(entity_source(&top, "host"), Some(BASE_URL));
+
+        let duplicates: Vec<&Error> = nfes
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    Error::DuplicateGroupId { .. } | Error::DuplicateGroupName { .. }
+                )
+            })
+            .collect();
+        assert!(
+            duplicates.is_empty(),
+            "an import of one definition by two paths is not a duplicate declaration: {duplicates:?}"
+        );
+    }
+
     #[test]
     fn test_three_layer_transitive_diamond_upgrade() -> Result<(), Error> {
         // Test that collect_chosen_versions traverses deeply nested multi-layer dependencies.

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -2234,9 +2234,6 @@ groups:
     /// without change. It must keep the same brief and the same identity and
     /// description attributes. It must also keep `base` as its source. A
     /// registry must not fork an entity when it names the entity.
-    ///
-    /// This test fails now. An `entity_associations` entry is an opaque string
-    /// that nothing resolves, so `host` never arrives.
     #[test]
     fn test_entity_association_implicitly_imports_entity() {
         use weaver_resolved_schema::v2::catalog::AttributeCatalog;
@@ -2293,9 +2290,6 @@ groups:
     /// An `entity_associations` entry that nothing in scope satisfies must be
     /// reported. The resolver already reports an attribute ref that it cannot
     /// resolve.
-    ///
-    /// This test fails now. Nothing tests associations against anything, so
-    /// `no.such.entity` passes without a report.
     #[test]
     fn test_entity_association_is_validated() {
         // The fix must add a dedicated error for this case. Until then, any
@@ -2347,9 +2341,6 @@ groups:
     /// the association in `middle` pulls the entity in. This is what makes the
     /// implicit import worth having. `top_reexport` reaches `host` by the
     /// explicit route. Both fixtures must give the same answer.
-    ///
-    /// This test fails now for `top`. `middle` imports nothing, so the import
-    /// binds to nothing.
     #[test]
     fn test_entity_import_binds_against_dependency_surface() {
         for fixture in ["top", "top_reexport"] {
@@ -2369,16 +2360,47 @@ groups:
     /// `top_bad_import` depends on `middle_reexport`, which does export `host`.
     /// The import asks for `no.such.entity`. So the import fails for one reason
     /// only: no dependency offers anything with that name.
-    ///
-    /// This test fails now. The resolver drops the unmatched import in silence
-    /// and reports success.
     #[test]
     fn test_import_that_binds_to_nothing_is_reported() {
         let errors = entity_assoc_fixture_errors("top_bad_import");
         assert!(
-            !errors.is_empty(),
+            matches!(
+                errors.as_slice(),
+                [Error::UnmatchedImport { pattern, signal }]
+                    if pattern == "no.such.entity" && signal == "entities"
+            ),
             "no dependency offers `no.such.entity`, and the resolver must report \
-             this import"
+             this import: {errors:?}"
+        );
+    }
+
+    /// Every `imports` field is checked, not only `entities`.
+    ///
+    /// `top_bad_imports_all_types` asks for one name of each signal type that
+    /// no dependency offers. It also asks for a metric and an entity that
+    /// `middle_reexport` does export, so a report of those would be wrong.
+    #[test]
+    fn test_unmatched_imports_are_reported_for_every_signal_type() {
+        let errors = entity_assoc_fixture_errors("top_bad_imports_all_types");
+        let mut reported: Vec<(&str, &str)> = errors
+            .iter()
+            .map(|e| match e {
+                Error::UnmatchedImport { pattern, signal } => (pattern.as_str(), signal.as_str()),
+                other => panic!("unexpected error: {other:?}"),
+            })
+            .collect();
+        reported.sort_unstable();
+        assert_eq!(
+            reported,
+            [
+                ("no.such.attribute_group", "attribute_groups"),
+                ("no.such.entity", "entities"),
+                ("no.such.event", "events"),
+                ("no.such.metric", "metrics"),
+                ("no.such.span", "spans"),
+            ],
+            "each signal type must report its own unmatched import, and the \
+             imports that do bind must stay silent"
         );
     }
 
@@ -2388,11 +2410,6 @@ groups:
     /// `middle_reexport`. Both paths lead to the same definition in `base`.
     /// There is no conflict to resolve and nothing to report. The entity must
     /// appear one time only, with `base` as its source.
-    ///
-    /// This test fails now. The resolver applies imports for each dependency
-    /// and joins the results without deduplication. As a result, the registry
-    /// holds two identical copies. The resolver also reports duplicate id and
-    /// name warnings. Both warnings name the same single origin, `base`.
     #[test]
     fn test_entity_reachable_by_two_paths_is_imported_once() {
         let (top, nfes) = resolve_entity_assoc_fixture("top_diamond");

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -2302,6 +2302,23 @@ groups:
         );
     }
 
+    /// A legacy `type: resource` group carries its entity type in the id and
+    /// leaves `name` unset. An association names it by that id, so the resolver
+    /// must count it as defined here rather than hunt for it in a dependency.
+    #[test]
+    fn test_association_to_legacy_resource_group() {
+        let (schema, nfes) = resolve_entity_assoc_fixture("legacy_resource");
+        assert!(nfes.is_empty(), "unexpected errors: {nfes:?}");
+        assert_eq!(entity_types(&schema), ["browser"]);
+        let metric = schema
+            .registry
+            .metrics
+            .iter()
+            .find(|m| &*m.name == "legacy.request.count")
+            .expect("`legacy.request.count` is in the resolved registry");
+        assert_eq!(metric.entity_associations.len(), 1);
+    }
+
     /// An entity marked `dependency_resolution.exclude: true` is private to the
     /// registry that defines it. A dependent must not reach it by any route.
     ///

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -2120,6 +2120,25 @@ groups:
             .collect()
     }
 
+    /// Resolves a fixture that must fail, and returns the fatal error. Panics
+    /// when the fixture resolves, so a test cannot pass on a warning alone.
+    fn entity_assoc_fixture_fatal_error(name: &str) -> Error {
+        match load_entity_assoc_fixture(name) {
+            WResult::Ok(_) | WResult::OkWithNFEs(_, _) => {
+                panic!("`{name}` resolved, but it must fail")
+            }
+            WResult::FatalErr(e) => e,
+        }
+    }
+
+    /// Every error in a compound error, flattened one level.
+    fn flatten_errors(error: &Error) -> Vec<&Error> {
+        match error {
+            Error::CompoundError(errors) => errors.iter().collect(),
+            e => vec![e],
+        }
+    }
+
     fn load_entity_assoc_fixture(name: &str) -> WResult<WeaverResolvedSchema, Error> {
         let registry_path = VirtualDirectoryPath::LocalFolder {
             path: format!("data/entity-assoc-imports/{name}"),
@@ -2287,6 +2306,34 @@ groups:
             "`no.such.entity` is not in scope anywhere, and the resolver must \
              report it"
         );
+    }
+
+    /// An entity marked `dependency_resolution.exclude: true` is private to the
+    /// registry that defines it. A dependent must not reach it by any route.
+    ///
+    /// Naming it is an error, whether the name appears in an `imports` clause
+    /// or in `entity_associations`. Both routes name one entity, so both give
+    /// the same answer, and the answer is fatal. A private entity that arrived
+    /// in silence would leak into code gen, doc gen and live-check.
+    #[test]
+    fn test_excluded_entity_cannot_be_reached() {
+        for fixture in ["top_excluded_import", "middle_excluded_assoc"] {
+            let error = entity_assoc_fixture_fatal_error(fixture);
+            let excluded: Vec<&Error> = flatten_errors(&error)
+                .into_iter()
+                .filter(|e| matches!(e, Error::ExcludedFromDependencyResolution { .. }))
+                .collect();
+            assert_eq!(
+                excluded.len(),
+                1,
+                "`{fixture}` must fail because `host` is excluded, but reported: {error:?}"
+            );
+            let Error::ExcludedFromDependencyResolution { id, r#type, .. } = excluded[0] else {
+                unreachable!("filtered above")
+            };
+            assert_eq!(id, "entity.host");
+            assert_eq!(r#type, "entity");
+        }
     }
 
     /// An explicit import must bind against everything that its dependency

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -2319,6 +2319,20 @@ groups:
         assert_eq!(metric.entity_associations.len(), 1);
     }
 
+    /// A dependent must be able to import a legacy `type: resource` entity. The
+    /// group has no name, so the id that carries its type is the only name a
+    /// pattern can use.
+    #[test]
+    fn test_legacy_resource_entity_can_be_imported() {
+        let (schema, nfes) = resolve_entity_assoc_fixture("top_legacy_import");
+        assert!(nfes.is_empty(), "unexpected errors: {nfes:?}");
+        assert_eq!(
+            entity_types(&schema),
+            ["browser"],
+            "the import must reach the legacy resource group of the dependency"
+        );
+    }
+
     /// An entity marked `dependency_resolution.exclude: true` is private to the
     /// registry that defines it. A dependent must not reach it by any route.
     ///

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -164,6 +164,14 @@ pub(crate) fn resolve_registry_with_dependencies<C: crate::SchemaCacheLookup>(
         return WResult::FatalErr(e);
     }
 
+    // An entity named in `entity_associations` is imported the way an
+    // attribute named in a `ref` is.
+    if let Err(e) =
+        resolve_entity_associations(&mut ureg, repo.schema_url(), attr_catalog, cache_lookup)
+    {
+        return WResult::FatalErr(e);
+    }
+
     // Now we do validations.
 
     // Note: this will remove all the `groups` from UnresolvedRegistry and create
@@ -386,7 +394,20 @@ fn resolve_dependency_imports<C: crate::SchemaCacheLookup>(
     cache_lookup: &C,
 ) -> Result<(), Error> {
     // Import from our dependencies, and add to the final registry.
-    let imports = &ureg.imports;
+    let imports = std::mem::take(&mut ureg.imports);
+    let result = import_into_registry(ureg, &imports, attribute_catalog, cache_lookup);
+    ureg.imports = imports;
+    result
+}
+
+/// Imports the groups that `imports` matches in the dependencies, and adds them
+/// to the registry.
+fn import_into_registry<C: crate::SchemaCacheLookup>(
+    ureg: &mut UnresolvedRegistry,
+    imports: &[ImportsWithProvenance],
+    attribute_catalog: &mut AttributeCatalog,
+    cache_lookup: &C,
+) -> Result<(), Error> {
     let dependencies = &ureg.dependencies;
     let groups = dependencies.import_groups(imports, attribute_catalog, cache_lookup)?;
     for crate::dependency::GroupWithProvenance { group, schema_url } in groups {
@@ -421,6 +442,109 @@ fn resolve_dependency_imports<C: crate::SchemaCacheLookup>(
             is_v2,
             provenance,
         });
+    }
+    Ok(())
+}
+
+/// The entity types that `entity_associations` names anywhere in the registry.
+fn associated_entity_types(ureg: &UnresolvedRegistry) -> Vec<String> {
+    ureg.groups
+        .iter()
+        .flat_map(|g| g.group.entity_associations.iter())
+        .flat_map(|assoc| assoc.referenced_entities())
+        .map(|name| name.to_owned())
+        .unique()
+        .collect()
+}
+
+/// The entity types that the registry defines.
+///
+/// An entity carries its type in `name`. A v1 group may leave `name` unset, so
+/// the id without its `entity.` prefix counts too.
+fn defined_entity_types(ureg: &UnresolvedRegistry) -> HashSet<&str> {
+    ureg.groups
+        .iter()
+        .map(|g| &g.group)
+        .filter(|g| g.r#type == GroupType::Entity)
+        .flat_map(|g| {
+            [
+                g.name.as_deref(),
+                Some(g.id.strip_prefix("entity.").unwrap_or(&g.id)),
+            ]
+        })
+        .flatten()
+        .collect()
+}
+
+/// Resolves the entity associations of every signal in the registry.
+///
+/// An entity named in `entity_associations` is imported the way an attribute
+/// named in a `ref` is. An association that nothing satisfies is an error, as
+/// an unresolved attribute ref is.
+///
+/// This runs after the explicit imports, because a signal can arrive from a
+/// dependency with associations of its own. An entity holds no associations, so
+/// one import pass is enough.
+fn resolve_entity_associations<C: crate::SchemaCacheLookup>(
+    ureg: &mut UnresolvedRegistry,
+    schema_url: &weaver_semconv::schema_url::SchemaUrl,
+    attribute_catalog: &mut AttributeCatalog,
+    cache_lookup: &C,
+) -> Result<(), Error> {
+    let defined = defined_entity_types(ureg);
+    let missing: Vec<String> = associated_entity_types(ureg)
+        .into_iter()
+        .filter(|entity_type| !defined.contains(entity_type.as_str()))
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let mut wildcards = vec![];
+    for entity_type in &missing {
+        let glob = globset::Glob::new(&globset::escape(entity_type)).map_err(|e| {
+            Error::InvalidWildcard {
+                error: e.to_string(),
+            }
+        })?;
+        wildcards.push(GroupWildcard(glob));
+    }
+    let imports = [ImportsWithProvenance {
+        imports: weaver_semconv::semconv::Imports {
+            metrics: None,
+            events: None,
+            entities: Some(wildcards),
+            spans: None,
+            attribute_groups: None,
+        },
+        // Not an implicit import: the user named this entity, so an excluded
+        // entity is an error here, as it is in an `imports` clause.
+        provenance: Provenance::new(schema_url.clone(), "--entity-associations"),
+    }];
+    import_into_registry(ureg, &imports, attribute_catalog, cache_lookup)?;
+
+    // No dependency offered these, so they are in scope nowhere.
+    let defined = defined_entity_types(ureg);
+    let errors: Vec<Error> = ureg
+        .groups
+        .iter()
+        .flat_map(|g| {
+            g.group
+                .entity_associations
+                .iter()
+                .flat_map(|assoc| assoc.referenced_entities())
+                .unique()
+                .filter(|entity_type| !defined.contains(entity_type))
+                .map(|entity_type| Error::UnresolvedEntityAssociation {
+                    group_id: g.group.id.clone(),
+                    entity_type: entity_type.to_owned(),
+                    provenance: g.provenance.clone().map(Box::new),
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    if !errors.is_empty() {
+        return Err(Error::CompoundError(errors));
     }
     Ok(())
 }

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -160,9 +160,8 @@ pub(crate) fn resolve_registry_with_dependencies<C: crate::SchemaCacheLookup>(
     }
 
     // We need to *import* objects from the dependencies as required.
-    match resolve_dependency_imports(&mut ureg, attr_catalog, cache_lookup) {
-        Ok(unmatched) => errors.extend(unmatched),
-        Err(e) => return WResult::FatalErr(e),
+    if let Err(e) = resolve_dependency_imports(&mut ureg, attr_catalog, cache_lookup, &mut errors) {
+        return WResult::FatalErr(e);
     }
 
     // An entity named in `entity_associations` is imported the way an
@@ -393,15 +392,17 @@ fn resolve_dependency_imports<C: crate::SchemaCacheLookup>(
     ureg: &mut UnresolvedRegistry,
     attribute_catalog: &mut AttributeCatalog,
     cache_lookup: &C,
-) -> Result<Vec<Error>, Error> {
+    non_fatal_errors: &mut Vec<Error>,
+) -> Result<(), Error> {
     // Import from our dependencies, and add to the final registry.
     let imports = std::mem::take(&mut ureg.imports);
-    let result = import_into_registry(ureg, &imports, attribute_catalog, cache_lookup)
+    let nfes = import_into_registry(ureg, &imports, attribute_catalog, cache_lookup)
         // A pattern that named nothing is reported here, and only here. The
         // imports that the resolver adds itself are checked elsewhere.
         .and_then(|groups| crate::dependency::unmatched_import_errors(&imports, &groups));
     ureg.imports = imports;
-    result
+    non_fatal_errors.extend(nfes?);
+    Ok(())
 }
 
 /// Imports the groups that `imports` matches in the dependencies, and adds them
@@ -468,8 +469,9 @@ fn associated_entity_types(ureg: &UnresolvedRegistry) -> Vec<String> {
 
 /// The entity types that the registry defines.
 ///
-/// An entity carries its type in `name`. A v1 group may leave `name` unset, so
-/// the id without its `entity.` prefix counts too.
+/// A v2 entity carries its type in `name`. A legacy `type: resource` group
+/// carries it in the id instead and leaves `name` unset, so the id without its
+/// `entity.` prefix counts too.
 fn defined_entity_types(ureg: &UnresolvedRegistry) -> HashSet<&str> {
     ureg.groups
         .iter()

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -160,8 +160,9 @@ pub(crate) fn resolve_registry_with_dependencies<C: crate::SchemaCacheLookup>(
     }
 
     // We need to *import* objects from the dependencies as required.
-    if let Err(e) = resolve_dependency_imports(&mut ureg, attr_catalog, cache_lookup) {
-        return WResult::FatalErr(e);
+    match resolve_dependency_imports(&mut ureg, attr_catalog, cache_lookup) {
+        Ok(unmatched) => errors.extend(unmatched),
+        Err(e) => return WResult::FatalErr(e),
     }
 
     // An entity named in `entity_associations` is imported the way an
@@ -392,24 +393,28 @@ fn resolve_dependency_imports<C: crate::SchemaCacheLookup>(
     ureg: &mut UnresolvedRegistry,
     attribute_catalog: &mut AttributeCatalog,
     cache_lookup: &C,
-) -> Result<(), Error> {
+) -> Result<Vec<Error>, Error> {
     // Import from our dependencies, and add to the final registry.
     let imports = std::mem::take(&mut ureg.imports);
-    let result = import_into_registry(ureg, &imports, attribute_catalog, cache_lookup);
+    let result = import_into_registry(ureg, &imports, attribute_catalog, cache_lookup)
+        // A pattern that named nothing is reported here, and only here. The
+        // imports that the resolver adds itself are checked elsewhere.
+        .and_then(|groups| crate::dependency::unmatched_import_errors(&imports, &groups));
     ureg.imports = imports;
     result
 }
 
 /// Imports the groups that `imports` matches in the dependencies, and adds them
-/// to the registry.
+/// to the registry. Returns the groups it imported.
 fn import_into_registry<C: crate::SchemaCacheLookup>(
     ureg: &mut UnresolvedRegistry,
     imports: &[ImportsWithProvenance],
     attribute_catalog: &mut AttributeCatalog,
     cache_lookup: &C,
-) -> Result<(), Error> {
+) -> Result<Vec<crate::dependency::GroupWithProvenance>, Error> {
     let dependencies = &ureg.dependencies;
     let groups = dependencies.import_groups(imports, attribute_catalog, cache_lookup)?;
+    let mut imported = vec![];
     for crate::dependency::GroupWithProvenance { group, schema_url } in groups {
         let is_v2 = group.is_v2();
         let mut prov_url = if let Some(prov) = group.provenance() {
@@ -434,6 +439,10 @@ fn import_into_registry<C: crate::SchemaCacheLookup>(
             schema_url: prov_url.clone(),
             path,
         });
+        imported.push(crate::dependency::GroupWithProvenance {
+            group: group.clone(),
+            schema_url: prov_url,
+        });
         ureg.groups.push(UnresolvedGroup {
             group,
             attributes: vec![],
@@ -443,7 +452,7 @@ fn import_into_registry<C: crate::SchemaCacheLookup>(
             provenance,
         });
     }
-    Ok(())
+    Ok(imported)
 }
 
 /// The entity types that `entity_associations` names anywhere in the registry.
@@ -521,7 +530,7 @@ fn resolve_entity_associations<C: crate::SchemaCacheLookup>(
         // entity is an error here, as it is in an `imports` clause.
         provenance: Provenance::new(schema_url.clone(), "--entity-associations"),
     }];
-    import_into_registry(ureg, &imports, attribute_catalog, cache_lookup)?;
+    let _ = import_into_registry(ureg, &imports, attribute_catalog, cache_lookup)?;
 
     // No dependency offered these, so they are in scope nowhere.
     let defined = defined_entity_types(ureg);

--- a/crates/weaver_semconv_gen/src/v2.rs
+++ b/crates/weaver_semconv_gen/src/v2.rs
@@ -11,14 +11,8 @@ use weaver_forge::{
     OutputProcessor,
 };
 use weaver_resolved_schema::v2::{
-    attribute::Attribute,
-    attribute_group::AttributeGroup,
-    catalog::AttributeCatalog,
-    entity::{Entity, EntityRefinement},
-    event::Event,
-    metric::Metric,
-    span::Span,
-    ResolvedTelemetrySchema, Signal,
+    attribute::Attribute, attribute_group::AttributeGroup, catalog::AttributeCatalog,
+    entity::Entity, event::Event, metric::Metric, span::Span, ResolvedTelemetrySchema, Signal,
 };
 
 use crate::{
@@ -107,23 +101,23 @@ fn lookup_signal_by_id<'a, T: Signal>(signals: &'a [T], id: &str) -> Option<&'a 
 /// schema is built by this workspace, so a dangling index is a logic error.
 fn named_associations(
     associations: &[weaver_resolved_schema::v2::entity::EntityAssociation],
-    entity_refinements: &[EntityRefinement],
+    registry: &ResolvedTelemetrySchema,
 ) -> Vec<weaver_semconv::entity_association::EntityAssociation> {
-    weaver_resolved_schema::v2::entity::to_named_associations(associations, entity_refinements)
-        .unwrap_or_else(|entity_ref| {
-            panic!(
-                "Invalid schema file: Entity reference {} does not exist",
-                entity_ref.0
-            )
-        })
+    weaver_resolved_schema::v2::entity::to_named_associations(
+        associations,
+        &registry.refinements.entities,
+    )
+    .unwrap_or_else(|entity_ref| {
+        panic!(
+            "Invalid schema file: Entity reference {} does not exist",
+            entity_ref.0
+        )
+    })
 }
 
 /// Creates a renderable context for a resolved metric.
-fn resolved_metric<AC: AttributeCatalog>(
-    m: &Metric,
-    catalog: &AC,
-    entity_refinements: &[EntityRefinement],
-) -> ResolvedId {
+fn resolved_metric(m: &Metric, registry: &ResolvedTelemetrySchema) -> ResolvedId {
+    let catalog = &registry.attribute_catalog;
     let mut attributes = Vec::new();
     for ar in m.attributes.iter() {
         let attr = catalog.attribute(&ar.base).unwrap_or_else(|| {
@@ -150,7 +144,7 @@ fn resolved_metric<AC: AttributeCatalog>(
             unit: m.unit.clone(),
             requirement_level: m.requirement_level.clone(),
             attributes,
-            entity_associations: named_associations(&m.entity_associations, entity_refinements),
+            entity_associations: named_associations(&m.entity_associations, registry),
             common: m.common.clone(),
             provenance: Default::default(),
         },
@@ -158,11 +152,8 @@ fn resolved_metric<AC: AttributeCatalog>(
 }
 
 // Creates renderable span.
-fn resolved_span<AC: AttributeCatalog>(
-    s: &Span,
-    catalog: &AC,
-    entity_refinements: &[EntityRefinement],
-) -> ResolvedId {
+fn resolved_span(s: &Span, registry: &ResolvedTelemetrySchema) -> ResolvedId {
+    let catalog = &registry.attribute_catalog;
     let mut attributes = Vec::new();
     for ar in s.attributes.iter() {
         let attr = catalog.attribute(&ar.base).unwrap_or_else(|| {
@@ -189,7 +180,7 @@ fn resolved_span<AC: AttributeCatalog>(
             name: s.name.clone(),
             attributes,
             kind: s.kind.clone(),
-            entity_associations: named_associations(&s.entity_associations, entity_refinements),
+            entity_associations: named_associations(&s.entity_associations, registry),
             requirement_level: s.requirement_level.clone(),
             common: s.common.clone(),
             provenance: Default::default(),
@@ -198,11 +189,8 @@ fn resolved_span<AC: AttributeCatalog>(
 }
 
 // Creates renderable event.
-fn resolved_event<AC: AttributeCatalog>(
-    s: &Event,
-    catalog: &AC,
-    entity_refinements: &[EntityRefinement],
-) -> ResolvedId {
+fn resolved_event(s: &Event, registry: &ResolvedTelemetrySchema) -> ResolvedId {
+    let catalog = &registry.attribute_catalog;
     let mut attributes = Vec::new();
     for ar in s.attributes.iter() {
         let attr = catalog.attribute(&ar.base).unwrap_or_else(|| {
@@ -226,7 +214,7 @@ fn resolved_event<AC: AttributeCatalog>(
         event: weaver_forge::v2::event::Event {
             name: s.name.clone(),
             attributes,
-            entity_associations: named_associations(&s.entity_associations, entity_refinements),
+            entity_associations: named_associations(&s.entity_associations, registry),
             requirement_level: s.requirement_level.clone(),
             common: s.common.clone(),
             provenance: Default::default(),
@@ -235,7 +223,8 @@ fn resolved_event<AC: AttributeCatalog>(
 }
 
 // Creates renderable entity.
-fn resolved_entity<AC: AttributeCatalog>(s: &Entity, catalog: &AC) -> ResolvedId {
+fn resolved_entity(s: &Entity, registry: &ResolvedTelemetrySchema) -> ResolvedId {
+    let catalog = &registry.attribute_catalog;
     let mut identity = Vec::new();
     for ar in s.identity.iter() {
         let attr = catalog.attribute(&ar.base).unwrap_or_else(|| {
@@ -287,7 +276,8 @@ fn resolved_entity<AC: AttributeCatalog>(s: &Entity, catalog: &AC) -> ResolvedId
 }
 
 // Creates renderable attribute group.
-fn resolved_attribute_group<AC: AttributeCatalog>(s: &AttributeGroup, catalog: &AC) -> ResolvedId {
+fn resolved_attribute_group(s: &AttributeGroup, registry: &ResolvedTelemetrySchema) -> ResolvedId {
+    let catalog = &registry.attribute_catalog;
     let mut attributes = Vec::new();
     for ar in s.attributes.iter() {
         let attr = catalog.attribute(&ar.base).unwrap_or_else(|| {
@@ -344,84 +334,47 @@ fn lookup_id(registry: &ResolvedTelemetrySchema, id: &str) -> Result<Option<Reso
             &registry.registry.attribute_groups,
             &id,
         )
-        .map(|ag| resolved_attribute_group(ag, &registry.attribute_catalog))),
+        .map(|ag| resolved_attribute_group(ag, registry))),
         IdLookupV2::Registry(RegistryLookup::Span { id }) => {
-            Ok(lookup_signal_by_id(&registry.registry.spans, &id).map(|s| {
-                resolved_span(
-                    s,
-                    &registry.attribute_catalog,
-                    &registry.refinements.entities,
-                )
-            }))
+            Ok(lookup_signal_by_id(&registry.registry.spans, &id)
+                .map(|s| resolved_span(s, registry)))
         }
         IdLookupV2::Registry(RegistryLookup::Metric { id }) => {
-            Ok(
-                lookup_signal_by_id(&registry.registry.metrics, &id).map(|m| {
-                    resolved_metric(
-                        m,
-                        &registry.attribute_catalog,
-                        &registry.refinements.entities,
-                    )
-                }),
-            )
+            Ok(lookup_signal_by_id(&registry.registry.metrics, &id)
+                .map(|m| resolved_metric(m, registry)))
         }
         IdLookupV2::Registry(RegistryLookup::Event { id }) => {
-            Ok(
-                lookup_signal_by_id(&registry.registry.events, &id).map(|e| {
-                    resolved_event(
-                        e,
-                        &registry.attribute_catalog,
-                        &registry.refinements.entities,
-                    )
-                }),
-            )
+            Ok(lookup_signal_by_id(&registry.registry.events, &id)
+                .map(|e| resolved_event(e, registry)))
         }
         IdLookupV2::Registry(RegistryLookup::Entity { id }) => {
             Ok(lookup_signal_by_id(&registry.registry.entities, &id)
-                .map(|e| resolved_entity(e, &registry.attribute_catalog)))
+                .map(|e| resolved_entity(e, registry)))
         }
         IdLookupV2::Refinement(crate::parser::RefinementLookup::Metric { id }) => Ok(registry
             .refinements
             .metrics
             .iter()
             .find(|m| m.id == id)
-            .map(|m| {
-                resolved_metric(
-                    &m.metric,
-                    &registry.attribute_catalog,
-                    &registry.refinements.entities,
-                )
-            })),
+            .map(|m| resolved_metric(&m.metric, registry))),
         IdLookupV2::Refinement(crate::parser::RefinementLookup::Event { id }) => Ok(registry
             .refinements
             .events
             .iter()
             .find(|s| s.id == id)
-            .map(|e| {
-                resolved_event(
-                    &e.event,
-                    &registry.attribute_catalog,
-                    &registry.refinements.entities,
-                )
-            })),
+            .map(|e| resolved_event(&e.event, registry))),
         IdLookupV2::Refinement(crate::parser::RefinementLookup::Span { id }) => Ok(registry
             .refinements
             .spans
             .iter()
             .find(|s| s.id == id)
-            .map(|s| {
-                resolved_span(
-                    &s.span,
-                    &registry.attribute_catalog,
-                    &registry.refinements.entities,
-                )
-            })),
+            .map(|s| resolved_span(&s.span, registry))),
         IdLookupV2::Refinement(crate::parser::RefinementLookup::Entity { id }) => Ok(registry
             .refinements
             .entities
             .iter()
             .find(|e| e.id == id)
-            .map(|e| resolved_entity(&e.entity, &registry.attribute_catalog))),
+            .map(|e| resolved_entity(&e.entity, registry))),
     }
 }
 

--- a/crates/weaver_semconv_gen/src/v2.rs
+++ b/crates/weaver_semconv_gen/src/v2.rs
@@ -11,8 +11,14 @@ use weaver_forge::{
     OutputProcessor,
 };
 use weaver_resolved_schema::v2::{
-    attribute::Attribute, attribute_group::AttributeGroup, catalog::AttributeCatalog,
-    entity::Entity, event::Event, metric::Metric, span::Span, ResolvedTelemetrySchema, Signal,
+    attribute::Attribute,
+    attribute_group::AttributeGroup,
+    catalog::AttributeCatalog,
+    entity::{Entity, EntityRefinement},
+    event::Event,
+    metric::Metric,
+    span::Span,
+    ResolvedTelemetrySchema, Signal,
 };
 
 use crate::{
@@ -97,8 +103,27 @@ fn lookup_signal_by_id<'a, T: Signal>(signals: &'a [T], id: &str) -> Option<&'a 
     signals.iter().find(|s| s.id() == id)
 }
 
+/// Turns entity refinement indices back into names for rendering. A resolved
+/// schema is built by this workspace, so a dangling index is a logic error.
+fn named_associations(
+    associations: &[weaver_resolved_schema::v2::entity::EntityAssociation],
+    entity_refinements: &[EntityRefinement],
+) -> Vec<weaver_semconv::entity_association::EntityAssociation> {
+    weaver_resolved_schema::v2::entity::to_named_associations(associations, entity_refinements)
+        .unwrap_or_else(|entity_ref| {
+            panic!(
+                "Invalid schema file: Entity reference {} does not exist",
+                entity_ref.0
+            )
+        })
+}
+
 /// Creates a renderable context for a resolved metric.
-fn resolved_metric<AC: AttributeCatalog>(m: &Metric, catalog: &AC) -> ResolvedId {
+fn resolved_metric<AC: AttributeCatalog>(
+    m: &Metric,
+    catalog: &AC,
+    entity_refinements: &[EntityRefinement],
+) -> ResolvedId {
     let mut attributes = Vec::new();
     for ar in m.attributes.iter() {
         let attr = catalog.attribute(&ar.base).unwrap_or_else(|| {
@@ -125,7 +150,7 @@ fn resolved_metric<AC: AttributeCatalog>(m: &Metric, catalog: &AC) -> ResolvedId
             unit: m.unit.clone(),
             requirement_level: m.requirement_level.clone(),
             attributes,
-            entity_associations: m.entity_associations.clone(),
+            entity_associations: named_associations(&m.entity_associations, entity_refinements),
             common: m.common.clone(),
             provenance: Default::default(),
         },
@@ -133,7 +158,11 @@ fn resolved_metric<AC: AttributeCatalog>(m: &Metric, catalog: &AC) -> ResolvedId
 }
 
 // Creates renderable span.
-fn resolved_span<AC: AttributeCatalog>(s: &Span, catalog: &AC) -> ResolvedId {
+fn resolved_span<AC: AttributeCatalog>(
+    s: &Span,
+    catalog: &AC,
+    entity_refinements: &[EntityRefinement],
+) -> ResolvedId {
     let mut attributes = Vec::new();
     for ar in s.attributes.iter() {
         let attr = catalog.attribute(&ar.base).unwrap_or_else(|| {
@@ -160,7 +189,7 @@ fn resolved_span<AC: AttributeCatalog>(s: &Span, catalog: &AC) -> ResolvedId {
             name: s.name.clone(),
             attributes,
             kind: s.kind.clone(),
-            entity_associations: s.entity_associations.clone(),
+            entity_associations: named_associations(&s.entity_associations, entity_refinements),
             requirement_level: s.requirement_level.clone(),
             common: s.common.clone(),
             provenance: Default::default(),
@@ -169,7 +198,11 @@ fn resolved_span<AC: AttributeCatalog>(s: &Span, catalog: &AC) -> ResolvedId {
 }
 
 // Creates renderable event.
-fn resolved_event<AC: AttributeCatalog>(s: &Event, catalog: &AC) -> ResolvedId {
+fn resolved_event<AC: AttributeCatalog>(
+    s: &Event,
+    catalog: &AC,
+    entity_refinements: &[EntityRefinement],
+) -> ResolvedId {
     let mut attributes = Vec::new();
     for ar in s.attributes.iter() {
         let attr = catalog.attribute(&ar.base).unwrap_or_else(|| {
@@ -193,7 +226,7 @@ fn resolved_event<AC: AttributeCatalog>(s: &Event, catalog: &AC) -> ResolvedId {
         event: weaver_forge::v2::event::Event {
             name: s.name.clone(),
             attributes,
-            entity_associations: s.entity_associations.clone(),
+            entity_associations: named_associations(&s.entity_associations, entity_refinements),
             requirement_level: s.requirement_level.clone(),
             common: s.common.clone(),
             provenance: Default::default(),
@@ -313,16 +346,35 @@ fn lookup_id(registry: &ResolvedTelemetrySchema, id: &str) -> Result<Option<Reso
         )
         .map(|ag| resolved_attribute_group(ag, &registry.attribute_catalog))),
         IdLookupV2::Registry(RegistryLookup::Span { id }) => {
-            Ok(lookup_signal_by_id(&registry.registry.spans, &id)
-                .map(|s| resolved_span(s, &registry.attribute_catalog)))
+            Ok(lookup_signal_by_id(&registry.registry.spans, &id).map(|s| {
+                resolved_span(
+                    s,
+                    &registry.attribute_catalog,
+                    &registry.refinements.entities,
+                )
+            }))
         }
         IdLookupV2::Registry(RegistryLookup::Metric { id }) => {
-            Ok(lookup_signal_by_id(&registry.registry.metrics, &id)
-                .map(|m| resolved_metric(m, &registry.attribute_catalog)))
+            Ok(
+                lookup_signal_by_id(&registry.registry.metrics, &id).map(|m| {
+                    resolved_metric(
+                        m,
+                        &registry.attribute_catalog,
+                        &registry.refinements.entities,
+                    )
+                }),
+            )
         }
         IdLookupV2::Registry(RegistryLookup::Event { id }) => {
-            Ok(lookup_signal_by_id(&registry.registry.events, &id)
-                .map(|e| resolved_event(e, &registry.attribute_catalog)))
+            Ok(
+                lookup_signal_by_id(&registry.registry.events, &id).map(|e| {
+                    resolved_event(
+                        e,
+                        &registry.attribute_catalog,
+                        &registry.refinements.entities,
+                    )
+                }),
+            )
         }
         IdLookupV2::Registry(RegistryLookup::Entity { id }) => {
             Ok(lookup_signal_by_id(&registry.registry.entities, &id)
@@ -333,19 +385,37 @@ fn lookup_id(registry: &ResolvedTelemetrySchema, id: &str) -> Result<Option<Reso
             .metrics
             .iter()
             .find(|m| m.id == id)
-            .map(|m| resolved_metric(&m.metric, &registry.attribute_catalog))),
+            .map(|m| {
+                resolved_metric(
+                    &m.metric,
+                    &registry.attribute_catalog,
+                    &registry.refinements.entities,
+                )
+            })),
         IdLookupV2::Refinement(crate::parser::RefinementLookup::Event { id }) => Ok(registry
             .refinements
             .events
             .iter()
             .find(|s| s.id == id)
-            .map(|e| resolved_event(&e.event, &registry.attribute_catalog))),
+            .map(|e| {
+                resolved_event(
+                    &e.event,
+                    &registry.attribute_catalog,
+                    &registry.refinements.entities,
+                )
+            })),
         IdLookupV2::Refinement(crate::parser::RefinementLookup::Span { id }) => Ok(registry
             .refinements
             .spans
             .iter()
             .find(|s| s.id == id)
-            .map(|s| resolved_span(&s.span, &registry.attribute_catalog))),
+            .map(|s| {
+                resolved_span(
+                    &s.span,
+                    &registry.attribute_catalog,
+                    &registry.refinements.entities,
+                )
+            })),
         IdLookupV2::Refinement(crate::parser::RefinementLookup::Entity { id }) => Ok(registry
             .refinements
             .entities

--- a/schemas/semconv-schemas.md
+++ b/schemas/semconv-schemas.md
@@ -18,6 +18,7 @@
     - [Diff schema](#diff-schema)
   - [Common types](#common-types)
     - [Requirement level](#requirement-level)
+    - [Entity associations](#entity-associations)
     - [Common signal and attribute properties](#common-signal-and-attribute-properties)
 
 <!-- tocstop -->
@@ -187,6 +188,9 @@ refinements:
 
 Attribute references are indexes into the `attribute_catalog` array, paired with per-signal properties such as `requirement_level`.
 
+Entity references are indexes into the `refinements.entities` array. See
+[Entity associations](#entity-associations).
+
 #### Resolved schema properties
 
 - **file_format**: `"resolved/2.0"`
@@ -213,7 +217,7 @@ Attribute references are indexes into the `attribute_catalog` array, paired with
     - `attributes`: Attribute references (optional)
       - `base`: Index into `attribute_catalog`
       - `requirement_level`: See [Requirement level](#requirement-level)
-    - `entity_associations`: Associated entity types (optional)
+    - `entity_associations`: [Entity associations](#entity-associations) — indexes into `refinements.entities` (optional)
     - [Common properties](#common-signal-and-attribute-properties)
   - **spans**: Span signal definitions
     - `type`: Unique span type identifier
@@ -223,14 +227,14 @@ Attribute references are indexes into the `attribute_catalog` array, paired with
       - `base`: Index into `attribute_catalog`
       - `requirement_level`: See [Requirement level](#requirement-level)
       - `sampling_relevant`: Whether this attribute must be available at span start (optional)
-    - `entity_associations`: Associated entity types (optional)
+    - `entity_associations`: [Entity associations](#entity-associations) — indexes into `refinements.entities` (optional)
     - [Common properties](#common-signal-and-attribute-properties)
   - **events**: Event signal definitions
     - `name`: Unique event name
     - `attributes`: Attribute references (optional)
       - `base`: Index into `attribute_catalog`
       - `requirement_level`: See [Requirement level](#requirement-level)
-    - `entity_associations`: Associated entity types (optional)
+    - `entity_associations`: [Entity associations](#entity-associations) — indexes into `refinements.entities` (optional)
     - [Common properties](#common-signal-and-attribute-properties)
   - **entities**: Entity (resource) signal definitions
     - `type`: Unique entity type
@@ -319,7 +323,8 @@ refinements:
 - **schema_url**: The Schema URL where this registry is or will be published
 - **registry**: Same structure as in the *resolved* schema, but all attribute references are replaced
   by complete attribute definitions. This applies to all signal types (metrics, spans, events, entities)
-  and to `attribute_groups`.
+  and to `attribute_groups`. [Entity associations](#entity-associations) are also expanded: each index
+  is replaced by the id of the entity refinement it points at.
 - **refinements**: Same structure as in the *resolved* schema, but attribute references are fully expanded.
 
 ### Diff schema
@@ -366,6 +371,30 @@ It is either a simple string or an object carrying an explanation:
 | `{"conditionally_required": "<condition>"}` | Required when the condition holds |
 | `{"recommended": "<reason>"}` | Recommended, with explicit rationale |
 | `{"opt_in": "<reason>"}` | Opt-in, with explicit rationale |
+
+### Entity associations
+
+`entity_associations` appears on metrics, spans, events, and their refinements. It is a list of
+*entity association expressions*, each of which is one of:
+
+| Form | Meaning |
+| --- | --- |
+| `<entity reference>` | The signal is associated with this entity |
+| `{"one_of": [<expression>, ...]}` | Satisfied when at least one contained expression is satisfied |
+| `{"all_of": [<expression>, ...]}` | Satisfied when every contained expression is satisfied |
+
+`one_of` and `all_of` nest, so an expression is a tree with entity references at its leaves.
+
+How a leaf names its entity depends on the schema:
+
+- In the [definition schema](#definition-schema) a leaf is an entity type, for example `service`.
+- In the [resolved schema](#resolved-schema) a leaf is an index into the `refinements.entities` array.
+  Every entity definition in `registry.entities` also has a base refinement, so an index can reach a
+  definition or a refinement of one. An association is resolved during
+  [`weaver registry package`](/docs/usage.md#weaver-registry-package): the named entity is imported
+  from the registry that defines it, and an association that no registry in scope satisfies is an error.
+- In the [materialized schema](#materialized-resolved-schema) a leaf is the id of the entity refinement
+  the index points at.
 
 ### Common signal and attribute properties
 

--- a/schemas/semconv-syntax.v2.md
+++ b/schemas/semconv-syntax.v2.md
@@ -463,6 +463,13 @@ entity_associations:
           - container
 ```
 
+Every referenced entity must be defined by this registry or by one of its dependencies. An entity
+that a dependency defines is imported the way an attribute named in a `ref` is — naming it in
+`entity_associations` is enough, it does not also need an [`imports`](#imports-definition) entry. A
+reference that no registry in scope defines fails resolution, and so does a reference to an entity
+that its registry excludes with
+[`dependency_resolution`](#dependency-resolution-annotations).
+
 ### `events` definition
 
 The events section contains a list of event definitions. An event represents a discrete occurrence at a point in time, such as a request completion, system startup, or error condition.
@@ -784,7 +791,7 @@ The `dependency_resolution` annotation hides an attribute, group, or signal from
 registries that consume this one as a dependency. The owning registry still
 sees the item normally - resolution, codegen, and docs are unaffected — but any
 dependent registry that references the item (via `ref`, `extends`,
-`include_groups`, `imports`, or a v2 refinement) fails to resolve.
+`include_groups`, `imports`, `entity_associations`, or a v2 refinement) fails to resolve.
 
 This is intended for migrations where definitions move out of a parent registry
 into a new one. Marking the old definitions excluded prevents conflicts in

--- a/schemas/semconv.resolved.v2.json
+++ b/schemas/semconv.resolved.v2.json
@@ -411,11 +411,11 @@
       ]
     },
     "EntityAssociation": {
-      "description": "An entity association expression.\n\nIn YAML this is either a bare string (an entity reference), a `{ one_of: [...] }` map or a\n`{ all_of: [...] }` map, where each list element is itself an [`EntityAssociation`].",
+      "description": "An entity association expression in a resolved schema.\n\nThe leaf is an index into the entity refinements, not a name. Every entity\ndefinition also has a base refinement, so an index can reach a definition or\na refinement of one.",
       "anyOf": [
         {
-          "description": "A reference to an entity by its type name.",
-          "type": "string"
+          "description": "A reference to one entity refinement.",
+          "$ref": "#/$defs/EntityRef"
         },
         {
           "description": "Satisfied when at least one of the contained expressions is satisfied.",
@@ -469,6 +469,12 @@
         "base",
         "requirement_level"
       ]
+    },
+    "EntityRef": {
+      "description": "A reference, by index, to an entity refinement of the schema.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
     },
     "EntityRefinement": {
       "description": "A refinement of an entity signal.\n\nDescribes an entity optimized for a specific environment,\nfor example, a host entity might be refined for a specific OS\nand describe how base entity attributes are obtained in that OS.",


### PR DESCRIPTION
## Summary of what the resolver does now

1. **An entity association pulls the entity in.** Name an entity in `entity_associations` and it arrives, the way an attribute named in a `ref` already did. Code gen, doc gen and live-check can see it. The copy is the definition from the registry that declared it, unchanged, and it keeps that registry as its source.
2. **An association that nothing satisfies fails the resolve.** A name that no registry in scope defines is an error, not silence.
3. **A private entity stays private.** An entity marked `dependency_resolution.exclude: true` cannot be reached from a dependent, by an `imports` clause or by an association.
4. **One definition reached by two paths is one entity.** A diamond in the dependency graph no longer produces duplicate copies and duplicate warnings.
5. **An import that matches nothing is reported.** For every signal type, not only entities. Resolution still succeeds, with a warning.
6. **A resolved schema points at the entity instead of naming it.** `entity_associations` holds an index into the entity refinements, so a consumer gets a pointer rather than a name to look up again. Templates still read the name.
