### PR TITLE
Report an import that matches nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
+- Report an `imports` pattern that matched nothing in any dependency, as a warning. A typo or a stale name was previously dropped in silence. ([#1701](https://github.com/open-telemetry/weaver/pull/1701) by @jerbly)
 - Fix a span imported from a v2 dependency losing the `sampling_relevant` setting on its attributes. This is per-span state, held on the span's attribute reference rather than on the catalog attribute, so the import path never read it. Refining such a span was unaffected. ([#1694](https://github.com/open-telemetry/weaver/pull/1694) by @jerbly)
 - Fix `imports` never matching a legacy `type: resource` entity in a dependency. Such a group sets no `name` and holds its entity type in the group id, so the matcher now matches the group id as well as the name. ([#1694](https://github.com/open-telemetry/weaver/pull/1694) by @jerbly)
 - Fix a definition reached by two paths through the dependency graph being imported twice, which produced duplicate groups and misleading duplicate-declaration warnings. Imported groups are now deduplicated as the per-dependency results are joined. ([#1694](https://github.com/open-telemetry/weaver/pull/1694) by @jerbly)

--- a/crates/weaver_resolver/data/entity-assoc-imports/README.md
+++ b/crates/weaver_resolver/data/entity-assoc-imports/README.md
@@ -12,6 +12,8 @@ work. Each pull request in that series adds the fixtures that its tests need.
 | `top_legacy_import` | legacy_resource | `entities: [browser]` | the import reaches the legacy group |
 | `rival_base` | – | – | defines its own unrelated `host` entity |
 | `top_rival_import` | base **and** rival_base | `entities: [host]` | two `host` entities, and a reported clash |
+| `top_bad_import` | middle_reexport | `entities: [no.such.entity]` | one unmatched-import warning |
+| `top_bad_imports_all_types` | middle_reexport | one bad name per signal type | five warnings, and silence for the two names that bind |
 
 ## A diamond is not a clash
 

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_bad_import/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_bad_import/manifest.yaml
@@ -1,0 +1,10 @@
+name: top
+description: >
+  This registry imports an entity that no declared dependency offers.
+  `middle_reexport` does export `host`. So the import fails for one reason only.
+  No entity has the name `no.such.entity`.
+schema_url: https://example.com/top/1.0.0
+dependencies:
+  - name: middle
+    schema_url: https://example.com/middle/1.0.0
+    registry_path: data/entity-assoc-imports/middle_reexport

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_bad_import/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_bad_import/registry.yaml
@@ -1,0 +1,6 @@
+file_format: definition/2
+imports:
+  metrics:
+    - middle.request.count
+  entities:
+    - no.such.entity

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_bad_imports_all_types/manifest.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_bad_imports_all_types/manifest.yaml
@@ -1,0 +1,9 @@
+name: top
+description: >
+  An import of every signal type that no dependency offers. The resolver must
+  report all five, not only the entity.
+schema_url: https://example.com/top/1.0.0
+dependencies:
+  - name: middle
+    schema_url: https://example.com/middle/1.0.0
+    registry_path: data/entity-assoc-imports/middle_reexport

--- a/crates/weaver_resolver/data/entity-assoc-imports/top_bad_imports_all_types/registry.yaml
+++ b/crates/weaver_resolver/data/entity-assoc-imports/top_bad_imports_all_types/registry.yaml
@@ -1,0 +1,14 @@
+file_format: definition/2
+imports:
+  metrics:
+    - middle.request.count
+    - no.such.metric
+  events:
+    - no.such.event
+  spans:
+    - no.such.span
+  entities:
+    - host
+    - no.such.entity
+  attribute_groups:
+    - no.such.attribute_group

--- a/crates/weaver_resolver/src/error.rs
+++ b/crates/weaver_resolver/src/error.rs
@@ -146,6 +146,19 @@ pub enum Error {
         // TODO: plumb provenance?
     },
 
+    /// An import pattern that named nothing in any dependency.
+    #[error("The import `{pattern}` under `{signal}` matched nothing in any dependency")]
+    #[diagnostic(severity(Warning))]
+    #[diagnostic(help(
+        "Check the spelling, and check that a dependency exports it. Imports are not transitive: a registry further down the chain is reachable only when the registry in between re-exports it."
+    ))]
+    UnmatchedImport {
+        /// The pattern that matched nothing.
+        pattern: String,
+        /// The `imports` field the pattern is under.
+        signal: String,
+    },
+
     /// An invalid Schema path.
     #[error("Invalid Schema path: {path}")]
     InvalidSchemaPath {

--- a/crates/weaver_resolver/src/imports.rs
+++ b/crates/weaver_resolver/src/imports.rs
@@ -59,6 +59,28 @@ impl ImportField {
         }
     }
 
+    /// Every field, in a stable order.
+    fn all() -> [Self; 5] {
+        [
+            Self::Metrics,
+            Self::Events,
+            Self::Spans,
+            Self::Entities,
+            Self::AttributeGroups,
+        ]
+    }
+
+    /// The name of the field, for a diagnostic.
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Metrics => "metrics",
+            Self::Events => "events",
+            Self::Spans => "spans",
+            Self::Entities => "entities",
+            Self::AttributeGroups => "attribute_groups",
+        }
+    }
+
     /// The patterns of this field, in one `imports` block.
     fn patterns<'a>(&self, imports: &'a weaver_semconv::semconv::Imports) -> &'a [GroupWildcard] {
         let field = match self {
@@ -70,6 +92,63 @@ impl ImportField {
         };
         field.as_deref().unwrap_or_default()
     }
