### PR TITLE
Prepare release v0.26.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,7 @@ jobs:
         run: | # zizmor: ignore[template-injection] cargo-dist emits this script in the run-scoped build plan.
           ${{ matrix.packages_install }}
       - name: Build artifacts
+        shell: bash
         env:
           DIST_ARGS: ${{ matrix.dist_args }}
           TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.26.1] - 2026-09-02
+
+- Fix `weaver-installer.sh` failing to detect Unix platforms due to missing bash shell in release workflow. ([#1744](https://github.com/open-telemetry/weaver/issues/1744))
+
 # [0.26.0] - 2026-09-02
 
 - 💥 BREAKING CHANGE 💥 `registry live-check` and `registry infer` now bind their OTLP and HTTP admin listeners to `127.0.0.1` instead of `0.0.0.0`, so they no longer listen on every local address by default. Pass `--otlp-grpc-address` (live-check) or `--grpc-address` (infer) to bind a specific interface, or `0.0.0.0` for all of them. The admin listener now binds to the same address as the OTLP listener rather than always to `0.0.0.0`. ([#1740](https://github.com/open-telemetry/weaver/pull/1740) by @lmolkova)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6243,7 +6243,7 @@ dependencies = [
 
 [[package]]
 name = "weaver"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "assert_cmd",
  "axum",
@@ -6302,7 +6302,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_checker"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "globset",
  "log",
@@ -6320,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_codegen_test"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "dirs",
  "log",
@@ -6335,7 +6335,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_common"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "axum",
  "dirs",
@@ -6364,7 +6364,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_config"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "log",
  "schemars",
@@ -6380,7 +6380,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_diff"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "serde_json",
  "similar",
@@ -6389,7 +6389,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_emit"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "futures-util",
  "miette",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_forge"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "convert_case 0.11.0",
  "dirs",
@@ -6447,7 +6447,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_infer"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "convert_case 0.11.0",
  "log",
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_live_check"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "assert_cmd",
  "globset",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_macros"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6501,7 +6501,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_mcp"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "log",
  "miette",
@@ -6530,7 +6530,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_resolved_schema"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "log",
  "schemars",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_resolver"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "glob",
  "globset",
@@ -6570,7 +6570,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_search"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "schemars",
  "serde",
@@ -6582,7 +6582,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_semconv"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "glob",
  "globset",
@@ -6608,7 +6608,7 @@ dependencies = [
 
 [[package]]
 name = "weaver_semconv_gen"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "miette",
  "nom 8.0.0",
@@ -6625,11 +6625,11 @@ dependencies = [
 
 [[package]]
 name = "weaver_test_support"
-version = "0.26.0"
+version = "0.26.1"
 
 [[package]]
 name = "weaver_version"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "schemars",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = ["crates/*"]
 exclude = ["fuzz", "target"]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.26.1"
 authors = ["OpenTelemetry"]
 edition = "2021"
 repository = "https://github.com/open-telemetry/weaver"


### PR DESCRIPTION
Fixes #1744.

- Fix `weaver-installer.sh` on Unix platforms by adding `shell: bash` to the release workflow's `Build artifacts` step so `$DIST_ARGS` expands correctly on Windows runners. - regression introduced in https://github.com/open-telemetry/weaver/pull/1727
- Bump workspace version to `0.26.1`.