### PR TITLE
Fixes for nightly build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ eula = false
 # Workspace definition ========================================================
 [workspace]
 members = ["crates/*"]
-exclude = ["fuzz"]
+exclude = ["fuzz", "target"]
 
 [workspace.package]
 version = "0.25.1"

--- a/crates/weaver_resolver/src/attribute.rs
+++ b/crates/weaver_resolver/src/attribute.rs
@@ -193,6 +193,15 @@ fn resolve_conflict(
     m: AttributeWithSource,
     existing: AttributeWithSource,
 ) -> Result<AttributeWithSource, Error> {
+    let m_excluded = m.attribute.annotations.as_ref().is_some_and(is_excluded);
+    let existing_excluded = existing
+        .attribute
+        .annotations
+        .as_ref()
+        .is_some_and(is_excluded);
+    if m_excluded != existing_excluded {
+        return Ok(if m_excluded { existing } else { m });
+    }
     match (m.is_definition, existing.is_definition) {
         (true, false) => return Ok(m),
         (false, true) => return Ok(existing),

--- a/crates/weaver_resolver/src/lib.rs
+++ b/crates/weaver_resolver/src/lib.rs
@@ -1558,6 +1558,50 @@ groups:
     }
 
     #[test]
+    fn test_dep_exclusion_migration_redefine_ref_before_def() {
+        // Test that when a consumer references a redefined attribute (via ref) in a group,
+        // it resolves against the local definition rather than falling back to the dependency's
+        // excluded definition.
+        let consumer_yaml = r#"
+file_format: definition/2
+metrics:
+  - name: moved.metric
+    requirement_level: recommended
+    instrument: counter
+    unit: "1"
+    stability: stable
+    brief: Redefined metric.
+    attributes:
+      - ref: moved.attr
+        requirement_level: required
+attributes:
+  - key: moved.attr
+    type: string
+    stability: stable
+    brief: Redefined attribute (same name as the deprecated parent item).
+"#;
+        let result = resolve_inline_with_parent(
+            consumer_yaml,
+            "data/registry-test-dep-exclusion/migration_parent",
+        );
+        let resolved = match result {
+            WResult::Ok(s) | WResult::OkWithNFEs(s, _) => s,
+            WResult::FatalErr(e) => panic!("expected success; got {e:?}"),
+        };
+
+        let metric = resolved
+            .groups(GroupType::Metric)
+            .get("metric.moved.metric")
+            .cloned()
+            .expect("metric.moved.metric should be present");
+        let attr = resolved
+            .catalog
+            .attribute(&metric.attributes[0])
+            .expect("attribute should exist in catalog");
+        assert_eq!(attr.name, "moved.attr");
+    }
+
+    #[test]
     fn test_within_registry_leak_v2_refinement() {
         // V2: a public metric_refinement targets an excluded base metric in
         // the same registry. Exercises the `extends` exclusion path on V2.

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -637,11 +637,51 @@ fn resolve_attribute_references<C: crate::SchemaCacheLookup>(
     attr_catalog: &mut AttributeCatalog,
     cache_lookup: &C,
 ) -> Result<(), Error> {
-    // TODO - Right now the attribute registry does NOT have any of the
-    // attributes from dependencies. We expect to resolve all groups in the current
-    // algorithm, instead we need to *pre-register* those attributes here.
+    // First, resolve all attribute definitions (AttributeSpec::Id) across all groups.
+    // This populates the catalog with all local and refinement attribute definitions
+    // before resolving attribute references (AttributeSpec::Ref), preventing dependency
+    // lookups from preempting local definitions.
+    let mut init_errors = vec![];
+    for unresolved_group in ureg.groups.iter_mut() {
+        let mut resolved_attr = vec![];
+        let mut still_unresolved = vec![];
+        let group_excluded = is_group_excluded(
+            &unresolved_group.group.annotations,
+            unresolved_group.visibility.as_ref(),
+            &unresolved_group.group.r#type,
+        );
+        for attr in unresolved_group.attributes.drain(..) {
+            if matches!(attr.spec, AttributeSpec::Id { .. }) {
+                match attr_catalog.resolve(
+                    &unresolved_group.group.id,
+                    &unresolved_group.group.prefix,
+                    group_excluded,
+                    &attr.spec,
+                    attr.origin.as_ref(),
+                    unresolved_group.group.lineage.as_mut(),
+                    &ureg.dependencies,
+                    cache_lookup,
+                ) {
+                    Ok(Some(attr_ref)) => {
+                        resolved_attr.push(attr_ref);
+                    }
+                    Ok(None) => still_unresolved.push(attr),
+                    Err(e @ Error::ExcludedFromDependencyResolution { .. }) => {
+                        init_errors.push(e);
+                        still_unresolved.push(attr);
+                    }
+                    Err(e) => return Err(e),
+                }
+            } else {
+                still_unresolved.push(attr);
+            }
+        }
+        unresolved_group.attributes = still_unresolved;
+        unresolved_group.group.attributes.extend(resolved_attr);
+    }
+
     loop {
-        let mut errors = vec![];
+        let mut errors = init_errors.clone();
         let mut resolved_attr_count = 0;
 
         // Iterate over all groups and resolve the attributes.


### PR DESCRIPTION
This fixes the issues we *can* fix in weaver for the nightly build - #1689.

- We isolate our workspace for cargo so `target` directory is not considered in the workspace, since the nightly checks out code into it.  We may also need to do other updates *or* just move all the checkouts outside of the target directory into a tmp directory.
- Attributes are pre-resolved for local dependency, before doing lookups on dependencies.  This avoid an lazy expansion issue where looking up attributes would find a dependency *before* a local definition.  There was a TODO around this in the code that was never implemented and led to an actual bug.

Super thanks to @lmolkova for the nightly build! I'm glad we caught these before release.