+}
+
+/// Whether the resolver added this `imports` block itself, rather than the
+/// author writing it. `--include-unreferenced` asks for everything, so it is
+/// not a name that can be misspelled.
+fn is_implicit_import(import: &ImportsWithProvenance) -> bool {
+    import.provenance.path == "--include-unreferenced"
+}
+
+/// Reports every explicit import pattern that named none of the imported
+/// groups.
+///
+/// An unmatched pattern is nearly always a typo or a stale name, and the
+/// resolver drops it in silence. This runs across all dependencies at once,
+/// because a pattern can name nothing in one dependency and still be satisfied
+/// by another.
+pub(crate) fn unmatched_import_errors(
+    imports: &[ImportsWithProvenance],
+    groups: &[GroupWithProvenance],
+) -> Result<Vec<Error>, Error> {
+    let explicit: Vec<&ImportsWithProvenance> =
+        imports.iter().filter(|i| !is_implicit_import(i)).collect();
+    let mut errors = vec![];
+    for field in ImportField::all() {
+        let patterns: Vec<&GroupWildcard> = explicit
+            .iter()
+            .flat_map(|i| field.patterns(&i.imports))
+            .collect();
+        if patterns.is_empty() {
+            continue;
+        }
+        // Built from the same list, in the same order, so a match index is an
+        // index into `patterns`.
+        let matcher = build_globset(patterns.iter().copied())?;
+        let mut matched = vec![false; patterns.len()];
+        for group in groups {
+            if ImportField::of(&group.group.r#type) != Some(field) {
+                continue;
+            }
+            for key in import_match_keys(&group.group) {
+                for index in matcher.matches(key) {
+                    matched[index] = true;
+                }
+            }
+        }
+        errors.extend(
+            patterns
+                .iter()
+                .zip(matched)
+                .filter(|(_, matched)| !matched)
+                .map(|(pattern, _)| Error::UnmatchedImport {
+                    pattern: pattern.0.glob().to_owned(),
+                    signal: field.name().to_owned(),
+                }),
+        );
+    }
+    Ok(errors)
 }
 
 /// The strings that an import pattern can match a group by.
