### PR TITLE
Restore support for dependencies declared by  name  in legacy (v1) manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Restore support for dependencies declared by `name` + `registry_path` in legacy (v1) manifests. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @lmolkova)
 - Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
 - Live-check: preserve instrumentation scope through OTLP ingestion, expose it to Rego policies, and render it in standard output. ([#1605](https://github.com/open-telemetry/weaver/pull/1605) by @McGluut)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-- Restore support for dependencies declared by `name` + `registry_path` in legacy (v1) manifests. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @lmolkova)
-- Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#TBD](https://github.com/open-telemetry/weaver/pull/TBD) by @jerbly)
+- Restore support for dependencies declared by `name` + `registry_path` in legacy (v1) manifests. ([#1696](https://github.com/open-telemetry/weaver/pull/1696) by @lmolkova)
+- Fix elements inherited from a transitive dependency being reported as locally defined. A resolved schema's `dependencies` set is the table that `DependencyRef` provenance indexes into, but it listed only direct dependencies, so anything reaching the registry through a dependency-of-a-dependency had no entry to point at. It now records the full closure. ([#1655](https://github.com/open-telemetry/weaver/pull/1655) by @jerbly)
 - Live-check: preserve instrumentation scope through OTLP ingestion, expose it to Rego policies, and render it in standard output. ([#1605](https://github.com/open-telemetry/weaver/pull/1605) by @McGluut)
 
 # [0.25.1] - 2026-07-28

--- a/crates/weaver_resolver/data/unversioned-conflict/dep-a/semconv.yaml
+++ b/crates/weaver_resolver/data/unversioned-conflict/dep-a/semconv.yaml
@@ -1,0 +1,7 @@
+file_format: definition/2
+attributes:
+  - key: dep.a.id
+    type: string
+    stability: stable
+    brief: Unique ID.
+    examples: ["abc123"]

--- a/crates/weaver_resolver/data/unversioned-conflict/dep-b/semconv.yaml
+++ b/crates/weaver_resolver/data/unversioned-conflict/dep-b/semconv.yaml
@@ -1,0 +1,7 @@
+file_format: definition/2
+attributes:
+  - key: dep.b.id
+    type: string
+    stability: stable
+    brief: Unique ID.
+    examples: ["abc123"]

--- a/crates/weaver_resolver/data/unversioned-conflict/main/manifest.yaml
+++ b/crates/weaver_resolver/data/unversioned-conflict/main/manifest.yaml
@@ -1,0 +1,9 @@
+name: main
+description: Two distinct registries both declared by the same name, neither versioned.
+semconv_version: 0.1.0
+schema_base_url: https://example.com/main/
+dependencies:
+  - name: dep
+    registry_path: data/unversioned-conflict/dep-a
+  - name: dep
+    registry_path: data/unversioned-conflict/dep-b

--- a/crates/weaver_resolver/data/v1-dependency-syntax/dep/manifest.yaml
+++ b/crates/weaver_resolver/data/v1-dependency-syntax/dep/manifest.yaml
@@ -1,0 +1,3 @@
+name: dep
+description: Dependency registry defining a metric.
+schema_url: https://example.com/dep/1.0.0

--- a/crates/weaver_resolver/data/v1-dependency-syntax/dep/semconv.yaml
+++ b/crates/weaver_resolver/data/v1-dependency-syntax/dep/semconv.yaml
@@ -1,0 +1,15 @@
+file_format: definition/2
+attributes:
+  - key: dep.id
+    type: string
+    stability: stable
+    brief: Unique ID.
+    examples: ["abc123"]
+metrics:
+  - name: dep.uptime
+    brief: Uptime metric defined in dep.
+    instrument: gauge
+    unit: "s"
+    stability: stable
+    attributes:
+      - ref: dep.id

--- a/crates/weaver_resolver/data/v1-dependency-syntax/main/imports.yaml
+++ b/crates/weaver_resolver/data/v1-dependency-syntax/main/imports.yaml
@@ -1,0 +1,3 @@
+imports:
+  metrics:
+    - dep.uptime

--- a/crates/weaver_resolver/data/v1-dependency-syntax/main/manifest.yaml
+++ b/crates/weaver_resolver/data/v1-dependency-syntax/main/manifest.yaml
@@ -1,0 +1,7 @@
+name: main
+description: v1 definition manifest declaring its dependency by `name` + `registry_path`.
+semconv_version: 0.1.0
+schema_base_url: https://example.com/main/
+dependencies:
+  - name: dep
+    registry_path: data/v1-dependency-syntax/dep

--- a/crates/weaver_resolver/src/error.rs
+++ b/crates/weaver_resolver/src/error.rs
@@ -45,6 +45,16 @@ pub enum Error {
     #[error("Schema URL is missing in the manifest and cannot be constructed from the registry name and version.")]
     FailToResolveSchemaUrl {},
 
+    /// A registry is declared more than once and at least one declaration has no version.
+    #[error("Registry '{name}' is declared by more than one dependency, but at least one declaration is unversioned")]
+    #[diagnostic(help(
+        "Use a `schema_url` with a semantic version, e.g. https://example.com/{name}/1.0.0."
+    ))]
+    UnversionedDependencyConflict {
+        /// The registry declared more than once.
+        name: String,
+    },
+
     /// An invalid URL.
     #[error("Invalid URL `{url:?}`, error: {error:?})")]
     #[diagnostic(help("Check the URL and try again."))]

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -11,6 +11,7 @@ use weaver_common::result::WResult;
 use weaver_resolved_schema::v2::ResolvedTelemetrySchema as V2Schema;
 use weaver_resolved_schema::ResolvedTelemetrySchema;
 use weaver_semconv::group::ImportsWithProvenance;
+use weaver_semconv::manifest::Dependency;
 use weaver_semconv::registry_repo::RegistryRepo;
 use weaver_semconv::schema_url::SchemaUrl;
 use weaver_semconv::semconv::SemConvSpecWithProvenance;
@@ -525,7 +526,7 @@ impl WeaverResolver {
                 Err(e) => return WResult::FatalErr(Error::FailToResolveDefinition(e)),
             }
         } else {
-            let dep = weaver_semconv::manifest::Dependency {
+            let dep = Dependency {
                 schema_url: schema_url.clone(),
                 registry_path: None,
             };
@@ -1889,12 +1890,32 @@ groups:
     }
 
     #[test]
+    fn test_v1_manifest_resolves_dependency_declared_by_name() {
+        // `main` is a v1 manifest, where `name` + `registry_path` stays supported.
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/v1-dependency-syntax/main".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])
+            .expect("a v1 manifest may declare dependencies by name");
+        let mut resolver = WeaverResolver::new(WeaverResolverConfig::default());
+        let resolved = match resolver.load_and_resolve_schema(registry_repo, DefaultSchemaVisitor) {
+            WResult::Ok(r) | WResult::OkWithNFEs(r, _) => r.into_v1().unwrap(),
+            WResult::FatalErr(e) => panic!("Failed to resolve schema: {e}"),
+        };
+        assert!(
+            resolved
+                .groups(GroupType::Metric)
+                .values()
+                .any(|g| g.metric_name.as_deref() == Some("dep.uptime")),
+            "expected the imported metric from the dependency to resolve"
+        );
+    }
+
+    #[test]
     fn test_dependency_without_schema_url_is_rejected() {
-        // `main`'s manifest declares its dependency with only `name` and
-        // `registry_path`. `schema_url` is mandatory for dependencies — it is
-        // the identity that provenance and version-conflict resolution key
-        // on — so this must fail with an error naming the offending
-        // dependency.
+        // `main` is a v2 manifest (it declares its own `schema_url`) but declares its
+        // dependency with only `name` and `registry_path`. `schema_url` is mandatory there --
+        // it is the identity provenance and version-conflict resolution key on.
         let registry_path = VirtualDirectoryPath::LocalFolder {
             path: "data/mandatory-schema-url/main".to_owned(),
         };

--- a/crates/weaver_resolver/src/loader.rs
+++ b/crates/weaver_resolver/src/loader.rs
@@ -13,6 +13,7 @@ use walkdir::DirEntry;
 use weaver_common::result::WResult;
 use weaver_resolved_schema::v2::ResolvedTelemetrySchema as V2Schema;
 use weaver_resolved_schema::ResolvedTelemetrySchema as V1Schema;
+use weaver_semconv::manifest::Dependency;
 use weaver_semconv::registry_repo::{RegistryRepo, LEGACY_REGISTRY_MANIFEST, REGISTRY_MANIFEST};
 use weaver_semconv::schema_url::SchemaUrl;
 use weaver_semconv::{group::ImportsWithProvenance, semconv::SemConvSpecWithProvenance};
@@ -322,24 +323,19 @@ fn load_semconv_repository_recursive(
             // Load dependencies.
             let mut loaded_dependencies = vec![];
             let mut non_fatal_errors: Vec<Error> = vec![];
-            let mut seen_dependencies: std::collections::HashMap<String, SchemaUrl> =
+            let mut seen_dependencies: std::collections::HashMap<String, &Dependency> =
                 std::collections::HashMap::new();
 
             for d in manifest.dependencies().iter() {
                 let dep_name = d.schema_url.name().to_owned();
-
-                if let Some(prev_schema_url) = seen_dependencies.get(&dep_name) {
-                    if prev_schema_url != &d.schema_url {
-                        if let Err(e) =
-                            check_version_compatibility(&dep_name, prev_schema_url, &d.schema_url)
-                        {
-                            // Clean up the state of dependency_chain before erroring.
-                            let _ = dependency_chain.pop();
-                            return WResult::FatalErr(e);
-                        }
+                if let Some(prev) = seen_dependencies.get(&dep_name) {
+                    if let Err(e) = check_version_compatibility(prev, d) {
+                        // Clean up the state of dependency_chain before erroring.
+                        let _ = dependency_chain.pop();
+                        return WResult::FatalErr(e);
                     }
                 } else {
-                    let _ = seen_dependencies.insert(dep_name, d.schema_url.clone());
+                    let _ = seen_dependencies.insert(dep_name, d);
                 }
                 let mut semconv_nfes: Vec<weaver_semconv::Error> = vec![];
                 match RegistryRepo::try_new_dependency_with_auth(d, &mut semconv_nfes, auth) {
@@ -537,13 +533,17 @@ fn load_definition_repository(
     )
 }
 
-/// Checks version compatibility between two schema URLs.
-fn check_version_compatibility(
-    _registry_name: &str,
-    prev_schema_url: &SchemaUrl,
-    schema_url: &SchemaUrl,
-) -> Result<(), Error> {
-    let _ = UseLatestMajorVersion.resolve_conflict(prev_schema_url, schema_url)?;
+/// Checks that two declarations of the same registry can be reconciled.
+///
+/// An unversioned declaration has nothing to compare against, so it must be the only one for
+/// its registry.
+fn check_version_compatibility(prev: &Dependency, dep: &Dependency) -> Result<(), Error> {
+    if !prev.is_versioned() || !dep.is_versioned() {
+        return Err(Error::UnversionedDependencyConflict {
+            name: dep.schema_url.name().to_owned(),
+        });
+    }
+    let _ = UseLatestMajorVersion.resolve_conflict(&prev.schema_url, &dep.schema_url)?;
     Ok(())
 }
 
@@ -640,6 +640,33 @@ mod tests {
                 panic!("Expected fatal error due to depth limit, but got success");
             }
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_two_unversioned_dependencies_under_the_same_name_are_fatal(
+    ) -> Result<(), weaver_semconv::Error> {
+        // Both dependencies are declared by `name: dep` and neither registry carries a
+        // version, so they collapse onto the same placeholder schema URL. There is nothing
+        // to reconcile them against, so this must fail rather than silently pick one.
+        let registry_path = VirtualDirectoryPath::LocalFolder {
+            path: "data/unversioned-conflict/main".to_owned(),
+        };
+        let registry_repo = RegistryRepo::try_new(None, &registry_path, &mut vec![])?;
+        let result = load_semconv_repository(
+            registry_repo,
+            true,
+            &weaver_common::http_auth::HttpAuthResolver::empty(),
+        );
+
+        let WResult::FatalErr(fatal) = result else {
+            panic!("Expected a fatal error for two unversioned declarations of 'dep'");
+        };
+        assert!(
+            matches!(fatal, Error::UnversionedDependencyConflict { ref name, .. } if name == "dep"),
+            "Expected an unversioned dependency conflict on 'dep', got: {fatal}"
+        );
 
         Ok(())
     }

--- a/crates/weaver_semconv/src/lib.rs
+++ b/crates/weaver_semconv/src/lib.rs
@@ -417,6 +417,17 @@ pub enum Error {
         schema_url: String,
     },
 
+    /// A registry whose dependencies do not pin a version cannot be packaged.
+    #[error("Dependency `{schema_url}` (registry_path: {}) does not pin a version, which a publication manifest requires. Declare it with a versioned `schema_url` before packaging.", .registry_path.as_deref().unwrap_or("not specified"))]
+    #[diagnostic(severity(Error))]
+    UnversionedDependencyInPublication {
+        /// The schema URL of the dependency, which carries no usable version.
+        /// It is a placeholder when the dependency is declared by `name`.
+        schema_url: String,
+        /// Where the dependency's files were declared to live, if anywhere.
+        registry_path: Option<String>,
+    },
+
     /// A schema_url has an invalid version component.
     #[error("Registry `{schema_url}` contains an invalid version: {err}.")]
     #[diagnostic(severity(Error))]

--- a/crates/weaver_semconv/src/manifest.rs
+++ b/crates/weaver_semconv/src/manifest.rs
@@ -115,8 +115,10 @@ impl Dependency {
     /// only) does not: it names a registry without saying which version of it, so it cannot be
     /// reconciled with any other declaration of the same registry.
     ///
-    /// Only the minted placeholder counts as unversioned; a `schema_url` whose version segment
-    /// is not valid semver is still an author-supplied version.
+    /// Detected by the version segment, so a `schema_url` an author wrote as `.../unknown`
+    /// counts as unversioned too. That is the intent: it says no more about which version is
+    /// wanted than the minted placeholder does. Any other segment is treated as a version,
+    /// valid semver or not.
     #[must_use]
     pub fn is_versioned(&self) -> bool {
         self.schema_url.version() != UNKNOWN_VERSION
@@ -135,6 +137,13 @@ const UNKNOWN_VERSION: &str = "unknown";
 /// declare a dependency by `name`, which then gets a placeholder, unversioned schema URL minted
 /// from that name.
 fn parse_dependency(value: serde_yaml::Value, strict: bool) -> Result<Dependency, String> {
+    #[derive(Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct NamedDependency {
+        name: String,
+        registry_path: VirtualDirectoryPath,
+    }
+
     if value.get("schema_url").is_some() {
         return serde_yaml::from_value(value).map_err(|e| e.to_string());
     }
@@ -149,12 +158,6 @@ fn parse_dependency(value: serde_yaml::Value, strict: bool) -> Result<Dependency
         ));
     }
 
-    #[derive(Deserialize)]
-    #[serde(deny_unknown_fields)]
-    struct NamedDependency {
-        name: String,
-        registry_path: VirtualDirectoryPath,
-    }
     let named: NamedDependency = serde_yaml::from_value(value).map_err(|e| e.to_string())?;
     Ok(Dependency {
         schema_url: SchemaUrl::try_from_name_version(&named.name, UNKNOWN_VERSION)?,

--- a/crates/weaver_semconv/src/manifest.rs
+++ b/crates/weaver_semconv/src/manifest.rs
@@ -19,7 +19,7 @@ use crate::Error::{
     RegistryManifestNotFound,
 };
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use weaver_common::vdir::VirtualDirectoryPath;
 
 /// The file format version of the publication manifest.
@@ -30,7 +30,7 @@ pub const PUBLICATION_MANIFEST_FILE_FORMAT: &str = "manifest/2.0";
 /// This is used when developing a registry before it is published.
 /// See [`PublicationRegistryManifest`] for the stricter publication form produced
 /// by `weaver registry package`.
-#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[derive(Serialize, Debug, Clone, JsonSchema)]
 pub struct DefinitionRegistryManifest {
     /// The schema URL for this registry.
     /// This URL is populated before registry is published and is used as
@@ -48,8 +48,6 @@ pub struct DefinitionRegistryManifest {
     pub description: Option<String>,
 
     /// List of the registry's dependencies.
-    /// Note: In the current phase, we only support zero or one dependency.
-    /// See this GH issue for more details: <https://github.com/open-telemetry/weaver/issues/604>
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub dependencies: Vec<Dependency>,
 
@@ -92,7 +90,7 @@ impl DefinitionRegistryManifest {
 }
 
 /// Represents a dependency of a semantic convention registry.
-#[derive(Serialize, Debug, Clone, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 pub struct Dependency {
     /// The schema URL for the dependency (required).
     /// It must follow OTel schema URL format, which is: `http[s]://server[:port]/path/<version>`.
@@ -108,47 +106,60 @@ pub struct Dependency {
     /// This can be either:
     /// - A manifest of a published registry
     /// - A directory containing the raw definition.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub registry_path: Option<VirtualDirectoryPath>,
 }
 
-impl<'de> Deserialize<'de> for Dependency {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct DependencyHelper {
-            name: Option<String>,
-            schema_url: Option<SchemaUrl>,
-            registry_path: Option<VirtualDirectoryPath>,
-        }
-
-        let helper = DependencyHelper::deserialize(deserializer)?;
-
-        let schema_url = match (helper.schema_url, helper.name) {
-            (Some(url), _) => url,
-            (None, Some(name)) => {
-                return Err(serde::de::Error::custom(format!(
-                    "missing required field 'schema_url' for dependency '{name}'. \
-                     The schema_url uniquely identifies the dependency registry and its \
-                     version, e.g. https://example.com/{name}/1.0.0"
-                )))
-            }
-            (None, None) => {
-                return Err(serde::de::Error::custom(
-                    "missing required field 'schema_url' for a dependency. \
-                     The schema_url uniquely identifies the dependency registry and its \
-                     version, e.g. https://example.com/my-registry/1.0.0",
-                ))
-            }
-        };
-
-        Ok(Dependency {
-            schema_url,
-            registry_path: helper.registry_path,
-        })
+impl Dependency {
+    /// Whether the declaration pins a version. A dependency declared by `name` (v1 manifests
+    /// only) does not: it names a registry without saying which version of it, so it cannot be
+    /// reconciled with any other declaration of the same registry.
+    ///
+    /// Only the minted placeholder counts as unversioned; a `schema_url` whose version segment
+    /// is not valid semver is still an author-supplied version.
+    #[must_use]
+    pub fn is_versioned(&self) -> bool {
+        self.schema_url.version() != UNKNOWN_VERSION
     }
+}
+
+const SCHEMA_URL_HELP: &str = "The schema_url uniquely identifies the dependency registry \
+                               and its version, e.g. https://example.com/my-registry/1.0.0";
+
+/// The version given to a dependency declared by `name`, which carries none.
+const UNKNOWN_VERSION: &str = "unknown";
+
+/// Parses a dependency declaration, discriminating on which identifying field it declares.
+///
+/// `strict` is set for v2 manifests, which require `schema_url`. A v1 manifest may instead
+/// declare a dependency by `name`, which then gets a placeholder, unversioned schema URL minted
+/// from that name.
+fn parse_dependency(value: serde_yaml::Value, strict: bool) -> Result<Dependency, String> {
+    if value.get("schema_url").is_some() {
+        return serde_yaml::from_value(value).map_err(|e| e.to_string());
+    }
+    let name = value.get("name").and_then(serde_yaml::Value::as_str);
+    if strict || name.is_none() {
+        let subject = name.map_or_else(
+            || "a dependency".to_owned(),
+            |name| format!("dependency '{name}'"),
+        );
+        return Err(format!(
+            "{subject} is missing the required field 'schema_url'. {SCHEMA_URL_HELP}"
+        ));
+    }
+
+    #[derive(Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct NamedDependency {
+        name: String,
+        registry_path: VirtualDirectoryPath,
+    }
+    let named: NamedDependency = serde_yaml::from_value(value).map_err(|e| e.to_string())?;
+    Ok(Dependency {
+        schema_url: SchemaUrl::try_from_name_version(&named.name, UNKNOWN_VERSION)?,
+        registry_path: Some(named.registry_path),
+    })
 }
 
 /// Raw helper for deserializing a manifest before validation.
@@ -162,8 +173,10 @@ struct RawManifestFields {
     semconv_version: Option<String>,
     #[allow(deprecated)]
     schema_base_url: Option<String>,
+    /// Parsed once the manifest version is known: only v1 manifests may declare a dependency
+    /// by `name`.
     #[serde(default)]
-    dependencies: Vec<Dependency>,
+    dependencies: Vec<serde_yaml::Value>,
     #[serde(default)]
     stability: Stability,
     resolved_registry_uri: Option<String>,
@@ -180,6 +193,15 @@ impl RawManifestFields {
                 .ok_or_else(|| Error::InvalidPublicationManifest {
                     path: path.to_path_buf(),
                     details: "missing required field 'schema_url'".into(),
+                })?;
+            let dependencies = self
+                .dependencies
+                .into_iter()
+                .map(|value| parse_dependency(value, true))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|details| Error::InvalidPublicationManifest {
+                    path: path.to_path_buf(),
+                    details,
                 })?;
             let mut warnings = vec![];
             let resolved_registry_uri = match (self.resolved_registry_uri, self.resolved_schema_uri)
@@ -203,7 +225,7 @@ impl RawManifestFields {
                 file_format: PUBLICATION_MANIFEST_FILE_FORMAT.to_owned(),
                 schema_url,
                 description: self.description,
-                dependencies: self.dependencies,
+                dependencies,
                 stability: self.stability,
                 resolved_registry_uri,
                 deserialization_warnings: warnings,
@@ -218,6 +240,9 @@ impl RawManifestFields {
                     ),
                 });
             }
+            // Only v1 manifests -- those identified by `schema_base_url` + `semconv_version`
+            // rather than `schema_url` -- may declare dependencies by `name`.
+            let is_v1 = self.schema_url.is_none();
             let schema_url = if let Some(url) = self.schema_url {
                 url
             } else {
@@ -242,10 +267,19 @@ impl RawManifestFields {
                     }
                 })?
             };
+            let dependencies = self
+                .dependencies
+                .into_iter()
+                .map(|value| parse_dependency(value, !is_v1))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| InvalidRegistryManifest {
+                    path: path.to_path_buf(),
+                    error,
+                })?;
             Ok(RegistryManifest::Definition(DefinitionRegistryManifest {
                 schema_url,
                 description: self.description,
-                dependencies: self.dependencies,
+                dependencies,
                 stability: self.stability,
                 deserialization_warnings: warnings,
             }))
@@ -360,7 +394,7 @@ impl RegistryManifest {
 /// This is produced by `weaver registry package` and describes the contents of
 /// a self-contained registry artifact, including the URI of the resolved
 /// registry artifact (`resolved.yaml`).
-#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[derive(Serialize, Debug, Clone, JsonSchema)]
 pub struct PublicationRegistryManifest {
     /// The file format version of this publication manifest.
     /// Always `"manifest/2.0"`in this version.
@@ -394,20 +428,40 @@ pub struct PublicationRegistryManifest {
 impl PublicationRegistryManifest {
     /// Creates a `PublicationRegistryManifest` from a `DefinitionRegistryManifest` and a
     /// `resolved_registry_uri` pointing to where the resolved registry will be published.
-    #[must_use]
+    ///
+    /// Dependencies are reduced to their `schema_url`: `registry_path` points at the author's
+    /// machine and means nothing to a consumer of the published registry, who locates the
+    /// dependency by its schema URL. That URL must pin a version, which rules out dependencies
+    /// declared by `name`.
     pub fn try_from_registry_manifest(
         registry_manifest: &DefinitionRegistryManifest,
         resolved_registry_uri: String,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, Error> {
+        let dependencies = registry_manifest
+            .dependencies
+            .iter()
+            .map(|dependency| {
+                if !dependency.is_versioned() {
+                    return Err(Error::UnversionedDependencyInPublication {
+                        schema_url: dependency.schema_url.to_string(),
+                        registry_path: dependency.registry_path.as_ref().map(ToString::to_string),
+                    });
+                }
+                Ok(Dependency {
+                    schema_url: dependency.schema_url.clone(),
+                    registry_path: None,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
             file_format: PUBLICATION_MANIFEST_FILE_FORMAT.to_owned(),
             schema_url: registry_manifest.schema_url.clone(),
             description: registry_manifest.description.clone(),
-            dependencies: registry_manifest.dependencies.clone(),
+            dependencies,
             stability: registry_manifest.stability.clone(),
             resolved_registry_uri,
             deserialization_warnings: vec![],
-        }
+        })
     }
 }
 
@@ -469,26 +523,46 @@ mod tests {
     }
 
     // Dependency tests
+    /// Parses as a v1 manifest would: both dependency shapes are accepted.
+    fn dep_from_yaml_lenient(yaml: &str) -> Result<Dependency, String> {
+        parse_dependency(serde_yaml::from_str(yaml).expect("invalid YAML"), false)
+    }
+
+    /// Parses as a v2 manifest would: only the `schema_url` shape is accepted.
+    fn dep_from_yaml_strict(yaml: &str) -> Result<Dependency, String> {
+        parse_dependency(serde_yaml::from_str(yaml).expect("invalid YAML"), true)
+    }
+
+    fn dep(schema_url: &str, registry_path: Option<&str>) -> Dependency {
+        Dependency {
+            schema_url: schema_url.try_into().unwrap(),
+            registry_path: registry_path.map(|path| VirtualDirectoryPath::LocalFolder {
+                path: path.to_owned(),
+            }),
+        }
+    }
+
     #[test]
     fn test_dependency_deserialize_with_schema_url() {
-        let yaml = r#"
-schema_url: "https://opentelemetry.io/schemas/1.0.0"
-"#;
-        let dep: Dependency = serde_yaml::from_str(yaml).expect("Failed to deserialize");
+        let dep = dep_from_yaml_lenient(r#"schema_url: "https://opentelemetry.io/schemas/1.0.0""#)
+            .expect("Failed to deserialize");
         assert_eq!(
             dep.schema_url.as_str(),
             "https://opentelemetry.io/schemas/1.0.0"
         );
         assert!(dep.registry_path.is_none());
+        assert!(dep.is_versioned());
     }
 
     #[test]
     fn test_dependency_deserialize_with_registry_path() {
-        let yaml = r#"
+        let dep = dep_from_yaml_lenient(
+            r#"
 schema_url: "https://opentelemetry.io/schemas/1.0.0"
 registry_path: "./registry"
-"#;
-        let dep: Dependency = serde_yaml::from_str(yaml).expect("Failed to deserialize");
+"#,
+        )
+        .expect("Failed to deserialize");
         assert_eq!(
             dep.schema_url.as_str(),
             "https://opentelemetry.io/schemas/1.0.0"
@@ -497,26 +571,67 @@ registry_path: "./registry"
     }
 
     #[test]
-    fn test_dependency_deserialize_name_only_is_rejected() {
-        let yaml = r#"
+    fn test_v1_dependency_accepts_name_and_registry_path() {
+        let dep = dep_from_yaml_lenient(
+            r#"
 name: "acme-registry"
-"#;
-        let err = serde_yaml::from_str::<Dependency>(yaml)
-            .expect_err("a dependency without 'schema_url' must be rejected");
-        let msg = err.to_string();
+registry_path: "./registry"
+"#,
+        )
+        .expect("v1 manifests must keep supporting dependencies declared by name");
+        assert_eq!(dep.schema_url.as_str(), "https://acme-registry/unknown");
         assert!(
-            msg.contains("schema_url") && msg.contains("acme-registry"),
-            "error should name the dependency missing 'schema_url'; got: {msg}"
+            !dep.is_versioned(),
+            "a dependency declared without 'schema_url' carries no version"
+        );
+    }
+
+    /// A version segment that is not semver is still a version the author supplied, so it must
+    /// not be mistaken for the placeholder minted from a `name`.
+    #[test]
+    fn test_non_semver_schema_url_is_versioned() {
+        let dep = dep_from_yaml_lenient(r#"schema_url: "https://example.com/dep/1.0""#)
+            .expect("Failed to deserialize");
+        assert!(dep.schema_url.semver().is_err());
+        assert!(dep.is_versioned());
+    }
+
+    #[test]
+    fn test_v1_dependency_name_without_registry_path_is_rejected() {
+        // A dependency declared by `name` has no `schema_url` to locate the files with,
+        // so `registry_path` is required.
+        let err = dep_from_yaml_lenient(r#"name: "acme-registry""#)
+            .expect_err("a dependency with no identity and no path cannot be located");
+        assert!(
+            err.contains("registry_path"),
+            "error should report the missing 'registry_path'; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_v2_dependency_name_only_is_rejected() {
+        let err = dep_from_yaml_strict(
+            r#"
+name: "acme-registry"
+registry_path: "./registry"
+"#,
+        )
+        .expect_err("a v2 manifest must reject a dependency declared by name");
+        assert!(
+            err.contains("schema_url") && err.contains("acme-registry"),
+            "error should name the dependency missing 'schema_url'; got: {err}"
         );
     }
 
     #[test]
     fn test_dependency_deserialize_schema_url_takes_precedence() {
-        let yaml = r#"
+        let dep = dep_from_yaml_lenient(
+            r#"
 schema_url: "https://opentelemetry.io/schemas/1.0.0"
 name: "ignored-name"
-"#;
-        let dep: Dependency = serde_yaml::from_str(yaml).expect("Failed to deserialize");
+"#,
+        )
+        .expect("Failed to deserialize");
         assert_eq!(
             dep.schema_url.as_str(),
             "https://opentelemetry.io/schemas/1.0.0"
@@ -525,69 +640,41 @@ name: "ignored-name"
 
     #[test]
     fn test_dependency_deserialize_missing_both_fields() {
-        let yaml = r#"
-registry_path: "./registry"
-"#;
-        let result: Result<Dependency, _> = serde_yaml::from_str(yaml);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("missing required field 'schema_url'"));
+        for result in [
+            dep_from_yaml_lenient(r#"registry_path: "./registry""#),
+            dep_from_yaml_strict(r#"registry_path: "./registry""#),
+        ] {
+            let err = result.expect_err("a dependency with no identity must be rejected");
+            assert!(err.contains("schema_url"), "got: {err}");
+        }
     }
 
     #[test]
     fn test_dependency_serialize() {
-        let dep = Dependency {
-            schema_url: "https://opentelemetry.io/schemas/1.0.0".try_into().unwrap(),
-            registry_path: None,
-        };
-
-        let yaml = serde_yaml::to_string(&dep).expect("Failed to serialize");
-        // Verify schema_url is serialized
+        let yaml = serde_yaml::to_string(&dep("https://opentelemetry.io/schemas/1.0.0", None))
+            .expect("Failed to serialize");
         assert!(yaml.contains("schema_url"));
         assert!(yaml.contains("https://opentelemetry.io/schemas/1.0.0"));
-        // Verify name is NOT serialized (skip_serializing)
-        assert!(!yaml.contains("name:"));
+        // `registry_path` is skipped when None.
+        assert!(!yaml.contains("registry_path"));
     }
 
     #[test]
     fn test_dependency_serialize_with_registry_path() {
-        let dep = Dependency {
-            schema_url: "https://opentelemetry.io/schemas/1.0.0".try_into().unwrap(),
-            registry_path: Some(VirtualDirectoryPath::LocalFolder {
-                path: "./registry".to_owned(),
-            }),
-        };
-
-        let yaml = serde_yaml::to_string(&dep).expect("Failed to serialize");
+        let yaml = serde_yaml::to_string(&dep(
+            "https://opentelemetry.io/schemas/1.0.0",
+            Some("./registry"),
+        ))
+        .expect("Failed to serialize");
         assert!(yaml.contains("schema_url"));
         assert!(yaml.contains("registry_path"));
     }
 
     #[test]
-    fn test_dependency_serialize_without_optional_path() {
-        let dep = Dependency {
-            schema_url: "https://opentelemetry.io/schemas/1.0.0".try_into().unwrap(),
-            registry_path: None,
-        };
-
-        let yaml = serde_yaml::to_string(&dep).expect("Failed to serialize");
-        // registry_path should not be serialized when None (skip_serializing_if)
-        assert!(!yaml.contains("registry_path"));
-    }
-
-    #[test]
     fn test_dependency_roundtrip_serialization() {
-        let original = Dependency {
-            schema_url: "https://example.com/schemas/1.0.0".try_into().unwrap(),
-            registry_path: Some(VirtualDirectoryPath::LocalFolder {
-                path: "./test/registry".to_owned(),
-            }),
-        };
-
+        let original = dep("https://example.com/schemas/1.0.0", Some("./test/registry"));
         let yaml = serde_yaml::to_string(&original).expect("Failed to serialize");
-        let deserialized: Dependency = serde_yaml::from_str(&yaml).expect("Failed to deserialize");
+        let deserialized = dep_from_yaml_lenient(&yaml).expect("Failed to deserialize");
 
         assert_eq!(original.schema_url, deserialized.schema_url);
         assert!(deserialized.registry_path.is_some());
@@ -727,7 +814,8 @@ stability: stable
         let publication = PublicationRegistryManifest::try_from_registry_manifest(
             &definition,
             resolved_registry_uri.clone(),
-        );
+        )
+        .expect("Failed to build the publication manifest");
 
         assert_eq!(publication.file_format, PUBLICATION_MANIFEST_FILE_FORMAT);
         assert_eq!(
@@ -738,6 +826,81 @@ stability: stable
         assert_eq!(publication.stability, Stability::Stable);
         assert!(publication.dependencies.is_empty());
         assert_eq!(publication.resolved_registry_uri, resolved_registry_uri);
+    }
+
+    /// The local `registry_path` of a dependency is not published: consumers locate the
+    /// dependency by its schema URL, and the path only exists on the author's machine.
+    #[test]
+    fn test_from_registry_manifest_drops_dependency_registry_path() {
+        let manifest = manifest_from_yaml(
+            r#"
+schema_url: "https://example.com/schemas/1.0.0"
+dependencies:
+  - schema_url: "https://example.com/dep/2.0.0"
+    registry_path: "/home/author/dep/registry"
+"#,
+            &mut vec![],
+        )
+        .expect("Failed to load RegistryManifest");
+
+        let RegistryManifest::Definition(definition) = manifest else {
+            panic!("Expected a Definition manifest");
+        };
+
+        let publication = PublicationRegistryManifest::try_from_registry_manifest(
+            &definition,
+            "https://example.com/resolved/1.0.0/resolved.yaml".to_owned(),
+        )
+        .expect("Failed to build the publication manifest");
+
+        let [dependency] = publication.dependencies.as_slice() else {
+            panic!("expected exactly one dependency");
+        };
+        assert_eq!(
+            dependency.schema_url.as_str(),
+            "https://example.com/dep/2.0.0"
+        );
+        assert!(dependency.registry_path.is_none());
+
+        // The result must round-trip through the publication manifest reader.
+        let yaml = serde_yaml::to_string(&publication).expect("Failed to serialize");
+        let reparsed =
+            manifest_from_yaml(&yaml, &mut vec![]).expect("publication manifest is not readable");
+        assert!(matches!(reparsed, RegistryManifest::Publication(_)));
+    }
+
+    /// A dependency declared with the v1 `name` syntax carries no version, so it cannot be
+    /// published; packaging must fail rather than emit a manifest the reader rejects.
+    #[test]
+    fn test_from_registry_manifest_rejects_v1_dependency() {
+        let manifest = manifest_from_yaml(
+            r#"
+schema_base_url: "https://example.com/schemas"
+semconv_version: "1.0.0"
+dependencies:
+  - name: "acme-registry"
+    registry_path: "/home/author/dep/registry"
+"#,
+            &mut vec![],
+        )
+        .expect("Failed to load RegistryManifest");
+
+        let RegistryManifest::Definition(definition) = manifest else {
+            panic!("Expected a Definition manifest");
+        };
+
+        let result = PublicationRegistryManifest::try_from_registry_manifest(
+            &definition,
+            "https://example.com/resolved/1.0.0/resolved.yaml".to_owned(),
+        );
+        assert!(matches!(
+            result,
+            Err(Error::UnversionedDependencyInPublication {
+                schema_url,
+                registry_path,
+            }) if schema_url == "https://acme-registry/unknown"
+                && registry_path.as_deref() == Some("/home/author/dep/registry")
+        ));
     }
 
     #[test]

--- a/docs/define-your-own-telemetry-schema.md
+++ b/docs/define-your-own-telemetry-schema.md
@@ -38,6 +38,12 @@ can actually be fetched from — the files themselves are located via
 `registry_path` — but it must follow the OTel schema URL format and include a
 version segment.
 
+Legacy manifests that identify themselves with `schema_base_url` +
+`semconv_version` instead of `schema_url` may still declare a dependency by
+`name` + `registry_path`. Such a dependency carries no version, so it cannot be
+declared twice, and `weaver registry package` rejects it — give it a
+`schema_url` before publishing.
+
 > **Current limitations**:
 > - Weaver supports a maximum of 10 registry levels without circular
     dependencies. In practice, this is not a limitation, even for complex

--- a/schemas/definition-manifest.v2.json
+++ b/schemas/definition-manifest.v2.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "dependencies": {
-      "description": "List of the registry's dependencies.\nNote: In the current phase, we only support zero or one dependency.\nSee this GH issue for more details: <https://github.com/open-telemetry/weaver/issues/604>",
+      "description": "List of the registry's dependencies.",
       "type": "array",
       "items": {
         "$ref": "#/$defs/Dependency"

--- a/src/registry/package.rs
+++ b/src/registry/package.rs
@@ -136,7 +136,7 @@ pub(crate) fn command(
     let publication_manifest = PublicationRegistryManifest::try_from_registry_manifest(
         &definition_manifest,
         resolved_registry_uri,
-    );
+    )?;
 
     write_yaml(&output.join("resolved.yaml"), resolved_v2.resolved_schema())?;
     write_yaml(&output.join("manifest.yaml"), &publication_manifest)?;
@@ -221,10 +221,10 @@ mod tests {
         // manifest.yaml must exist and contain the correct fields
         let manifest_path = output.path().join("manifest.yaml");
         assert!(manifest_path.exists(), "manifest.yaml not written");
-        let manifest_content =
-            fs::read_to_string(&manifest_path).expect("failed to read manifest.yaml");
-        let manifest: PublicationRegistryManifest =
-            serde_yaml::from_str(&manifest_content).expect("manifest.yaml is not valid YAML");
+        let manifest = match RegistryManifest::try_from_file(&manifest_path, &mut vec![]) {
+            Ok(RegistryManifest::Publication(manifest)) => manifest,
+            other => panic!("expected manifest.yaml to be a publication manifest, got: {other:?}"),
+        };
 
         assert_eq!(manifest.file_format, PUBLICATION_MANIFEST_FILE_FORMAT);
         assert_eq!(manifest.schema_url.as_str(), "https://test/schemas/1.0.0");


### PR DESCRIPTION
replace https://github.com/open-telemetry/weaver/pull/1690

fix regression introduced in 0.25.x where we started rejecting definition manifests where dependencies don't list schema_url. this is right behavior for v2, but a breaking change for v1. fixing for v1.