### PR TITLE
live-check: benchmark Rego shared context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +74,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -435,6 +450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +527,33 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf 0.12.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -708,6 +756,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +874,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -2214,6 +2303,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,6 +2773,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3448,6 +3557,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3623,6 +3738,16 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "palette"
@@ -3854,6 +3979,34 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -5492,6 +5645,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6427,6 +6590,7 @@ name = "weaver_live_check"
 version = "0.25.1"
 dependencies = [
  "assert_cmd",
+ "criterion",
  "globset",
  "log",
  "miette",

--- a/crates/weaver_live_check/Cargo.toml
+++ b/crates/weaver_live_check/Cargo.toml
@@ -31,6 +31,7 @@ strum = { version = "0.27.2", features = ["derive"] }
 globset.workspace = true
 
 [dev-dependencies]
+criterion = "0.8"
 weaver_test_support = { path = "../weaver_test_support" }
 assert_cmd.workspace = true
 tempfile.workspace = true
@@ -39,6 +40,10 @@ serial_test = "3.4.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 ureq.workspace = true
 reqwest.workspace = true
+
+[[bench]]
+name = "rego_advisor"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/weaver_live_check/README.md
+++ b/crates/weaver_live_check/README.md
@@ -162,6 +162,12 @@ make_finding(id, level, context, message) := {
 `input.registry_group`, when present, contains the matching group definition from the supplied registry.
 
 `data` contains a structure derived from the supplied `Registry`. A jq preprocessor takes the `Registry` (and maps for attributes and templates) to produce the `data` for the policy. If the jq is simply `.` this will passthrough as-is. Preprocessing is used to improve Rego performance and to simplify policy definitions. With this model `data` is processed once whereas the Rego policy runs for every sample entity as it arrives in the stream.
+### Rego input benchmarks
+
+Run the shared-context microbenchmark with `cargo bench -p weaver_live_check --bench rego_advisor`. It measures four lanes (`serialize_input`, `set_input`, `policy_evaluation`, and `set_input_and_check`) across seven context cases (`no_context/attrs_0`, `resource_only/attrs_0`, `resource_only/attrs_16`, `resource_only/attrs_128`, `resource_and_scope/attrs_0`, `resource_and_scope/attrs_16`, and `resource_and_scope/attrs_128`) at batch sizes 1, 32, and 256. An untimed preflight verifies fixed positive and nonmatching outcomes before measurement.
+
+This is a synthetic microbenchmark, not production traffic. Report medians without subtracting one lane's median from another, and use the results only as a baseline before considering conditional optimization.
+
 
 To override the default Otel jq preprocessor provide a path to the jq file through the `--advice-preprocessor` option.
 

--- a/crates/weaver_live_check/benches/rego_advisor.rs
+++ b/crates/weaver_live_check/benches/rego_advisor.rs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Benchmarks for the Rego advisor's shared-context input costs.
+
+use std::{hint::black_box, rc::Rc, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use serde::Serialize;
+use serde_json::Value;
+use weaver_checker::{Engine, FindingLevel, PolicyFinding, PolicyStage};
+use weaver_live_check::{
+    sample_attribute::SampleAttribute, sample_instrumentation_scope::SampleInstrumentationScope,
+    sample_resource::SampleResource, sample_span::SampleSpan, SampleRef,
+};
+use weaver_semconv::group::SpanKindSpec;
+
+const BENCHMARK_POLICY: &str = r#"
+package live_check_advice
+
+import rego.v1
+
+context_or_empty(context) := context if {
+    context != null
+}
+
+context_or_empty(context) := {} if {
+    context == null
+}
+
+context_attributes(context) := object.get(context_or_empty(context), "attributes", [])
+
+deny contains {
+    "id": "benchmark_match",
+    "level": "information",
+    "message": "benchmark match",
+} if {
+    sample := object.get(input, "sample", {})
+    span := object.get(sample, "span", {})
+    object.get(span, "name", "") == "benchmark.match"
+
+    resource_attributes := context_attributes(object.get(input, "resource", null))
+    scope_attributes := context_attributes(object.get(input, "instrumentation_scope", null))
+    resource_attribute_count := count(resource_attributes)
+    scope_attribute_count := count(scope_attributes)
+    # These checks intentionally force both context traversals for the benchmark.
+    resource_attribute_count >= 0
+    scope_attribute_count >= 0
+}
+"#;
+
+#[derive(Serialize)]
+struct BenchmarkRegoInput<'a> {
+    sample: SampleRef<'a>,
+    resource: Option<&'a SampleResource>,
+    instrumentation_scope: Option<&'a SampleInstrumentationScope>,
+    registry_attribute: Option<()>,
+    registry_group: Option<()>,
+}
+
+struct Fixture {
+    name: &'static str,
+    span: SampleSpan,
+}
+
+impl Fixture {
+    fn new(
+        name: &'static str,
+        resource_attribute_count: Option<usize>,
+        scope_attribute_count: Option<usize>,
+    ) -> Self {
+        let resource = resource_attribute_count.map(|count| {
+            Rc::new(SampleResource {
+                attributes: attributes("resource", count),
+                live_check_result: None,
+            })
+        });
+        let instrumentation_scope = scope_attribute_count.map(|count| {
+            Rc::new(SampleInstrumentationScope {
+                name: "benchmark.scope".to_owned(),
+                version: "1.0.0".to_owned(),
+                schema_url: "https://opentelemetry.io/schemas/1.0.0".to_owned(),
+                attributes: attributes("scope", count),
+                dropped_attributes_count: 0,
+                live_check_result: None,
+            })
+        });
+
+        Self {
+            name,
+            span: SampleSpan {
+                name: "benchmark.match".to_owned(),
+                kind: SpanKindSpec::Internal,
+                status: None,
+                attributes: Vec::new(),
+                span_events: Vec::new(),
+                span_links: Vec::new(),
+                instrumentation_scope,
+                live_check_result: None,
+                resource,
+            },
+        }
+    }
+
+    fn input(&self) -> BenchmarkRegoInput<'_> {
+        input_for_span(&self.span)
+    }
+}
+
+fn attributes(context: &str, count: usize) -> Vec<SampleAttribute> {
+    let mut attributes = Vec::with_capacity(count);
+    for index in 0..count {
+        attributes.push(SampleAttribute {
+            name: format!("benchmark.{context}.attribute.{index:03}"),
+            value: Some(Value::String(format!(
+                "benchmark-{context}-value-{index:03}"
+            ))),
+            r#type: None,
+            live_check_result: None,
+        });
+    }
+    attributes
+}
+
+fn fixtures() -> Vec<Fixture> {
+    vec![
+        Fixture::new("no_context/attrs_0", None, None),
+        Fixture::new("resource_only/attrs_0", Some(0), None),
+        Fixture::new("resource_only/attrs_16", Some(16), None),
+        Fixture::new("resource_only/attrs_128", Some(128), None),
+        Fixture::new("resource_and_scope/attrs_0", Some(0), Some(0)),
+        Fixture::new("resource_and_scope/attrs_16", Some(16), Some(16)),
+        Fixture::new("resource_and_scope/attrs_128", Some(128), Some(128)),
+    ]
+}
+
+fn input_for_span(span: &SampleSpan) -> BenchmarkRegoInput<'_> {
+    BenchmarkRegoInput {
+        sample: SampleRef::Span(span),
+        resource: span.resource.as_deref(),
+        instrumentation_scope: span.instrumentation_scope.as_deref(),
+        registry_attribute: None,
+        registry_group: None,
+    }
+}
+
+fn expected_finding() -> PolicyFinding {
+    PolicyFinding {
+        id: "benchmark_match".to_owned(),
+        context: None,
+        message: "benchmark match".to_owned(),
+        level: FindingLevel::Information,
+        signal_type: None,
+        signal_name: None,
+    }
+}
+
+fn benchmark_engine() -> Engine {
+    let mut engine = Engine::new();
+    let _ = engine
+        .add_policy("rego_advisor_benchmark.rego", BENCHMARK_POLICY)
+        .expect("benchmark policy must compile");
+    engine
+}
+
+fn preflight(fixtures: &[Fixture]) {
+    let mut engine = benchmark_engine();
+
+    for fixture in fixtures {
+        engine
+            .set_input(&fixture.input())
+            .unwrap_or_else(|error| panic!("{} input must serialize: {error}", fixture.name));
+        let findings = engine
+            .check(PolicyStage::LiveCheckAdvice)
+            .unwrap_or_else(|error| panic!("{} policy check must succeed: {error}", fixture.name));
+        assert_eq!(
+            findings,
+            vec![expected_finding()],
+            "{} must produce the fixed benchmark finding",
+            fixture.name
+        );
+
+        let mut nonmatching_span = fixture.span.clone();
+        nonmatching_span.name = "benchmark.no_match".to_owned();
+        engine
+            .set_input(&input_for_span(&nonmatching_span))
+            .unwrap_or_else(|error| {
+                panic!("{} nonmatching input must serialize: {error}", fixture.name)
+            });
+        let findings = engine
+            .check(PolicyStage::LiveCheckAdvice)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "{} nonmatching policy check must succeed: {error}",
+                    fixture.name
+                )
+            });
+        assert!(
+            findings.is_empty(),
+            "{} nonmatching span must produce no findings: {findings:?}",
+            fixture.name
+        );
+    }
+}
+
+fn benchmark_rego_advisor(c: &mut Criterion) {
+    let fixtures = fixtures();
+    preflight(&fixtures);
+
+    for fixture in &fixtures {
+        let mut group = c.benchmark_group(format!("rego_advisor/{}", fixture.name));
+
+        for batch_size in [1u64, 32, 256] {
+            let _ = group.throughput(Throughput::Elements(batch_size));
+            let _ = group.bench_function(
+                BenchmarkId::new("serialize_input", format!("batch_{batch_size}")),
+                |b| {
+                    b.iter(|| {
+                        for _ in 0..batch_size {
+                            let input = fixture.input();
+                            let serialized = serde_json::to_value(black_box(&input))
+                                .expect("benchmark input must serialize");
+                            let _ = black_box(serialized);
+                        }
+                    });
+                },
+            );
+
+            let mut set_input_engine = benchmark_engine();
+            let _ = group.throughput(Throughput::Elements(batch_size));
+            let _ = group.bench_function(
+                BenchmarkId::new("set_input", format!("batch_{batch_size}")),
+                |b| {
+                    b.iter(|| {
+                        for _ in 0..batch_size {
+                            let input = fixture.input();
+                            let result = set_input_engine.set_input(black_box(&input));
+                            black_box(result).expect("benchmark input must serialize");
+                        }
+                    });
+                },
+            );
+
+            let mut evaluation_engine = benchmark_engine();
+            let evaluation_input = fixture.input();
+            evaluation_engine
+                .set_input(&evaluation_input)
+                .expect("benchmark input must serialize");
+            let _ = group.throughput(Throughput::Elements(batch_size));
+            let _ = group.bench_function(
+                BenchmarkId::new("policy_evaluation", format!("batch_{batch_size}")),
+                |b| {
+                    b.iter(|| {
+                        for _ in 0..batch_size {
+                            let findings = evaluation_engine
+                                .check(PolicyStage::LiveCheckAdvice)
+                                .expect("benchmark policy check must succeed");
+                            let _ = black_box(findings);
+                        }
+                    });
+                },
+            );
+
+            let mut combined_engine = benchmark_engine();
+            let _ = group.throughput(Throughput::Elements(batch_size));
+            let _ = group.bench_function(
+                BenchmarkId::new("set_input_and_check", format!("batch_{batch_size}")),
+                |b| {
+                    b.iter(|| {
+                        for _ in 0..batch_size {
+                            let input = fixture.input();
+                            combined_engine
+                                .set_input(black_box(&input))
+                                .expect("benchmark input must serialize");
+                            let findings = combined_engine
+                                .check(PolicyStage::LiveCheckAdvice)
+                                .expect("benchmark policy check must succeed");
+                            let _ = black_box(findings);
+                        }
+                    });
+                },
+            );
+        }
+
+        group.finish();
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_millis(250))
+        .measurement_time(Duration::from_secs(1))
+        .sample_size(20);
+    targets = benchmark_rego_advisor
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Add a Criterion benchmark for Rego input work with shared resource and instrumentation-scope context.

- Isolates serialization, `set_input`, policy evaluation, and the combined path.
- Covers seven context fixtures across batch sizes 1, 32, and 256.
- Performs fixed matching and nonmatching preflight checks before timing.
- Documents the synthetic-only interpretation boundary.

## Context

Follow-up to #1668. This is a baseline-only microbenchmark; it does not optimize the live-check path or claim production impact.

## Validation

- `cargo fmt --all -- --check`
- Locked/offline Cargo metadata
- Locked/offline gnullvm benchmark compile
- Full 84-cell Criterion run, including preflight
- `git diff --check`

The repository-wide `just` pre-push recipe was attempted, but this local Windows host stopped before the checks began because Git Bash could not create its signal pipe (Win32 error 5). CI remains the authoritative full pre-push validation.
