### PR TITLE
ci: smoke-test the generated installers before publishing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,87 @@ jobs:
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
+  # Run the generated installers against the freshly built artifacts, served from
+  # localhost, so a broken installer fails the release instead of shipping.
+  smoke-test-installers:
+    needs:
+      - build-local-artifacts
+      - build-global-artifacts
+    permissions:
+      "contents": "read"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["ubuntu-24.04", "ubuntu-24.04-arm", "macos-15", "macos-15-intel", "windows-2025"]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Fetch artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        with:
+          pattern: artifacts-*
+          path: bundles/
+      - name: Assemble the release directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          # A per-target build job must never produce the global artifacts: two jobs
+          # writing the same filename means whichever lands last wins the release.
+          rogue=$(ls bundles/artifacts-build-local-*/weaver-installer.* \
+                     bundles/artifacts-build-local-*/sha256.sum 2>/dev/null || true)
+          if [ -n "$rogue" ]; then
+            echo "::error::a per-target build job produced global artifacts:"
+            echo "$rogue"
+            exit 1
+          fi
+          # Global wins any remaining collision, rather than download order deciding.
+          mkdir -p dist
+          cp bundles/artifacts-build-local-*/* dist/
+          cp bundles/artifacts-build-global/* dist/
+      - name: Install from the shell installer
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        env:
+          WEAVER_DOWNLOAD_URL: http://localhost:8000
+        run: |
+          set -euo pipefail
+          python3 -m http.server 8000 --directory dist &
+          server=$!
+          trap 'kill $server' EXIT
+          for i in $(seq 30); do
+            if curl -sf http://localhost:8000/ > /dev/null; then break; fi
+            if [ "$i" = 30 ]; then echo "artifact server did not start"; exit 1; fi
+            sleep 1
+          done
+
+          sh dist/weaver-installer.sh
+          expected=$(jq -r '.announcement_tag' dist/global-dist-manifest.json)
+          actual=v$("$HOME/.cargo/bin/weaver" --version | awk '{print $2}')
+          echo "installed $actual, expected $expected"
+          [ "$actual" = "$expected" ]
+      - name: Install from the powershell installer
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        env:
+          WEAVER_DOWNLOAD_URL: http://localhost:8000
+        run: |
+          $server = Start-Process python -ArgumentList "-m","http.server","8000","--directory","dist" -PassThru
+          try {
+            $up = $false
+            foreach ($i in 1..30) {
+              if (Test-NetConnection localhost -Port 8000 -InformationLevel Quiet) { $up = $true; break }
+              Start-Sleep 1
+            }
+            if (-not $up) { throw "artifact server did not start" }
+
+            ./dist/weaver-installer.ps1
+            $expected = (Get-Content dist/global-dist-manifest.json | ConvertFrom-Json).announcement_tag
+            $actual = "v" + (& "$env:USERPROFILE\.cargo\bin\weaver.exe" --version).Split(" ")[1]
+            Write-Host "installed $actual, expected $expected"
+            if ($actual -ne $expected) { exit 1 }
+          } finally {
+            if ($server) { Stop-Process -Id $server.Id }
+          }
   # Determines if we should publish/announce
   host:
     permissions:
@@ -252,8 +333,9 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
-    # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+      - smoke-test-installers
+    # Only run if we're "publishing", and only if plan, local, global and the installer smoke test didn't fail (skipped is fine)
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && (needs.smoke-test-installers.result == 'skipped' || needs.smoke-test-installers.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,8 @@ jobs:
           name: artifacts-build-global
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+
   custom-smoke-test-installers:
     needs:
       - plan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,7 +253,6 @@ jobs:
     uses: ./.github/workflows/smoke-test-installers.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
     permissions:
       contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,88 +243,18 @@ jobs:
           name: artifacts-build-global
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
-            ${{ env.BUILD_MANIFEST_NAME }}
-  # Run the generated installers against the freshly built artifacts, served from
-  # localhost, so a broken installer fails the release instead of shipping.
-  smoke-test-installers:
+  custom-smoke-test-installers:
     needs:
+      - plan
       - build-local-artifacts
       - build-global-artifacts
+    uses: ./.github/workflows/smoke-test-installers.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
     permissions:
-      "contents": "read"
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: ["ubuntu-24.04", "ubuntu-24.04-arm", "macos-15", "macos-15-intel", "windows-2025"]
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Fetch artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
-        with:
-          pattern: artifacts-*
-          path: bundles/
-      - name: Assemble the release directory
-        shell: bash
-        run: |
-          set -euo pipefail
-          # A per-target build job must never produce the global artifacts: two jobs
-          # writing the same filename means whichever lands last wins the release.
-          rogue=$(ls bundles/artifacts-build-local-*/weaver-installer.* \
-                     bundles/artifacts-build-local-*/sha256.sum 2>/dev/null || true)
-          if [ -n "$rogue" ]; then
-            echo "::error::a per-target build job produced global artifacts:"
-            echo "$rogue"
-            exit 1
-          fi
-          # Global wins any remaining collision, rather than download order deciding.
-          mkdir -p dist
-          cp bundles/artifacts-build-local-*/* dist/
-          cp bundles/artifacts-build-global/* dist/
-      - name: Install from the shell installer
-        if: ${{ runner.os != 'Windows' }}
-        shell: bash
-        env:
-          WEAVER_DOWNLOAD_URL: http://localhost:8000
-        run: |
-          set -euo pipefail
-          python3 -m http.server 8000 --directory dist &
-          server=$!
-          trap 'kill $server' EXIT
-          for i in $(seq 30); do
-            if curl -sf http://localhost:8000/ > /dev/null; then break; fi
-            if [ "$i" = 30 ]; then echo "artifact server did not start"; exit 1; fi
-            sleep 1
-          done
+      contents: read
 
-          sh dist/weaver-installer.sh
-          expected=$(jq -r '.announcement_tag' dist/global-dist-manifest.json)
-          actual=v$("$HOME/.cargo/bin/weaver" --version | awk '{print $2}')
-          echo "installed $actual, expected $expected"
-          [ "$actual" = "$expected" ]
-      - name: Install from the powershell installer
-        if: ${{ runner.os == 'Windows' }}
-        shell: pwsh
-        env:
-          WEAVER_DOWNLOAD_URL: http://localhost:8000
-        run: |
-          $server = Start-Process python -ArgumentList "-m","http.server","8000","--directory","dist" -PassThru
-          try {
-            $up = $false
-            foreach ($i in 1..30) {
-              if (Test-NetConnection localhost -Port 8000 -InformationLevel Quiet) { $up = $true; break }
-              Start-Sleep 1
-            }
-            if (-not $up) { throw "artifact server did not start" }
-
-            ./dist/weaver-installer.ps1
-            $expected = (Get-Content dist/global-dist-manifest.json | ConvertFrom-Json).announcement_tag
-            $actual = "v" + (& "$env:USERPROFILE\.cargo\bin\weaver.exe" --version).Split(" ")[1]
-            Write-Host "installed $actual, expected $expected"
-            if ($actual -ne $expected) { exit 1 }
-          } finally {
-            if ($server) { Stop-Process -Id $server.Id }
-          }
   # Determines if we should publish/announce
   host:
     permissions:
@@ -333,9 +263,9 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
-      - smoke-test-installers
-    # Only run if we're "publishing", and only if plan, local, global and the installer smoke test didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && (needs.smoke-test-installers.result == 'skipped' || needs.smoke-test-installers.result == 'success') }}
+      - custom-smoke-test-installers
+    # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-smoke-test-installers.result == 'skipped' || needs.custom-smoke-test-installers.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-latest"

--- a/.github/workflows/smoke-test-installers.yml
+++ b/.github/workflows/smoke-test-installers.yml
@@ -1,0 +1,91 @@
+name: Smoke test installers
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+jobs:
+  smoke-test-installers:
+    permissions:
+      "contents": "read"
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["ubuntu-24.04", "ubuntu-24.04-arm", "macos-15", "macos-15-intel", "windows-2025"]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Fetch artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        with:
+          pattern: artifacts-*
+          path: bundles/
+      - name: Assemble the release directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          # A per-target build job must never produce the global artifacts: two jobs
+          # writing the same filename means whichever lands last wins the release.
+          rogue=$(ls bundles/artifacts-build-local-*/weaver-installer.* \
+                     bundles/artifacts-build-local-*/sha256.sum 2>/dev/null || true)
+          if [ -n "$rogue" ]; then
+            echo "::error::a per-target build job produced global artifacts:"
+            echo "$rogue"
+            exit 1
+          fi
+          # Global wins any remaining collision, rather than download order deciding.
+          mkdir -p dist
+          cp bundles/artifacts-build-local-*/* dist/
+          cp bundles/artifacts-build-global/* dist/
+      - name: Install from the shell installer
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        env:
+          WEAVER_DOWNLOAD_URL: http://localhost:8000
+        run: |
+          set -euo pipefail
+          python3 -m http.server 8000 --directory dist &
+          server=$!
+          trap 'kill $server' EXIT
+          for i in $(seq 30); do
+            if curl -sf http://localhost:8000/ > /dev/null; then break; fi
+            if ! kill -0 "$server" 2>/dev/null; then
+              echo "artifact server exited unexpectedly"
+              exit 1
+            fi
+            if [ "$i" = 30 ]; then echo "artifact server did not start"; exit 1; fi
+            sleep 1
+          done
+
+          sh dist/weaver-installer.sh
+          expected=$(jq -r '.announcement_tag' dist/global-dist-manifest.json)
+          actual=v$("$HOME/.cargo/bin/weaver" --version | awk '{print $2}')
+          echo "installed $actual, expected $expected"
+          [ "$actual" = "$expected" ]
+      - name: Install from the powershell installer
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        env:
+          WEAVER_DOWNLOAD_URL: http://localhost:8000
+        run: |
+          $server = Start-Process python -ArgumentList "-m","http.server","8000","--directory","dist" -PassThru
+          try {
+            $up = $false
+            foreach ($i in 1..30) {
+              if (Test-NetConnection localhost -Port 8000 -InformationLevel Quiet) { $up = $true; break }
+              if ($server.HasExited) { throw "artifact server exited unexpectedly" }
+              Start-Sleep 1
+            }
+            if (-not $up) { throw "artifact server did not start" }
+
+            ./dist/weaver-installer.ps1
+            $expected = (Get-Content dist/global-dist-manifest.json | ConvertFrom-Json).announcement_tag
+            $actual = "v" + (& "$env:USERPROFILE\.cargo\bin\weaver.exe" --version).Split(" ")[1]
+            Write-Host "installed $actual, expected $expected"
+            if ($actual -ne $expected) { exit 1 }
+          } finally {
+            if ($server -and -not $server.HasExited) { Stop-Process -Id $server.Id }
+          }

--- a/.github/workflows/smoke-test-installers.yml
+++ b/.github/workflows/smoke-test-installers.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   smoke-test-installers:
     permissions:
-      "contents": "read"
+      contents: read
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,8 +201,8 @@ regeneration:
 
 1. Temporarily remove `allow-dirty = ["ci"]` from `dist-workspace.toml`.
 2. Run `dist init`.
-3. Update the versions and shas in `crates/xtask/src/fix_release_permissions.rs`.
-4. Run `just fix-release-permissions` to re-apply the required permission patches.
+3. Update the versions and shas in `crates/xtask/src/patch_release_workflow.rs`.
+4. Run `just patch-release-workflow` to re-apply the required workflow patches.
 5. Restore `allow-dirty = ["ci"]` in `dist-workspace.toml`.
 
 #### 4. Monitor the CI/CD Process

--- a/crates/xtask/src/fix_release_permissions.rs
+++ b/crates/xtask/src/fix_release_permissions.rs
@@ -73,6 +73,12 @@ fn apply_patches(content: &str) -> anyhow::Result<String> {
             "uses: actions/attest@v4",
             "uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26",
         ),
+        // cargo-dist custom global-artifacts jobs only depend on build-local-artifacts;
+        // smoke-test-installers also needs the global installers built by build-global-artifacts.
+        (
+            "  custom-smoke-test-installers:\n    needs:\n      - plan\n      - build-local-artifacts\n    uses:",
+            "  custom-smoke-test-installers:\n    needs:\n      - plan\n      - build-local-artifacts\n      - build-global-artifacts\n    uses:",
+        ),
     ];
 
     let mut result = content.to_owned();
@@ -80,7 +86,7 @@ fn apply_patches(content: &str) -> anyhow::Result<String> {
         if result.contains(from) {
             result = result.replace(from, to);
         } else if !result.contains(to) {
-            bail!("{PATH} does not contain expected string — has the file drifted?\n  Expected: {from:?}");
+            bail!("{PATH} does not contain expected string - has the file drifted?\n  Expected: {from:?}");
         }
     }
     Ok(result)

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -11,8 +11,8 @@
 #![allow(clippy::print_stderr)]
 
 mod downstream;
-mod fix_release_permissions;
 mod history;
+mod patch_release_workflow;
 mod schema_compat;
 mod validate;
 
@@ -27,7 +27,7 @@ fn main() -> anyhow::Result<()> {
     match task {
         None => print_help(),
         Some(task) => match task.as_str() {
-            "fix-release-permissions" => fix_release_permissions::run(),
+            "patch-release-workflow" => patch_release_workflow::run(),
             "validate" => validate::run(),
             "history" => history::run(std::env::args().nth(2)),
             "schema-compat" => schema_compat::run(),
@@ -49,7 +49,7 @@ pub fn print_help() -> anyhow::Result<()> {
 Usage: Execute the command using `cargo xtask <task>`, e.g., `cargo xtask validate`.
 
 Tasks:
-  - fix-release-permissions: Patch release.yml after `dist generate` to scope contents:write to plan/host jobs only.
+  - patch-release-workflow: Patch release.yml after `dist generate` (permissions, scorecard shas, smoke tests).
   - validate: Validate the entire structure of the weaver project.
   - history: Run registry check on semconv models within back compatibility range.
              Optionally provide a start semver e.g. `history 1.29.0`.

--- a/crates/xtask/src/patch_release_workflow.rs
+++ b/crates/xtask/src/patch_release_workflow.rs
@@ -2,12 +2,13 @@ use anyhow::{bail, Context};
 
 const PATH: &str = ".github/workflows/release.yml";
 
-/// Patch release.yml after `dist generate` to fix Scorecard findings.
+/// Patch release.yml after `dist generate` to fix Scorecard and smoke test findings.
 ///
 /// 1. Permissions: dist generates `permissions: contents: write` at the top level; this patches
 ///    it to `contents: read` and grants `contents: write` only to plan and host jobs.
 /// 2. Pinned-Dependencies: replaces `curl | sh` patterns with download-verify-execute so
 ///    Scorecard recognises the scripts as hash-pinned.
+/// 3. Smoke tests: ensures custom-smoke-test-installers waits for build-global-artifacts.
 pub fn run() -> anyhow::Result<()> {
     let content =
         std::fs::read_to_string(PATH).with_context(|| format!("failed to read {PATH}"))?;
@@ -16,7 +17,9 @@ pub fn run() -> anyhow::Result<()> {
 
     std::fs::write(PATH, patched).with_context(|| format!("failed to write {PATH}"))?;
 
-    println!("Patched {PATH}: scoped permissions and pinned curl downloads");
+    println!(
+        "Patched {PATH}: scoped permissions, pinned curl downloads, and smoke test dependencies"
+    );
     Ok(())
 }
 

--- a/crates/xtask/src/patch_release_workflow.rs
+++ b/crates/xtask/src/patch_release_workflow.rs
@@ -82,6 +82,11 @@ fn apply_patches(content: &str) -> anyhow::Result<String> {
             "  custom-smoke-test-installers:\n    needs:\n      - plan\n      - build-local-artifacts\n    uses:",
             "  custom-smoke-test-installers:\n    needs:\n      - plan\n      - build-local-artifacts\n      - build-global-artifacts\n    uses:",
         ),
+        // smoke-test-installers uses no secrets; remove cargo-dist's default secrets: inherit
+        (
+            "    secrets: inherit\n    permissions:\n      contents: read",
+            "    permissions:\n      contents: read",
+        ),
     ];
 
     let mut result = content.to_owned();

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,6 +21,9 @@ install-path = "CARGO_HOME"
 github-attestations = true
 github-custom-runners = { global = "ubuntu-latest", x86_64-unknown-linux-gnu = "ubuntu-24.04", x86_64-unknown-linux-musl = "ubuntu-24.04", aarch64-unknown-linux-musl = "ubuntu-24.04-arm", x86_64-pc-windows-msvc = "windows-2025", aarch64-unknown-linux-gnu = "ubuntu-24.04-arm" }
 github-build-setup = "../build-setup.yml"
+# Global artifacts jobs to run in CI
+global-artifacts-jobs = ["./smoke-test-installers"]
+github-custom-job-permissions = { "smoke-test-installers" = { contents = "read" } }
 # Bypass dist's generate --check so we can keep the hand-patched permissions in release.yml
 allow-dirty = ["ci"]
 

--- a/justfile
+++ b/justfile
@@ -45,9 +45,9 @@ generate:
     docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp -v "$(pwd)":/home/weaver/source otel/weaver:v0.24.2 registry generate --registry /home/weaver/source/crates/weaver_live_check/model/ --templates /home/weaver/source/crates/weaver_live_check/templates/ --v2 markdown /home/weaver/source/crates/weaver_live_check/docs/
     cargo fmt -p weaver_live_check
 
-# Run after `dist generate` to restore scoped GitHub workflow permissions
-fix-release-permissions:
-    cargo xtask fix-release-permissions
+# Run after `dist generate` to patch release.yml (permissions, scorecard shas, smoke tests)
+patch-release-workflow:
+    cargo xtask patch-release-workflow
 
 validate-workspace:
     cargo xtask validate


### PR DESCRIPTION
Adds a smoke-test-installers job that runs the freshly generated installers before a release is published, and gates host on it.

Motivated by #1744: v0.26.0 shipped an installer that knew only the Windows target, so every Unix install failed. Every job in that run was green - nothing checks that the installer we publish can install anything.

Between build-global-artifacts and host, on ubuntu x64/arm64, macOS arm64/x64 and Windows, the job serves the just-built artifacts over localhost, runs the real installer against them via the WEAVER_DOWNLOAD_URL override, and asserts weaver --version matches the tag being released. host now requires it, so a broken installer stops the release instead of shipping.

Verified by running the full release workflow on a fork: [all five jobs pass](https://github.com/lmolkova/weaver/actions/runs/33689073940).
