### PR TITLE
Add Resolve config for schema_url overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6340,6 +6340,7 @@ dependencies = [
  "weaver_checker",
  "weaver_common",
  "weaver_macros",
+ "weaver_semconv",
 ]
 
 [[package]]

--- a/crates/weaver_config/Cargo.toml
+++ b/crates/weaver_config/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 weaver_checker = { path = "../weaver_checker" }
 weaver_common = { path = "../weaver_common" }
 weaver_macros = { path = "../weaver_macros" }
+weaver_semconv = { path = "../weaver_semconv" }
 
 serde.workspace = true
 schemars.workspace = true

--- a/crates/weaver_config/README.md
+++ b/crates/weaver_config/README.md
@@ -30,6 +30,11 @@ skip = true
 [diagnostics]
 format = "ansi"   # ansi | json | gh_workflow_command
 
+# Shared resolution settings — override dependency schema URLs with local or custom locations.
+[resolve.schema_url_overrides]
+"https://opentelemetry.io/schemas/1.25.0" = "path/to/local/1.25.0"
+"https://opentelemetry.io/schemas/1.26.0" = "https://github.com/my-fork/semconv.git[model]"
+
 # Shared template settings — applied on top of every template package's `weaver.yaml`.
 [template]
 acronyms = ["API", "HTTP", "SDK", "iOS"] 
