### PR TITLE
Fix attributes with no stability being dropped in the v1 to v2 conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Fix the v2 conversion dropping an attribute that has no `stability` from the signal that declares it. The v2 catalog stores a missing stability as `alpha`, but the lookup required the field to be present, so an entity could be published with an empty `identity`. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
+- Fix the v2 conversion dropping an attribute that has no `stability` from the signal that declares it. The v2 catalog stores a missing stability as `alpha`, but the lookup required the field to be present, so an entity could be published with an empty `identity`. ([#1695](https://github.com/open-telemetry/weaver/pull/1695) by @jerbly)
 - Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
 - Live-check: preserve instrumentation scope through OTLP ingestion, expose it to Rego policies, and render it in standard output. ([#1605](https://github.com/open-telemetry/weaver/pull/1605) by @McGluut)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 # Unreleased
 
 - Restore support for dependencies declared by `name` + `registry_path` in legacy (v1) manifests. ([#1696](https://github.com/open-telemetry/weaver/pull/1696) by @lmolkova)
-- Fix the v2 conversion dropping an attribute that has no `stability` from the signal that declares it. The v2 catalog stores a missing stability as `alpha`, but the lookup required the field to be present, so an entity could be published with an empty `identity`. ([#1695](https://github.com/open-telemetry/weaver/pull/1695) by @jerbly)
+- Fix the v2 conversion dropping an attribute that has no `stability` from the signal that declares it. The catalog lookup required the field to be present, so an entity could be published with an empty `identity`. A missing stability now converts to `development`, the documented default, instead of `alpha`. ([#1695](https://github.com/open-telemetry/weaver/pull/1695) by @jerbly)
 - Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#1655](https://github.com/open-telemetry/weaver/pull/1655) by @jerbly)
 - Live-check: preserve instrumentation scope through OTLP ingestion, expose it to Rego policies, and render it in standard output. ([#1605](https://github.com/open-telemetry/weaver/pull/1605) by @McGluut)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Fix the v2 conversion dropping an attribute that has no `stability` from the signal that declares it. The v2 catalog stores a missing stability as `alpha`, but the lookup required the field to be present, so an entity could be published with an empty `identity`. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
 - Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
 - Live-check: preserve instrumentation scope through OTLP ingestion, expose it to Rego policies, and render it in standard output. ([#1605](https://github.com/open-telemetry/weaver/pull/1605) by @McGluut)
 

--- a/crates/weaver_forge/expected_output/semconv_jq_fn_v2/semconv_entities.json
+++ b/crates/weaver_forge/expected_output/semconv_jq_fn_v2/semconv_entities.json
@@ -5,7 +5,7 @@
         "attributes": null,
         "brief": "",
         "root_namespace": "db",
-        "stability": "alpha",
+        "stability": "development",
         "type": "db.client"
       }
     ],

--- a/crates/weaver_forge/expected_output/semconv_jq_fn_v2/semconv_events.json
+++ b/crates/weaver_forge/expected_output/semconv_jq_fn_v2/semconv_events.json
@@ -6,7 +6,7 @@
         "brief": "",
         "name": "db.query",
         "root_namespace": "db",
-        "stability": "alpha"
+        "stability": "development"
       }
     ],
     "root_namespace": "db"

--- a/crates/weaver_forge/expected_output/semconv_jq_fn_v2/semconv_metrics.json
+++ b/crates/weaver_forge/expected_output/semconv_jq_fn_v2/semconv_metrics.json
@@ -7,7 +7,7 @@
         "instrument": "histogram",
         "name": "db.client.operation.duration",
         "root_namespace": "db",
-        "stability": "alpha",
+        "stability": "development",
         "unit": "s"
       }
     ],

--- a/crates/weaver_forge/expected_output/semconv_jq_fn_v2/semconv_spans.json
+++ b/crates/weaver_forge/expected_output/semconv_jq_fn_v2/semconv_spans.json
@@ -10,7 +10,7 @@
           "note": "A database client span."
         },
         "root_namespace": "db",
-        "stability": "alpha",
+        "stability": "development",
         "type": "db.client"
       }
     ]

--- a/crates/weaver_resolved_schema/src/v2/catalog.rs
+++ b/crates/weaver_resolved_schema/src/v2/catalog.rs
@@ -69,14 +69,14 @@ impl Catalog {
                         && a.common.note == attribute.note
                         && a.common.deprecated == attribute.deprecated
                         // A v1 attribute can have no stability. The catalog
-                        // stores such an attribute as `Alpha`, so this
-                        // comparison applies the same default. The comparison
-                        // of the annotations below does the same.
+                        // stores such an attribute with the default stability,
+                        // so this comparison applies the same default. The
+                        // comparison of the annotations below does the same.
                         && a.common.stability
                             == *attribute
                                 .stability
                                 .as_ref()
-                                .unwrap_or(&weaver_semconv::stability::Stability::Alpha)
+                                .unwrap_or(&weaver_semconv::stability::Stability::default())
                         && attribute
                             .annotations
                             .as_ref()
@@ -205,7 +205,7 @@ mod test {
                 note: "note".to_owned(),
                 // What `convert_v1_to_v2` stores for an attribute with no
                 // stability.
-                stability: Stability::Alpha,
+                stability: Stability::default(),
                 deprecated: None,
                 annotations: BTreeMap::new(),
             },

--- a/crates/weaver_resolved_schema/src/v2/catalog.rs
+++ b/crates/weaver_resolved_schema/src/v2/catalog.rs
@@ -68,11 +68,15 @@ impl Catalog {
                         && a.common.brief == attribute.brief
                         && a.common.note == attribute.note
                         && a.common.deprecated == attribute.deprecated
-                        && attribute
-                            .stability
-                            .as_ref()
-                            .map(|s| a.common.stability == *s)
-                            .unwrap_or(false)
+                        // A v1 attribute can have no stability. The catalog
+                        // stores such an attribute as `Alpha`, so this
+                        // comparison applies the same default. The comparison
+                        // of the annotations below does the same.
+                        && a.common.stability
+                            == *attribute
+                                .stability
+                                .as_ref()
+                                .unwrap_or(&weaver_semconv::stability::Stability::Alpha)
                         && attribute
                             .annotations
                             .as_ref()
@@ -182,5 +186,49 @@ mod test {
             role: None,
         });
         assert!(result2.is_some());
+    }
+
+    /// A catalog entry stores a missing stability as `Alpha`. A lookup for an
+    /// attribute with no stability must find that entry.
+    #[test]
+    fn test_lookup_defaults_missing_stability() {
+        let key = "test.key".to_owned();
+        let atype = AttributeType::PrimitiveOrArray(
+            weaver_semconv::attribute::PrimitiveOrArrayTypeSpec::String,
+        );
+        let catalog = Catalog::from_attributes(vec![Attribute {
+            key: key.clone(),
+            r#type: atype.clone(),
+            examples: None,
+            common: CommonFields {
+                brief: "brief".to_owned(),
+                note: "note".to_owned(),
+                // What `convert_v1_to_v2` stores for an attribute with no
+                // stability.
+                stability: Stability::Alpha,
+                deprecated: None,
+                annotations: BTreeMap::new(),
+            },
+            provenance: Default::default(),
+        }]);
+
+        let result = catalog.convert_ref(&crate::attribute::Attribute {
+            name: key,
+            r#type: atype,
+            brief: "brief".to_owned(),
+            examples: None,
+            tag: None,
+            requirement_level: RequirementLevel::Basic(BasicRequirementLevelSpec::Required),
+            sampling_relevant: Some(true),
+            note: "note".to_owned(),
+            stability: None,
+            deprecated: None,
+            prefix: false,
+            tags: None,
+            annotations: None,
+            value: None,
+            role: None,
+        });
+        assert!(result.is_some());
     }
 }

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -255,9 +255,7 @@ pub fn convert_v1_to_v2(
                 common: CommonFields {
                     brief: a.brief,
                     note: a.note,
-                    stability: a
-                        .stability
-                        .unwrap_or(weaver_semconv::stability::Stability::Alpha),
+                    stability: a.stability.unwrap_or_default(),
                     deprecated: a.deprecated,
                     annotations: a.annotations.unwrap_or_default(),
                 },
@@ -317,10 +315,7 @@ pub fn convert_v1_to_v2(
                         common: CommonFields {
                             brief: g.brief.clone(),
                             note: g.note.clone(),
-                            stability: g
-                                .stability
-                                .clone()
-                                .unwrap_or(weaver_semconv::stability::Stability::Alpha),
+                            stability: g.stability.clone().unwrap_or_default(),
                             deprecated: g.deprecated.clone(),
                             annotations: g.annotations.clone().unwrap_or_default(),
                         },
@@ -358,10 +353,7 @@ pub fn convert_v1_to_v2(
                             common: CommonFields {
                                 brief: g.brief.clone(),
                                 note: g.note.clone(),
-                                stability: g
-                                    .stability
-                                    .clone()
-                                    .unwrap_or(weaver_semconv::stability::Stability::Alpha),
+                                stability: g.stability.clone().unwrap_or_default(),
                                 deprecated: g.deprecated.clone(),
                                 annotations: g.annotations.clone().unwrap_or_default(),
                             },
@@ -399,10 +391,7 @@ pub fn convert_v1_to_v2(
                         common: CommonFields {
                             brief: g.brief.clone(),
                             note: g.note.clone(),
-                            stability: g
-                                .stability
-                                .clone()
-                                .unwrap_or(weaver_semconv::stability::Stability::Alpha),
+                            stability: g.stability.clone().unwrap_or_default(),
                             deprecated: g.deprecated.clone(),
                             annotations: g.annotations.clone().unwrap_or_default(),
                         },
@@ -467,10 +456,7 @@ pub fn convert_v1_to_v2(
                     common: CommonFields {
                         brief: g.brief.clone(),
                         note: g.note.clone(),
-                        stability: g
-                            .stability
-                            .clone()
-                            .unwrap_or(weaver_semconv::stability::Stability::Alpha),
+                        stability: g.stability.clone().unwrap_or_default(),
                         deprecated: g.deprecated.clone(),
                         annotations: g.annotations.clone().unwrap_or_default(),
                     },
@@ -535,10 +521,7 @@ pub fn convert_v1_to_v2(
                     common: CommonFields {
                         brief: g.brief.clone(),
                         note: g.note.clone(),
-                        stability: g
-                            .stability
-                            .clone()
-                            .unwrap_or(weaver_semconv::stability::Stability::Alpha),
+                        stability: g.stability.clone().unwrap_or_default(),
                         deprecated: g.deprecated.clone(),
                         annotations: g.annotations.clone().unwrap_or_default(),
                     },
@@ -581,10 +564,7 @@ pub fn convert_v1_to_v2(
                         common: CommonFields {
                             brief: g.brief.clone(),
                             note: g.note.clone(),
-                            stability: g
-                                .stability
-                                .clone()
-                                .unwrap_or(weaver_semconv::stability::Stability::Alpha),
+                            stability: g.stability.clone().unwrap_or_default(),
                             deprecated: g.deprecated.clone(),
                             annotations: g.annotations.clone().unwrap_or_default(),
                         },

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -165,6 +165,26 @@ fn fix_span_group_id(group_id: &str) -> SignalId {
     fix_group_id("span.", group_id)
 }
 
+/// Converts one attribute reference of a v1 group into the v1 definition and
+/// the v2 catalog reference.
+///
+/// A lookup that finds nothing is an error. Without the error, the signal loses
+/// the attribute in silence. An entity holds its identity in these attributes.
+fn convert_attribute_ref<'a>(
+    group_id: &str,
+    attr_ref: &crate::attribute::AttributeRef,
+    c: &'a crate::catalog::Catalog,
+    v2_catalog: &Catalog,
+) -> Result<(&'a crate::attribute::Attribute, attribute::AttributeRef), crate::error::Error> {
+    let not_found = || crate::error::Error::AttributeNotFound {
+        group_id: group_id.to_owned(),
+        attr_ref: *attr_ref,
+    };
+    let attr = c.attribute(attr_ref).ok_or_else(not_found)?;
+    let v2_ref = v2_catalog.convert_ref(attr).ok_or_else(not_found)?;
+    Ok((attr, v2_ref))
+}
+
 /// Converts a V1 registry + catalog to V2.
 pub fn convert_v1_to_v2(
     c: crate::catalog::Catalog,
@@ -478,24 +498,21 @@ pub fn convert_v1_to_v2(
                     .unwrap_or(false);
                 let mut id_attrs = Vec::new();
                 let mut desc_attrs = Vec::new();
-                for attr in g.attributes.iter().filter_map(|a| c.attribute(a)) {
-                    if let Some(a) = v2_catalog.convert_ref(attr) {
-                        match attr.role {
-                            Some(weaver_semconv::attribute::AttributeRole::Identifying) => {
-                                id_attrs.push(entity::EntityAttributeRef {
-                                    base: a,
-                                    requirement_level: attr.requirement_level.clone(),
-                                });
-                            }
-                            _ => {
-                                desc_attrs.push(entity::EntityAttributeRef {
-                                    base: a,
-                                    requirement_level: attr.requirement_level.clone(),
-                                });
-                            }
+                for attr_ref in g.attributes.iter() {
+                    let (attr, a) = convert_attribute_ref(&g.id, attr_ref, &c, &v2_catalog)?;
+                    match attr.role {
+                        Some(weaver_semconv::attribute::AttributeRole::Identifying) => {
+                            id_attrs.push(entity::EntityAttributeRef {
+                                base: a,
+                                requirement_level: attr.requirement_level.clone(),
+                            });
                         }
-                    } else {
-                        // TODO logic error!
+                        _ => {
+                            desc_attrs.push(entity::EntityAttributeRef {
+                                base: a,
+                                requirement_level: attr.requirement_level.clone(),
+                            });
+                        }
                     }
                 }
                 let entity_type = if is_refinement {
@@ -1213,6 +1230,145 @@ mod tests {
             assert_eq!(entity.provenance.source, Some(provenance::DependencyRef(0)));
             assert_eq!(entity.provenance.path, "/path/to/source.yaml");
         }
+    }
+
+    /// Every signal keeps an attribute that has no stability, and not only an
+    /// entity. The catalog lookup is common to all of them.
+    #[test]
+    fn test_convert_span_keeps_attribute_without_stability() {
+        let mut builder = crate::catalog::test_utils::CatalogBuilder::default();
+        let ref0 = builder.add(
+            Attribute {
+                name: "test.key".to_owned(),
+                r#type: weaver_semconv::attribute::AttributeType::PrimitiveOrArray(
+                    weaver_semconv::attribute::PrimitiveOrArrayTypeSpec::String,
+                ),
+                brief: "".to_owned(),
+                examples: None,
+                tag: None,
+                requirement_level: weaver_semconv::attribute::RequirementLevel::Basic(
+                    weaver_semconv::attribute::BasicRequirementLevelSpec::Required,
+                ),
+                sampling_relevant: None,
+                note: "".to_owned(),
+                stability: None,
+                deprecated: None,
+                prefix: false,
+                tags: None,
+                annotations: None,
+                value: None,
+                role: None,
+            },
+            None,
+        );
+        let v1_catalog = builder.build();
+        let v1_registry = crate::registry::Registry {
+            registry_url: "my.schema.url".to_owned(),
+            groups: vec![Group {
+                id: "span.my-span".to_owned(),
+                r#type: GroupType::Span,
+                brief: "".to_owned(),
+                note: "".to_owned(),
+                prefix: "".to_owned(),
+                extends: None,
+                stability: Some(Stability::Stable),
+                deprecated: None,
+                attributes: vec![ref0],
+                span_kind: Some(weaver_semconv::group::SpanKindSpec::Internal),
+                events: vec![],
+                metric_name: None,
+                instrument: None,
+                unit: None,
+                requirement_level: None,
+                name: Some("my-span".to_owned()),
+                lineage: None,
+                display_name: None,
+                body: None,
+                annotations: None,
+                entity_associations: vec![],
+                visibility: None,
+                is_v2: false,
+                span_name: None,
+            }],
+        };
+        let (_, v2_registry, _, _) =
+            convert_v1_to_v2(v1_catalog, v1_registry, BTreeSet::new()).expect("conversion failed");
+        let span = v2_registry.spans.first().expect("span present");
+        assert_eq!(span.attributes.len(), 1, "span lost the attribute");
+    }
+
+    /// An entity must keep an attribute that has no stability. A registry with
+    /// such an attribute resolves, because a missing stability is only a
+    /// warning. An entity that loses its identity attribute has no identity.
+    #[test]
+    fn test_convert_entity_keeps_attribute_without_stability() {
+        let mut builder = crate::catalog::test_utils::CatalogBuilder::default();
+        let ref0 = builder.add(
+            Attribute {
+                name: "test.key".to_owned(),
+                r#type: weaver_semconv::attribute::AttributeType::PrimitiveOrArray(
+                    weaver_semconv::attribute::PrimitiveOrArrayTypeSpec::String,
+                ),
+                brief: "".to_owned(),
+                examples: None,
+                tag: None,
+                requirement_level: weaver_semconv::attribute::RequirementLevel::Basic(
+                    weaver_semconv::attribute::BasicRequirementLevelSpec::Required,
+                ),
+                sampling_relevant: None,
+                note: "".to_owned(),
+                // The point of this test.
+                stability: None,
+                deprecated: None,
+                prefix: false,
+                tags: None,
+                annotations: None,
+                value: None,
+                role: Some(weaver_semconv::attribute::AttributeRole::Identifying),
+            },
+            None,
+        );
+        let v1_catalog = builder.build();
+        let v1_registry = crate::registry::Registry {
+            registry_url: "my.schema.url".to_owned(),
+            groups: vec![Group {
+                id: "entity.my-entity".to_owned(),
+                r#type: GroupType::Entity,
+                brief: "".to_owned(),
+                note: "".to_owned(),
+                prefix: "".to_owned(),
+                extends: None,
+                stability: Some(Stability::Stable),
+                deprecated: None,
+                attributes: vec![ref0],
+                span_kind: None,
+                events: vec![],
+                metric_name: None,
+                instrument: None,
+                unit: None,
+                requirement_level: None,
+                name: Some("my-entity".to_owned()),
+                lineage: None,
+                display_name: None,
+                body: None,
+                annotations: None,
+                entity_associations: vec![],
+                visibility: None,
+                is_v2: false,
+                span_name: None,
+            }],
+        };
+        let (_, v2_registry, _, _) =
+            convert_v1_to_v2(v1_catalog, v1_registry, BTreeSet::new()).expect("conversion failed");
+        let entity = v2_registry
+            .entities
+            .first()
+            .expect("the entity is in the v2 registry");
+        assert_eq!(
+            entity.identity.len(),
+            1,
+            "an identity attribute with no stability must not be dropped"
+        );
     }
 
     #[test]

--- a/crates/weaver_semconv/src/v2/mod.rs
+++ b/crates/weaver_semconv/src/v2/mod.rs
@@ -32,7 +32,7 @@ pub mod signal_id;
 pub mod span;
 
 /// Common fields we want on all major components of semantic conventions.
-#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Hash, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Hash, Eq, Default)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
 pub struct CommonFields {
@@ -316,18 +316,6 @@ impl SemConvSpecV2 {
             && self.event_refinements.is_empty()
             && self.metric_refinements.is_empty()
             && self.span_refinements.is_empty()
-    }
-}
-
-impl Default for CommonFields {
-    fn default() -> Self {
-        Self {
-            brief: Default::default(),
-            note: Default::default(),
-            stability: Stability::Alpha,
-            deprecated: Default::default(),
-            annotations: Default::default(),
-        }
     }
 }
 


### PR DESCRIPTION
`Catalog::convert_ref` looks up a v1 attribute in the v2 catalog by comparing every field, and the stability clause read `.map(|s| a.common.stability == *s).unwrap_or(false)`. An attribute with no `stability` therefore never matched. The catalog itself is built with `stability.unwrap_or(Alpha)`, so the entry was there all along — the lookup just could not reach it. This PR applies the same `Alpha` default on the lookup side.

A missing stability is only a warning, so registries like this resolve and reach the conversion. Every signal loop calls `convert_ref` and skips the attribute when it returns `None`, so spans, events, metrics and attribute groups all lost it in silence. Entities are where it shows: an entity that loses an identity attribute has no identity, and `registry package --v2` shipped `identity: []` with a zero exit code.

The entity loop also hit an `else { // TODO logic error! }`, which is now a `convert_attribute_ref` helper returning `AttributeNotFound`.

This is the second of a series of small PRs for entity association resolution, and it is independent of the others.