@@ -209,10 +288,8 @@ impl ImportableDependency for V1Schema {
         attribute_catalog: &mut AttributeCatalog,
         cache_lookup: &C,
     ) -> Result<Vec<GroupWithProvenance>, Error> {
-        let explicit_imports: Vec<&ImportsWithProvenance> = imports
-            .iter()
-            .filter(|i| i.provenance.path != "--include-unreferenced")
-            .collect();
+        let explicit_imports: Vec<&ImportsWithProvenance> =
+            imports.iter().filter(|i| !is_implicit_import(i)).collect();
 
         let explicit = ImportMatchers::build(explicit_imports.iter().copied())?;
         let any = ImportMatchers::build(imports.iter())?;
@@ -582,10 +659,8 @@ impl ImportableDependency for V2Schema {
         // The table a `DependencyRef` indexes into, materialised once.
         let deps: Vec<SchemaUrl> = self.dependencies.iter().cloned().collect();
 
-        let explicit_imports: Vec<&ImportsWithProvenance> = imports
-            .iter()
-            .filter(|i| i.provenance.path != "--include-unreferenced")
-            .collect();
+        let explicit_imports: Vec<&ImportsWithProvenance> =
+            imports.iter().filter(|i| !is_implicit_import(i)).collect();
         let explicit = ImportMatchers::build(explicit_imports.iter().copied())?;
         let any = ImportMatchers::build(imports.iter())?;
 

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -2251,6 +2251,11 @@ groups:
         (v2, nfes)
     }
 
+    /// The non-fatal errors of one of the `entity-assoc-imports` registries.
+    fn entity_assoc_fixture_errors(name: &str) -> Vec<Error> {
+        resolve_entity_assoc_fixture(name).1
+    }
+
     /// The registry that defines the `host` entity.
     const BASE_URL: &str = "https://example.com/base/1.0.0";
 
@@ -2325,6 +2330,55 @@ groups:
         assert!(
             duplicates.is_empty(),
             "an import of one definition by two paths is not a duplicate declaration: {duplicates:?}"
+        );
+    }
+
+    /// An import that no dependency satisfies must be reported.
+    ///
+    /// `top_bad_import` depends on `middle_reexport`, which does export `host`.
+    /// The import asks for `no.such.entity`. So the import fails for one reason
+    /// only: no dependency offers anything with that name.
+    #[test]
+    fn test_import_that_binds_to_nothing_is_reported() {
+        let errors = entity_assoc_fixture_errors("top_bad_import");
+        assert!(
+            matches!(
+                errors.as_slice(),
+                [Error::UnmatchedImport { pattern, signal }]
+                    if pattern == "no.such.entity" && signal == "entities"
+            ),
+            "no dependency offers `no.such.entity`, and the resolver must report \
+             this import: {errors:?}"
+        );
+    }
+
+    /// Every `imports` field is checked, not only `entities`.
+    ///
+    /// `top_bad_imports_all_types` asks for one name of each signal type that
+    /// no dependency offers. It also asks for a metric and an entity that
+    /// `middle_reexport` does export, so a report of those would be wrong.
+    #[test]
+    fn test_unmatched_imports_are_reported_for_every_signal_type() {
+        let errors = entity_assoc_fixture_errors("top_bad_imports_all_types");
+        let mut reported: Vec<(&str, &str)> = errors
+            .iter()
+            .map(|e| match e {
+                Error::UnmatchedImport { pattern, signal } => (pattern.as_str(), signal.as_str()),
+                other => panic!("unexpected error: {other:?}"),
+            })
+            .collect();
+        reported.sort_unstable();
+        assert_eq!(
+            reported,
+            [
+                ("no.such.attribute_group", "attribute_groups"),
+                ("no.such.entity", "entities"),
+                ("no.such.event", "events"),
+                ("no.such.metric", "metrics"),
+                ("no.such.span", "spans"),
+            ],
+            "each signal type must report its own unmatched import, and the \
+             imports that do bind must stay silent"
         );
     }
 

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -162,7 +162,7 @@ pub(crate) fn resolve_registry_with_dependencies<C: crate::SchemaCacheLookup>(
     }
 
     // We need to *import* objects from the dependencies as required.
-    if let Err(e) = resolve_dependency_imports(&mut ureg, attr_catalog, cache_lookup) {
+    if let Err(e) = resolve_dependency_imports(&mut ureg, attr_catalog, cache_lookup, &mut errors) {
         return WResult::FatalErr(e);
     }
 
@@ -385,15 +385,21 @@ fn resolve_prefix_on_attributes(ureg: &mut UnresolvedRegistry) -> Result<(), Err
 }
 
 /// Resolves imports defined on dependencies.
+///
+/// A pattern that named nothing is reported into `errors`.
 fn resolve_dependency_imports<C: crate::SchemaCacheLookup>(
     ureg: &mut UnresolvedRegistry,
     attribute_catalog: &mut AttributeCatalog,
     cache_lookup: &C,
+    errors: &mut Vec<Error>,
 ) -> Result<(), Error> {
     // Import from our dependencies, and add to the final registry.
     let imports = &ureg.imports;
     let dependencies = &ureg.dependencies;
     let groups = dependencies.import_groups(imports, attribute_catalog, cache_lookup)?;
+    // Checked against what the imports produced, before the groups move into
+    // the registry.
+    errors.extend(crate::imports::unmatched_import_errors(imports, &groups)?);
     for crate::imports::GroupWithProvenance { group, schema_url } in groups {
         let is_v2 = group.is_v2();
         let mut prov_url = if let Some(prov) = group.provenance() {


### PR DESCRIPTION
Report an `imports` pattern that matched nothing in any dependency, as a warning. A typo or a stale name was previously dropped in silence.