@@ -89,7 +94,7 @@ See `schemas/weaver-config.json` for the full JSON schema (with VS Code / taplo 
 
 ### `WeaverConfig`
 
-The top-level config type. Typed fields cover the cross-cutting sections (`registry`, `policy`, `diagnostics`, `live_check`, `auth`). Per-command sections are stored as a raw `toml::Table` via `#[serde(flatten)]` and deserialized on demand by `command_config<C>(section)`.
+The top-level config type. Typed fields cover the cross-cutting sections (`registry`, `policy`, `diagnostics`, `resolve`, `live_check`, `auth`). Per-command sections are stored as a raw `toml::Table` via `#[serde(flatten)]` and deserialized on demand by `command_config<C>(section)`.
 
 ### `CliOverrides` trait
 
@@ -102,7 +107,7 @@ Each command's `*Args` struct implements `CliOverrides`, which declares:
 - `excluded_args` / `config_only_fields` — drive the consistency test
 - `apply_registry_overrides` / `apply_policy_overrides` / `apply_diagnostic_overrides` — handle shared args
 
-`load_config(args, cfg)` executes the three-layer merge and returns `CommandConfig<C>` containing the merged command config plus effective registry, policy, and diagnostic configs.
+`load_config(args, cfg)` executes the three-layer merge and returns `CommandConfig<C>` containing the merged command config plus effective registry, policy, resolution, and diagnostic configs.
 
 ### `#[derive(WeaverCommand)]` macro
 

--- a/crates/weaver_config/README.md
+++ b/crates/weaver_config/README.md
@@ -90,6 +90,24 @@ exclude = ["missing_namespace"]
 
 See `schemas/weaver-config.json` for the full JSON schema (with VS Code / taplo completion support via the `#:schema` annotation above).
 
+### Dependency Resolution Overrides (`[resolve]`)
+
+The `[resolve]` section configures how dependencies and schema URLs are resolved. This is a configuration-only setting (no CLI flags) designed for:
+
+- **Local Development**: Developing interdependent registries simultaneously without needing to publish or modify the `manifest.yaml` dependency paths.
+- **Air-Gapped / Offline CI**: Redirecting remote schema URL fetches to local directories, archives, or internal mirrors.
+- **Testing Forks and Branches**: Redirecting a canonical dependency schema URL to a local checkout or Git fork.
+
+```toml
+[resolve.schema_url_overrides]
+# Map a canonical schema URL to a local directory
+"https://opentelemetry.io/schemas/1.25.0" = "path/to/local/1.25.0"
+# Map to a specific Git repository subfolder
+"https://opentelemetry.io/schemas/1.26.0" = "https://github.com/my-fork/semconv.git[model]"
+```
+
+Aliases `[resolve.overrides]` and `[resolve.dependency_overrides]` are also supported. When Weaver loads and resolves dependencies during commands such as `check`, `generate`, `package`, or `live-check`, any dependency with a matching schema URL will be redirected to the configured override path.
+
 ## Architecture
 
 ### `WeaverConfig`

--- a/crates/weaver_config/allowed-external-types.toml
+++ b/crates/weaver_config/allowed-external-types.toml
@@ -10,4 +10,5 @@ allowed_external_types = [
     "weaver_checker::*",
     "weaver_macros::*",
     "weaver_common::*",
+    "weaver_semconv::*",
 ]

--- a/crates/weaver_config/src/effective.rs
+++ b/crates/weaver_config/src/effective.rs
@@ -162,7 +162,9 @@ impl EffectiveResolveConfig {
             let schema_url = match SchemaUrl::try_from(url_str.as_str()) {
                 Ok(url) => url,
                 Err(e) => {
-                    log::warn!("Invalid schema URL '{url_str}' in [resolve.schema_url_overrides]: {e}");
+                    log::warn!(
+                        "Invalid schema URL '{url_str}' in [resolve.schema_url_overrides]: {e}"
+                    );
                     continue;
                 }
             };

--- a/crates/weaver_config/src/effective.rs
+++ b/crates/weaver_config/src/effective.rs
@@ -4,11 +4,14 @@
 //!
 //! Each type is built via three-layer merge: defaults → `.weaver.toml` → CLI overrides.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use weaver_common::vdir::VirtualDirectoryPath;
+use weaver_semconv::schema_url::SchemaUrl;
 
 use crate::registry::{DiagnosticsConfig, PolicyConfig, RegistryConfig};
+use crate::resolve::ResolveConfig;
 
 /// Default registry URL used when no registry is specified.
 pub const DEFAULT_REGISTRY: &str =
@@ -143,12 +146,80 @@ impl EffectiveDiagnosticConfig {
     }
 }
 
+/// Effective resolution settings — every field has a concrete value.
+///
+/// Built by layering: defaults → `.weaver.toml`.
+#[derive(Debug, Clone, Default)]
+pub struct EffectiveResolveConfig {
+    /// Explicit overrides mapping a requested SchemaUrl to an alternative VirtualDirectoryPath.
+    pub schema_url_overrides: BTreeMap<SchemaUrl, VirtualDirectoryPath>,
+}
+
+impl EffectiveResolveConfig {
+    /// Apply `.weaver.toml` resolve section onto this effective config (layer 2).
+    pub fn layer_config(&mut self, cfg: &ResolveConfig) {
+        for (url_str, path_str) in &cfg.schema_url_overrides {
+            let schema_url = match SchemaUrl::try_from(url_str.as_str()) {
+                Ok(url) => url,
+                Err(e) => {
+                    log::warn!("Invalid schema URL '{url_str}' in [resolve.schema_url_overrides]: {e}");
+                    continue;
+                }
+            };
+            let path = match path_str.parse::<VirtualDirectoryPath>() {
+                Ok(p) => p,
+                Err(e) => {
+                    log::warn!("Invalid path '{path_str}' in [resolve.schema_url_overrides] for '{url_str}': {e}");
+                    continue;
+                }
+            };
+            _ = self.schema_url_overrides.insert(schema_url, path);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
     use super::*;
     use crate::registry::{DiagnosticsConfig, PolicyConfig, RegistryConfig};
+    use crate::resolve::ResolveConfig;
+
+    // ── EffectiveResolveConfig ────────────────────────────────────────────────
+
+    #[test]
+    fn test_resolve_default_values() {
+        let cfg = EffectiveResolveConfig::default();
+        assert!(cfg.schema_url_overrides.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_layer_config_applies_overrides() {
+        let mut cfg = EffectiveResolveConfig::default();
+        let mut overrides = BTreeMap::new();
+        _ = overrides.insert(
+            "https://opentelemetry.io/schemas/1.25.0".to_owned(),
+            "data/registry-test-v2-dep/app_registry".to_owned(),
+        );
+        cfg.layer_config(&ResolveConfig {
+            schema_url_overrides: overrides,
+        });
+        assert_eq!(cfg.schema_url_overrides.len(), 1);
+        let url = SchemaUrl::try_from("https://opentelemetry.io/schemas/1.25.0").unwrap();
+        assert!(cfg.schema_url_overrides.contains_key(&url));
+    }
+
+    #[test]
+    fn test_resolve_layer_config_skips_invalid() {
+        let mut cfg = EffectiveResolveConfig::default();
+        let mut overrides = BTreeMap::new();
+        _ = overrides.insert("invalid-url".to_owned(), "path/to/local".to_owned());
+        cfg.layer_config(&ResolveConfig {
+            schema_url_overrides: overrides,
+        });
+        assert!(cfg.schema_url_overrides.is_empty());
+    }
 
     // ── EffectiveRegistryConfig ───────────────────────────────────────────────
 

--- a/crates/weaver_config/src/lib.rs
+++ b/crates/weaver_config/src/lib.rs
@@ -14,13 +14,15 @@ pub mod effective;
 pub mod live_check;
 mod overrides;
 pub mod registry;
+pub mod resolve;
 pub mod template;
 
 // Re-export the public API so callers can use `weaver_config::LiveCheckConfig` etc.
 pub use auth::{build_resolver as build_auth_resolver, AuthEntry};
 pub use effective::{
     EffectiveDiagnosticConfig, EffectivePolicyConfig, EffectiveRegistryConfig,
-    DEFAULT_DIAGNOSTIC_FORMAT, DEFAULT_DIAGNOSTIC_TEMPLATE, DEFAULT_REGISTRY,
+    EffectiveResolveConfig, DEFAULT_DIAGNOSTIC_FORMAT, DEFAULT_DIAGNOSTIC_TEMPLATE,
+    DEFAULT_REGISTRY,
 };
 pub use live_check::{
     FailOnLevel, FindingFilter, FindingLevelOverride, LiveCheckConfig, LiveCheckEmitConfig,
@@ -28,6 +30,7 @@ pub use live_check::{
 };
 pub use overrides::{CliOverrides, CommandConfig, FieldMapping};
 pub use registry::{DiagnosticsConfig, PolicyConfig, RegistryConfig};
+pub use resolve::ResolveConfig;
 pub use template::TemplateConfig;
 pub use weaver_common::http_auth::TokenSource;
 // Re-export the WeaverCommand derive macro and the weaver_command attribute
@@ -48,6 +51,9 @@ pub struct WeaverConfig {
     pub policy: PolicyConfig,
     /// Shared diagnostic output settings (apply to all subcommands that accept them).
     pub diagnostics: DiagnosticsConfig,
+    /// Shared resolution settings (apply to all subcommands that accept them).
+    #[serde(alias = "resolution")]
+    pub resolve: ResolveConfig,
     /// Project-level template settings applied on top of every template package
     /// used by the project, layering over the package's own `weaver.yaml`.
     pub template: TemplateConfig,

--- a/crates/weaver_config/src/overrides.rs
+++ b/crates/weaver_config/src/overrides.rs
@@ -8,7 +8,10 @@
 
 use schemars::JsonSchema;
 
-use crate::effective::{EffectiveDiagnosticConfig, EffectivePolicyConfig, EffectiveRegistryConfig};
+use crate::effective::{
+    EffectiveDiagnosticConfig, EffectivePolicyConfig, EffectiveRegistryConfig,
+    EffectiveResolveConfig,
+};
 use crate::WeaverConfig;
 
 /// The unified result of loading all configuration for a command.
@@ -21,6 +24,8 @@ pub struct CommandConfig<C> {
     pub registry: EffectiveRegistryConfig,
     /// Effective policy settings (defaults → config → CLI).
     pub policy: EffectivePolicyConfig,
+    /// Effective resolution settings (defaults → config).
+    pub resolve: EffectiveResolveConfig,
 }
 
 /// A name mapping between a config field and its CLI arg counterpart.

--- a/crates/weaver_config/src/resolve.rs
+++ b/crates/weaver_config/src/resolve.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resolution configuration (`[resolve]` / `[resolution]` in `.weaver.toml`).
+//!
+//! Controls dependency resolution and schema URL overrides.
+
+use std::collections::BTreeMap;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+/// Resolution configuration — how dependencies and schema URLs are resolved.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, JsonSchema)]
+#[serde(default)]
+#[schemars(inline)]
+pub struct ResolveConfig {
+    /// Explicit overrides mapping a requested schema URL to an alternative
+    /// directory, Git repository, or archive path.
+    ///
+    /// ```toml
+    /// [resolve.schema_url_overrides]
+    /// "https://opentelemetry.io/schemas/1.25.0" = "path/to/local/1.25.0"
+    /// "https://opentelemetry.io/schemas/1.26.0" = "https://github.com/my-fork/semconv.git[model]"
+    /// ```
+    #[serde(default, alias = "overrides", alias = "dependency_overrides")]
+    pub schema_url_overrides: BTreeMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::WeaverConfig;
+
+    #[test]
+    fn test_parse_resolve_schema_url_overrides() {
+        let toml = r#"
+[resolve.schema_url_overrides]
+"https://opentelemetry.io/schemas/1.25.0" = "path/to/local/1.25.0"
+"https://opentelemetry.io/schemas/1.26.0" = "https://github.com/my-fork/semconv.git[model]"
+"#;
+        let config: WeaverConfig = toml::from_str(toml).expect("Failed to parse TOML");
+        assert_eq!(config.resolve.schema_url_overrides.len(), 2);
+        assert_eq!(
+            config
+                .resolve
+                .schema_url_overrides
+                .get("https://opentelemetry.io/schemas/1.25.0")
+                .map(|s| s.as_str()),
+            Some("path/to/local/1.25.0")
+        );
+        assert_eq!(
+            config
+                .resolve
+                .schema_url_overrides
+                .get("https://opentelemetry.io/schemas/1.26.0")
+                .map(|s| s.as_str()),
+            Some("https://github.com/my-fork/semconv.git[model]")
+        );
+    }
+
+    #[test]
+    fn test_parse_resolve_overrides_alias() {
+        let toml = r#"
+[resolve.overrides]
+"https://opentelemetry.io/schemas/1.25.0" = "path/to/local/1.25.0"
+"#;
+        let config: WeaverConfig = toml::from_str(toml).expect("Failed to parse TOML");
+        assert_eq!(
+            config
+                .resolve
+                .schema_url_overrides
+                .get("https://opentelemetry.io/schemas/1.25.0")
+                .map(|s| s.as_str()),
+            Some("path/to/local/1.25.0")
+        );
+    }
+
+    #[test]
+    fn test_parse_resolution_alias() {
+        let toml = r#"
+[resolution.schema_url_overrides]
+"https://opentelemetry.io/schemas/1.25.0" = "path/to/local/1.25.0"
+"#;
+        let config: WeaverConfig = toml::from_str(toml).expect("Failed to parse TOML");
+        assert_eq!(
+            config
+                .resolve
+                .schema_url_overrides
+                .get("https://opentelemetry.io/schemas/1.25.0")
+                .map(|s| s.as_str()),
+            Some("path/to/local/1.25.0")
+        );
+    }
+
+    #[test]
+    fn test_empty_resolve_config() {
+        let config: WeaverConfig = toml::from_str("").expect("Failed to parse empty TOML");
+        assert!(config.resolve.schema_url_overrides.is_empty());
+    }
+}

--- a/crates/weaver_config/src/resolve.rs
+++ b/crates/weaver_config/src/resolve.rs
@@ -28,7 +28,6 @@ pub struct ResolveConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::WeaverConfig;
 
     #[test]

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc = include_str!("../README.md")]
 
 use lru::LruCache;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use weaver_common::http_auth::HttpAuthResolver;
@@ -92,7 +92,7 @@ pub struct WeaverResolverConfig {
 
     /// Explicit overrides mapping a requested SchemaUrl to an alternative VirtualDirectoryPath.
     /// Used to redirect dependency graph requests to local clones, forks, or custom archives.
-    pub schema_url_overrides: HashMap<SchemaUrl, weaver_common::vdir::VirtualDirectoryPath>,
+    pub schema_url_overrides: BTreeMap<SchemaUrl, weaver_common::vdir::VirtualDirectoryPath>,
 }
 
 impl Default for WeaverResolverConfig {
@@ -102,7 +102,7 @@ impl Default for WeaverResolverConfig {
             follow_symlinks: false,
             include_unreferenced: false,
             auth: HttpAuthResolver::empty(),
-            schema_url_overrides: HashMap::new(),
+            schema_url_overrides: BTreeMap::new(),
         }
     }
 }

--- a/docs/define-your-own-telemetry-schema.md
+++ b/docs/define-your-own-telemetry-schema.md
@@ -138,3 +138,20 @@ Matching requests are sent with `Authorization: Bearer <token>`. Then:
 weaver registry check \
   -r "https://github.com/org/repo/releases/download/v1.0.0/manifest.yaml"
 ```
+
+## Overriding dependency schema URLs locally (`.weaver.toml`)
+
+When developing custom registries that depend on upstream registries (e.g., OpenTelemetry semantic conventions), you might want to test against local directory checkouts, forks, or offline archives without modifying the canonical `registry_path` in `manifest.yaml`.
+
+You can configure schema URL overrides in `.weaver.toml` under `[resolve.schema_url_overrides]`:
+
+```toml
+[resolve.schema_url_overrides]
+# Override an upstream dependency schema URL to point to a local checkout
+"https://opentelemetry.io/schemas/1.40.0" = "../semantic-conventions/model"
+
+# Or override to point to a specific Git fork or branch
+"https://example.com/schemas/1.0.0" = "https://github.com/my-fork/semconv.git[model]"
+```
+
+When Weaver resolves dependencies during commands like `weaver registry check`, `weaver registry generate`, or `weaver registry live-check`, any dependency whose `schema_url` matches an entry in `[resolve.schema_url_overrides]` will be redirected to the specified local path or URL instead of the default location in `manifest.yaml`.

--- a/schemas/weaver-config.json
+++ b/schemas/weaver-config.json
@@ -424,6 +424,20 @@
         }
       }
     },
+    "resolve": {
+      "description": "Resolution configuration — how dependencies and schema URLs are resolved.",
+      "type": "object",
+      "properties": {
+        "schema_url_overrides": {
+          "description": "Explicit overrides mapping a requested schema URL to an alternative\ndirectory, Git repository, or archive path.\n\n```toml\n[resolve.schema_url_overrides]\n\"https://opentelemetry.io/schemas/1.25.0\" = \"path/to/local/1.25.0\"\n\"https://opentelemetry.io/schemas/1.26.0\" = \"https://github.com/my-fork/semconv.git[model]\"\n```",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        }
+      }
+    },
     "serve": {
       "description": "Serve a resolved registry over a local HTTP API for browsing and search.",
       "type": "object",

--- a/src/registry/check.rs
+++ b/src/registry/check.rs
@@ -48,7 +48,12 @@ pub(crate) fn command(
     let mut diag_msgs = DiagnosticMessages::empty();
     info!("Weaver Registry Check");
     info!("Checking registry `{}`", cmd_config.registry.registry);
-    let weaver = WeaverEngine::new(&cmd_config.registry, &cmd_config.policy, auth);
+    let weaver = WeaverEngine::new(
+        &cmd_config.registry,
+        &cmd_config.policy,
+        &cmd_config.resolve,
+        auth,
+    );
 
     // Initialize the main registry.
     let main_resolved = weaver.load_and_resolve_main(&mut diag_msgs)?;

--- a/src/registry/diff.rs
+++ b/src/registry/diff.rs
@@ -64,7 +64,12 @@ pub(crate) fn command(
 ) -> Result<ExitDirectives, DiagnosticMessages> {
     let cmd_config = load_config(args, cfg);
     let mut diag_msgs = DiagnosticMessages::empty();
-    let weaver = WeaverEngine::new(&cmd_config.registry, &cmd_config.policy, auth);
+    let weaver = WeaverEngine::new(
+        &cmd_config.registry,
+        &cmd_config.policy,
+        &cmd_config.resolve,
+        auth,
+    );
 
     info!("Weaver Registry Diff");
     info!("Checking registry `{}`", cmd_config.registry.registry);

--- a/src/registry/emit.rs
+++ b/src/registry/emit.rs
@@ -65,7 +65,12 @@ pub(crate) fn command(
     } else {
         ExporterConfig::Otlp { endpoint }
     };
-    let weaver = WeaverEngine::new(&cmd_config.registry, &cmd_config.policy, auth);
+    let weaver = WeaverEngine::new(
+        &cmd_config.registry,
+        &cmd_config.policy,
+        &cmd_config.resolve,
+        auth,
+    );
     let resolved = weaver.load_and_resolve_main(&mut diag_msgs)?;
     match resolved {
         crate::weaver::Resolved::V2(v) => {

--- a/src/registry/generate.rs
+++ b/src/registry/generate.rs
@@ -103,7 +103,12 @@ pub(crate) fn command(
     );
 
     let mut diag_msgs = DiagnosticMessages::empty();
-    let weaver = WeaverEngine::new(&cmd_config.registry, &cmd_config.policy, auth);
+    let weaver = WeaverEngine::new(
+        &cmd_config.registry,
+        &cmd_config.policy,
+        &cmd_config.resolve,
+        auth,
+    );
     let config = cmd_config.config;
     let resolved = weaver.load_and_resolve_main(&mut diag_msgs)?;
     let params = generate_params(args)?;

--- a/src/registry/json_schema.rs
+++ b/src/registry/json_schema.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 use weaver_common::diagnostic::DiagnosticMessages;
 use weaver_common::http_auth::HttpAuthResolver;
 use weaver_config::{
-    AuthEntry, DiagnosticsConfig, LiveCheckConfig, PolicyConfig, RegistryConfig, TemplateConfig,
-    WeaverConfig,
+    AuthEntry, DiagnosticsConfig, LiveCheckConfig, PolicyConfig, RegistryConfig, ResolveConfig,
+    TemplateConfig, WeaverConfig,
 };
 use weaver_forge::registry::ResolvedRegistry;
 use weaver_forge::{OutputProcessor, OutputTarget};
@@ -27,6 +27,7 @@ struct WeaverConfigSchema {
     pub registry: RegistryConfig,
     pub policy: PolicyConfig,
     pub diagnostics: DiagnosticsConfig,
+    pub resolve: ResolveConfig,
     pub template: TemplateConfig,
     pub auth: Vec<AuthEntry>,
     pub check: super::check::CheckConfig,

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -287,12 +287,7 @@ pub(crate) fn command(
     info!("Resolving registry `{}`", registry_args.registry);
 
     let mut diag_msgs = DiagnosticMessages::empty();
-    let weaver = WeaverEngine::new(
-        &registry_args,
-        &policy_args,
-        &cmd_config.resolve,
-        auth,
-    );
+    let weaver = WeaverEngine::new(&registry_args, &policy_args, &cmd_config.resolve, auth);
     let resolved_registry = weaver.load_and_resolve_main(&mut diag_msgs)?;
     let registry = match resolved_registry {
         crate::weaver::Resolved::V2(resolved_v2) => {

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -287,7 +287,12 @@ pub(crate) fn command(
     info!("Resolving registry `{}`", registry_args.registry);
 
     let mut diag_msgs = DiagnosticMessages::empty();
-    let weaver = WeaverEngine::new(&registry_args, &policy_args, auth);
+    let weaver = WeaverEngine::new(
+        &registry_args,
+        &policy_args,
+        &cmd_config.resolve,
+        auth,
+    );
     let resolved_registry = weaver.load_and_resolve_main(&mut diag_msgs)?;
     let registry = match resolved_registry {
         crate::weaver::Resolved::V2(resolved_v2) => {

--- a/src/registry/mcp.rs
+++ b/src/registry/mcp.rs
@@ -68,7 +68,12 @@ pub(crate) fn command(
     let mut diag_msgs = DiagnosticMessages::empty();
 
     // Use WeaverEngine to load and resolve the registry (always use v2)
-    let weaver = WeaverEngine::new(&cmd_config.registry, &cmd_config.policy, auth);
+    let weaver = WeaverEngine::new(
+        &cmd_config.registry,
+        &cmd_config.policy,
+        &cmd_config.resolve,
+        auth,
+    );
     let resolved = weaver.load_and_resolve_main(&mut diag_msgs)?;
 
     // Convert to V2 ForgeResolvedRegistry

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -26,7 +26,10 @@ use weaver_common::diagnostic::{DiagnosticMessage, DiagnosticMessages};
 use weaver_common::http_auth::HttpAuthResolver;
 use weaver_common::log_warn;
 use weaver_common::vdir::VirtualDirectoryPath;
-use weaver_config::{CliOverrides, CommandConfig, EffectivePolicyConfig, EffectiveRegistryConfig};
+use weaver_config::{
+    CliOverrides, CommandConfig, EffectivePolicyConfig, EffectiveRegistryConfig,
+    EffectiveResolveConfig,
+};
 
 mod check;
 mod diff;
@@ -358,10 +361,17 @@ pub fn load_config<A: CliOverrides>(
         EffectivePolicyConfig::skip_all()
     };
 
+    // Resolution: default → config
+    let mut resolve = EffectiveResolveConfig::default();
+    if let Some(wc) = weaver_config {
+        resolve.layer_config(&wc.resolve);
+    }
+
     CommandConfig {
         config,
         registry,
         policy,
+        resolve,
     }
 }
 

--- a/src/registry/package.rs
+++ b/src/registry/package.rs
@@ -92,7 +92,12 @@ pub(crate) fn command(
     }
 
     let mut diag_msgs = DiagnosticMessages::empty();
-    let weaver = WeaverEngine::new(&cmd_config.registry, &cmd_config.policy, auth);
+    let weaver = WeaverEngine::new(
+        &cmd_config.registry,
+        &cmd_config.policy,
+        &cmd_config.resolve,
+        auth,
+    );
     let registry_path = &cmd_config.registry.registry;
 
     let mut nfes = vec![];

--- a/src/registry/resolve.rs
+++ b/src/registry/resolve.rs
@@ -15,7 +15,9 @@ use crate::registry::{PolicyArgs, RegistryArgs};
 use crate::weaver::WeaverEngine;
 use crate::{DiagnosticArgs, ExitDirectives};
 use weaver_common::http_auth::HttpAuthResolver;
-use weaver_config::{EffectivePolicyConfig, EffectiveRegistryConfig, WeaverConfig};
+use weaver_config::{
+    EffectivePolicyConfig, EffectiveRegistryConfig, EffectiveResolveConfig, WeaverConfig,
+};
 
 #[derive(thiserror::Error, Debug, serde::Serialize, Diagnostic)]
 enum Error {
@@ -83,9 +85,14 @@ pub(crate) fn command(
     }
     args.policy.apply_to(&mut policy);
 
+    let mut resolve = EffectiveResolveConfig::default();
+    if let Some(wc) = cfg {
+        resolve.layer_config(&wc.resolve);
+    }
+
     info!("Resolving registry `{}`", registry.registry);
     let mut diag_msgs = DiagnosticMessages::empty();
-    let weaver = WeaverEngine::new(&registry, &policy, auth);
+    let weaver = WeaverEngine::new(&registry, &policy, &resolve, auth);
     let resolved = weaver.load_and_resolve_main(&mut diag_msgs)?;
 
     let target = OutputTarget::from_optional_file(args.output.as_ref());

--- a/src/registry/search.rs
+++ b/src/registry/search.rs
@@ -26,7 +26,9 @@ use ratatui::{
 use ratatui_textarea::TextArea;
 use std::io::{stdout, IsTerminal};
 use weaver_common::http_auth::HttpAuthResolver;
-use weaver_config::{EffectivePolicyConfig, EffectiveRegistryConfig, WeaverConfig};
+use weaver_config::{
+    EffectivePolicyConfig, EffectiveRegistryConfig, EffectiveResolveConfig, WeaverConfig,
+};
 
 /// Parameters for the `registry search` sub-command
 #[derive(Debug, Args)]
@@ -386,7 +388,11 @@ pub(crate) fn command(
 
     let mut diag_msgs = DiagnosticMessages::empty();
     let policy_config = EffectivePolicyConfig::skip_all();
-    let weaver = WeaverEngine::new(&registry, &policy_config, auth);
+    let mut resolve = EffectiveResolveConfig::default();
+    if let Some(wc) = cfg {
+        resolve.layer_config(&wc.resolve);
+    }
+    let weaver = WeaverEngine::new(&registry, &policy_config, &resolve, auth);
     // Load the semantic convention registry into a local cache.
     let resolved = weaver.load_and_resolve_main(&mut diag_msgs)?;
 

--- a/src/registry/stats.rs
+++ b/src/registry/stats.rs
@@ -74,7 +74,12 @@ pub(crate) fn command(
     );
 
     let mut diag_msgs = DiagnosticMessages::empty();
-    let weaver = WeaverEngine::new(&cmd_config.registry, &cmd_config.policy, auth);
+    let weaver = WeaverEngine::new(
+        &cmd_config.registry,
+        &cmd_config.policy,
+        &cmd_config.resolve,
+        auth,
+    );
     let resolved = weaver.load_and_resolve_main(&mut diag_msgs)?;
 
     if diag_msgs.has_error() {

--- a/src/registry/update_markdown.rs
+++ b/src/registry/update_markdown.rs
@@ -146,7 +146,12 @@ pub(crate) fn command(
         crate::registry::apply_template_config(&mut config, cfg);
         OutputProcessor::from_template_config(config, loader, params, OutputTarget::Stdout)?
     };
-    let weaver = WeaverEngine::new(&cmd_config.registry, &cmd_config.policy, auth);
+    let weaver = WeaverEngine::new(
+        &cmd_config.registry,
+        &cmd_config.policy,
+        &cmd_config.resolve,
+        auth,
+    );
     let resolved = weaver.load_and_resolve_main(&mut diag_msgs)?;
     let generator: Box<dyn MarkdownSnippetGenerator> = match resolved {
         crate::weaver::Resolved::V2(resolved_v2) => {

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -79,8 +79,12 @@ fn run_serve(
 
     let mut diag_msgs = DiagnosticMessages::empty();
 
-    // Create a weaver engine and load/resolve the registry using V2 schema
-    let weaver = crate::weaver::WeaverEngine::new(&cmd_config.registry, &cmd_config.policy, auth);
+    let weaver = crate::weaver::WeaverEngine::new(
+        &cmd_config.registry,
+        &cmd_config.policy,
+        &cmd_config.resolve,
+        auth,
+    );
     let resolved = weaver.load_and_resolve_main(&mut diag_msgs)?;
 
     // Convert to V2 ForgeResolvedRegistry

--- a/src/weaver.rs
+++ b/src/weaver.rs
@@ -22,9 +22,7 @@ use weaver_semconv::semconv::Versioned;
 use weaver_semconv::{registry_repo::RegistryRepo, semconv::SemConvSpecWithProvenance};
 use weaver_version::schema_changes::SchemaChanges;
 
-use weaver_config::{
-    EffectivePolicyConfig, EffectiveRegistryConfig, EffectiveResolveConfig,
-};
+use weaver_config::{EffectivePolicyConfig, EffectiveRegistryConfig, EffectiveResolveConfig};
 
 /// Visitor that runs Rego policy evaluation during semantic convention loading.
 struct PolicyVisitor<'a> {
@@ -771,9 +769,7 @@ mod tests {
     use weaver_common::diagnostic::DiagnosticMessages;
     use weaver_common::http_auth::HttpAuthResolver;
     use weaver_common::vdir::VirtualDirectoryPath;
-    use weaver_config::{
-        EffectivePolicyConfig, EffectiveRegistryConfig, EffectiveResolveConfig,
-    };
+    use weaver_config::{EffectivePolicyConfig, EffectiveRegistryConfig, EffectiveResolveConfig};
 
     use super::{Resolved, WeaverEngine};
 

--- a/src/weaver.rs
+++ b/src/weaver.rs
@@ -22,7 +22,9 @@ use weaver_semconv::semconv::Versioned;
 use weaver_semconv::{registry_repo::RegistryRepo, semconv::SemConvSpecWithProvenance};
 use weaver_version::schema_changes::SchemaChanges;
 
-use weaver_config::{EffectivePolicyConfig, EffectiveRegistryConfig};
+use weaver_config::{
+    EffectivePolicyConfig, EffectiveRegistryConfig, EffectiveResolveConfig,
+};
 
 /// Visitor that runs Rego policy evaluation during semantic convention loading.
 struct PolicyVisitor<'a> {
@@ -50,6 +52,7 @@ impl<'a> SchemaLoadingVisitor for PolicyVisitor<'a> {
 pub struct WeaverEngine<'a> {
     registry_config: &'a EffectiveRegistryConfig,
     policy_config: &'a EffectivePolicyConfig,
+    resolve_config: &'a EffectiveResolveConfig,
     /// Per-URL HTTP credential resolver built from `.weaver.toml` (`[[auth]]`).
     auth: &'a HttpAuthResolver,
 }
@@ -59,11 +62,13 @@ impl<'a> WeaverEngine<'a> {
     pub fn new(
         registry: &'a EffectiveRegistryConfig,
         policy: &'a EffectivePolicyConfig,
+        resolve: &'a EffectiveResolveConfig,
         auth: &'a HttpAuthResolver,
     ) -> Self {
         Self {
             registry_config: registry,
             policy_config: policy,
+            resolve_config: resolve,
             auth,
         }
     }
@@ -95,6 +100,7 @@ impl<'a> WeaverEngine<'a> {
             follow_symlinks: self.registry_config.follow_symlinks,
             include_unreferenced: self.registry_config.include_unreferenced,
             auth: self.auth.clone(),
+            schema_url_overrides: self.resolve_config.schema_url_overrides.clone(),
             ..Default::default()
         };
         let mut resolver = WeaverResolver::new(config);
@@ -765,7 +771,9 @@ mod tests {
     use weaver_common::diagnostic::DiagnosticMessages;
     use weaver_common::http_auth::HttpAuthResolver;
     use weaver_common::vdir::VirtualDirectoryPath;
-    use weaver_config::{EffectivePolicyConfig, EffectiveRegistryConfig};
+    use weaver_config::{
+        EffectivePolicyConfig, EffectiveRegistryConfig, EffectiveResolveConfig,
+    };
 
     use super::{Resolved, WeaverEngine};
 
@@ -784,7 +792,8 @@ mod tests {
             display_policy_coverage: false,
         };
         let auth = HttpAuthResolver::default();
-        let engine = WeaverEngine::new(&registry_config, &policy_config, &auth);
+        let resolve_config = EffectiveResolveConfig::default();
+        let engine = WeaverEngine::new(&registry_config, &policy_config, &resolve_config, &auth);
         let mut diag_msgs = DiagnosticMessages::empty();
 
         let resolved = engine
@@ -845,6 +854,80 @@ mod tests {
         assert_rendered_forge_schema(
             "tests/published_v2_registry",
             "tests/published_v2_registry/expected_schema.yaml",
+        );
+    }
+
+    #[test]
+    fn test_weaver_engine_schema_url_overrides() {
+        let registry_config = EffectiveRegistryConfig {
+            registry: VirtualDirectoryPath::LocalFolder {
+                path: "tests/v2_forge_dep/root".to_owned(),
+            },
+            v2: true,
+            follow_symlinks: false,
+            include_unreferenced: false,
+        };
+        let policy_config = EffectivePolicyConfig::skip_all();
+        let mut resolve_config = EffectiveResolveConfig::default();
+        _ = resolve_config.schema_url_overrides.insert(
+            "https://dep.example.com/schemas/1.0.0".try_into().unwrap(),
+            VirtualDirectoryPath::LocalFolder {
+                path: "tests/v2_forge_dep/dep".to_owned(),
+            },
+        );
+        let auth = HttpAuthResolver::default();
+        let engine = WeaverEngine::new(&registry_config, &policy_config, &resolve_config, &auth);
+        let mut diag_msgs = DiagnosticMessages::empty();
+
+        let resolved = engine
+            .load_and_resolve_main(&mut diag_msgs)
+            .expect("Failed to load and resolve registry with overrides");
+
+        let Resolved::V2(v2) = resolved else {
+            panic!("Expected Resolved::V2");
+        };
+        assert_eq!(
+            v2.resolved_schema().schema_url.as_str(),
+            "https://root.example.com/schemas/1.0.0"
+        );
+    }
+
+    #[test]
+    fn test_weaver_toml_resolve_override_integration() {
+        let toml_str = r#"
+[resolve.schema_url_overrides]
+"https://dep.example.com/schemas/1.0.0" = "tests/v2_forge_dep/dep"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(".weaver.toml");
+        std::fs::write(&config_path, toml_str).unwrap();
+        let config = weaver_config::load(&config_path).unwrap();
+        let mut resolve_config = EffectiveResolveConfig::default();
+        resolve_config.layer_config(&config.resolve);
+
+        let registry_config = EffectiveRegistryConfig {
+            registry: VirtualDirectoryPath::LocalFolder {
+                path: "tests/v2_forge_dep/root".to_owned(),
+            },
+            v2: true,
+            follow_symlinks: false,
+            include_unreferenced: false,
+        };
+        let policy_config = EffectivePolicyConfig::skip_all();
+        let auth = HttpAuthResolver::default();
+        let engine = WeaverEngine::new(&registry_config, &policy_config, &resolve_config, &auth);
+        let mut diag_msgs = DiagnosticMessages::empty();
+
+        let resolved = engine
+            .load_and_resolve_main(&mut diag_msgs)
+            .expect("Failed to load and resolve registry using weaver.toml overrides");
+
+        let Resolved::V2(v2) = resolved else {
+            panic!("Expected Resolved::V2");
+        };
+        assert_eq!(
+            v2.resolved_schema().schema_url.as_str(),
+            "https://root.example.com/schemas/1.0.0"
         );
     }
 }


### PR DESCRIPTION
Helps solve migration friction when moving from V1 where `schema_url` was not a hard requirement to V2 where it is.

This exposes a `[resolver]` section in `.weaver.toml` that can be used to express where to find a specific `schema_url` in the current run of weaver.