### PR TITLE
Record OTLP context on live-check samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# Unreleased
+
+- Live-check reports now retain OTLP context on their samples, including span and log trace IDs, timestamps, span-event and link context, and metric data-point timing. OTLP finding logs are correlated with their source spans. ([#1749](https://github.com/open-telemetry/weaver/pull/1749) by @clarsen)
+
 # [0.26.1] - 2026-09-02
 
 - Fix `weaver-installer.sh` failing to detect Unix platforms due to missing bash shell in release workflow. ([#1744](https://github.com/open-telemetry/weaver/issues/1744))

--- a/crates/weaver_infer/src/lib.rs
+++ b/crates/weaver_infer/src/lib.rs
@@ -985,6 +985,12 @@ mod tests {
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         };
 
         acc.add_span(span);
@@ -1015,11 +1021,18 @@ mod tests {
                     live_check_result: None,
                 }],
                 live_check_result: None,
+                timestamp: None,
             }],
             span_links: vec![],
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         };
 
         acc.add_span(span);
@@ -1098,6 +1111,12 @@ mod tests {
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         }));
         acc.add_sample(Sample::Metric(SampleMetric {
             name: "requests.total".to_owned(),
@@ -1119,15 +1138,19 @@ mod tests {
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+            timestamp: None,
         }));
         acc.add_sample(Sample::SpanEvent(SampleSpanEvent {
             name: "ignored".to_owned(),
             attributes: vec![],
             live_check_result: None,
+            timestamp: None,
         }));
         acc.add_sample(Sample::SpanLink(SampleSpanLink {
             attributes: vec![],
             live_check_result: None,
+            trace_id: None,
+            span_id: None,
         }));
 
         assert_eq!(acc.stats(), (2, 1, 1, 1));
@@ -1175,6 +1198,8 @@ mod tests {
                 flags: 0,
                 exemplars: vec![],
                 live_check_result: None,
+                start_time: None,
+                end_time: None,
             }])),
             instrumentation_scope: None,
             live_check_result: None,
@@ -1200,6 +1225,8 @@ mod tests {
                 flags: 0,
                 exemplars: vec![],
                 live_check_result: None,
+                start_time: None,
+                end_time: None,
             }])),
             instrumentation_scope: None,
             live_check_result: None,
@@ -1229,6 +1256,8 @@ mod tests {
                     zero_threshold: 0.0,
                     exemplars: vec![],
                     live_check_result: None,
+                    start_time: None,
+                    end_time: None,
                 },
             ])),
             instrumentation_scope: None,
@@ -1305,6 +1334,12 @@ mod tests {
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         });
 
         let registry = acc.to_semconv_spec();
@@ -1419,11 +1454,18 @@ mod tests {
                     },
                 ],
                 live_check_result: None,
+                timestamp: None,
             }],
             span_links: vec![],
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         });
 
         let registry = acc.to_semconv_spec();
@@ -1544,11 +1586,18 @@ mod tests {
                     live_check_result: None,
                 }],
                 live_check_result: None,
+                timestamp: None,
             }],
             span_links: vec![],
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         });
 
         let registry = acc.to_semconv_spec();

--- a/crates/weaver_live_check/Cargo.toml
+++ b/crates/weaver_live_check/Cargo.toml
@@ -39,6 +39,7 @@ serial_test = "3.4.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 ureq.workspace = true
 reqwest.workspace = true
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/weaver_live_check/README.md
+++ b/crates/weaver_live_check/README.md
@@ -287,6 +287,34 @@ To provide your own custom templates use the `--templates` option.
 
 As mentioned, the exit-code is set non-zero if any `violation` finding is provided in the output. This can be used in tests and/or CI to fail builds for example.
 
+### OTLP context in reports
+
+When live check receives OTLP, it records the full telemetry fields on the
+corresponding live-check samples in the report:
+
+```sh
+weaver registry live-check --format json --output ./outdir
+```
+
+Spans include `trace_id`, `span_id`, `parent_span_id`, `trace_state`,
+`start_time`, and `end_time`. Span events include `timestamp`, span links
+include their linked `trace_id` and `span_id`, logs include their trace and
+span IDs plus `timestamp`, and metric data points include `start_time` and
+`end_time`. Timestamps use RFC 3339 format.
+
+Resource and instrumentation-scope data is emitted as `resource` and
+`instrumentation_scope` samples before the signals that share it, rather than
+being repeated on every span, log, or metric. The serialized signal samples do
+not contain a separate reference to those entries, so consumers that need this
+provenance must retain that ordering and grouping.
+
+This is Weaver's live-check report format (JSON, YAML, or JSON Lines), not
+OTLP JSON or OTLP protobuf, and it is not directly ingestible by an OTLP
+backend. It is intended to supplement validation findings with enough source
+context for report consumers. To inspect findings in a standard OpenTelemetry
+backend, enable [`OTLP Log Record Emission`](#otlp-log-record-emission), which
+emits the findings themselves as OTLP log records.
+
 ### Statistics
 
 A statistics entity is produced when the input is closed like this snippet:

--- a/crates/weaver_live_check/src/lib.rs
+++ b/crates/weaver_live_check/src/lib.rs
@@ -444,6 +444,16 @@ impl Sample {
             Sample::Profile(_) => None,
         }
     }
+
+    /// Returns the trace and span IDs associated with a signal, if available.
+    #[must_use]
+    pub fn trace_context_ids(&self) -> Option<(&str, &str)> {
+        match self {
+            Sample::Span(span) => span.trace_id.as_deref().zip(span.span_id.as_deref()),
+            Sample::Log(log) => log.trace_id.as_deref().zip(log.span_id.as_deref()),
+            _ => None,
+        }
+    }
 }
 
 // Dispatch the live check to the sample type
@@ -645,7 +655,26 @@ pub fn get_json_schema() -> Result<String, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sample_log::SampleLog;
     use sample_profile::SampleProfile;
+    use sample_span::{SampleSpan, Status, StatusCode};
+    use weaver_semconv::v1::group::SpanKindSpec;
+
+    fn sample_log_with_timestamp(timestamp: Option<String>) -> SampleLog {
+        SampleLog {
+            event_name: "event".to_owned(),
+            severity_number: None,
+            severity_text: None,
+            body: None,
+            attributes: vec![],
+            trace_id: None,
+            span_id: None,
+            instrumentation_scope: None,
+            live_check_result: None,
+            resource: None,
+            timestamp,
+        }
+    }
 
     fn make_sample_profile() -> SampleProfile {
         SampleProfile {
@@ -654,6 +683,29 @@ mod tests {
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+        }
+    }
+
+    fn sample_span_with_trace_context(trace_id: Option<&str>, span_id: Option<&str>) -> SampleSpan {
+        SampleSpan {
+            name: "operation".to_owned(),
+            kind: SpanKindSpec::Internal,
+            status: Some(Status {
+                code: StatusCode::Ok,
+                message: String::new(),
+            }),
+            attributes: vec![],
+            span_events: vec![],
+            span_links: vec![],
+            instrumentation_scope: None,
+            live_check_result: None,
+            resource: None,
+            trace_id: trace_id.map(str::to_owned),
+            span_id: span_id.map(str::to_owned),
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         }
     }
 
@@ -682,9 +734,74 @@ mod tests {
     }
 
     #[test]
+    fn trace_context_ids_returns_span_context() {
+        let sample = Sample::Span(sample_span_with_trace_context(
+            Some("00000000000000000000000000000001"),
+            Some("0000000000000001"),
+        ));
+
+        assert_eq!(
+            sample.trace_context_ids(),
+            Some(("00000000000000000000000000000001", "0000000000000001"))
+        );
+    }
+
+    #[test]
+    fn trace_context_ids_returns_log_context() {
+        let mut log = sample_log_with_timestamp(None);
+        log.trace_id = Some("00000000000000000000000000000002".to_owned());
+        log.span_id = Some("0000000000000002".to_owned());
+
+        assert_eq!(
+            Sample::Log(log).trace_context_ids(),
+            Some(("00000000000000000000000000000002", "0000000000000002"))
+        );
+    }
+
+    #[test]
+    fn trace_context_ids_returns_none_without_signal_context() {
+        assert_eq!(
+            Sample::Profile(make_sample_profile()).trace_context_ids(),
+            None
+        );
+        assert_eq!(
+            Sample::Span(sample_span_with_trace_context(
+                Some("00000000000000000000000000000001"),
+                None,
+            ))
+            .trace_context_ids(),
+            None
+        );
+    }
+
+    #[test]
     fn test_sample_ref_profile_sample_type() {
         let profile = make_sample_profile();
         let sample_ref = SampleRef::Profile(&profile);
         assert_eq!(sample_ref.sample_type(), SampleType::Profile);
+    }
+
+    #[test]
+    fn report_serializes_captured_timestamp_on_its_source_sample() {
+        let report = LiveCheckReport {
+            samples: vec![Sample::Log(sample_log_with_timestamp(Some(
+                "timestamp".to_owned(),
+            )))],
+            statistics: LiveCheckStatistics::Disabled(DisabledStatistics),
+        };
+
+        let json = serde_json::to_value(report).expect("serialize report");
+        assert_eq!(json["samples"][0]["log"]["timestamp"], "timestamp");
+    }
+
+    #[test]
+    fn report_without_captured_timestamp_omits_it_from_samples() {
+        let report = LiveCheckReport {
+            samples: vec![Sample::Log(sample_log_with_timestamp(None))],
+            statistics: LiveCheckStatistics::Disabled(DisabledStatistics),
+        };
+
+        let json = serde_json::to_value(report).expect("serialize report");
+        assert!(json["samples"][0]["log"].get("timestamp").is_none());
     }
 }

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -1994,6 +1994,8 @@ mod tests {
                     flags: 0,
                     zero_threshold: 0.0,
                     exemplars: vec![],
+                    start_time: None,
+                    end_time: None,
                 },
             ])),
             instrumentation_scope: None,
@@ -2073,6 +2075,8 @@ mod tests {
                     trace_id: "".to_owned(),
                     live_check_result: None,
                 }],
+                start_time: None,
+                end_time: None,
             }])),
             instrumentation_scope: None,
             live_check_result: None,
@@ -2474,6 +2478,7 @@ mod tests {
             instrumentation_scope: None,
             live_check_result: None,
             resource: Some(resource),
+            timestamp: None,
         })
     }
 
@@ -2629,6 +2634,7 @@ mod tests {
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+            timestamp: None,
         });
         sample_no_resource
             .run_live_check(
@@ -2744,6 +2750,12 @@ mod tests {
                 attributes: vec![],
                 live_check_result: None,
             })),
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         });
         let mut stats =
             LiveCheckStatistics::Cumulative(CumulativeStatistics::new(&live_checker.registry));
@@ -3744,6 +3756,8 @@ mod tests {
                     flags: 0,
                     exemplars: vec![],
                     live_check_result: None,
+                    start_time: None,
+                    end_time: None,
                 }])),
                 instrumentation_scope: None,
                 live_check_result: None,

--- a/crates/weaver_live_check/src/otlp_logger.rs
+++ b/crates/weaver_live_check/src/otlp_logger.rs
@@ -2,8 +2,8 @@
 
 //! OTLP logger provider for emitting policy findings as log records.
 
-use opentelemetry::logs::{AnyValue, Logger, LoggerProvider, Severity};
-use opentelemetry::{Key, KeyValue};
+use opentelemetry::logs::{AnyValue, LogRecord as _, Logger, LoggerProvider, Severity};
+use opentelemetry::{Key, KeyValue, SpanId, TraceId};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
 use opentelemetry_sdk::resource::ResourceDetector;
@@ -136,6 +136,10 @@ impl OtlpEmitter {
             signal_type.as_ref(),
         );
 
+        if let Some((trace_id, span_id)) = trace_context_from_sample(parent_signal) {
+            log_record.set_trace_context(trace_id, span_id, None);
+        }
+
         logger.emit(log_record);
     }
 
@@ -152,6 +156,13 @@ impl OtlpEmitter {
             error: format!("Failed to shutdown OTLP log provider: {e}"),
         })
     }
+}
+
+fn trace_context_from_sample(sample: &Sample) -> Option<(TraceId, SpanId)> {
+    let (trace_id, span_id) = sample.trace_context_ids()?;
+    TraceId::from_hex(trace_id)
+        .ok()
+        .zip(SpanId::from_hex(span_id).ok())
 }
 
 impl From<&FindingLevel> for GeneratedFindingLevel {
@@ -267,6 +278,7 @@ mod tests {
     use crate::sample_metric::{SampleInstrument, SampleMetric};
     use crate::sample_resource::SampleResource;
     use crate::sample_span::{SampleSpan, SampleSpanEvent, SampleSpanLink, Status, StatusCode};
+    use opentelemetry_sdk::logs::InMemoryLogExporter;
     use serde_json::json;
     use weaver_checker::{FindingLevel, PolicyFinding};
     use weaver_semconv::v1::group::{InstrumentSpec, SpanKindSpec};
@@ -296,7 +308,75 @@ mod tests {
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         }
+    }
+
+    #[test]
+    fn finding_trace_context_uses_the_source_span_ids() {
+        let mut span = create_test_span("operation");
+        span.trace_id = Some("00000000000000000000000000000001".to_owned());
+        span.span_id = Some("0000000000000001".to_owned());
+
+        let (trace_id, span_id) =
+            trace_context_from_sample(&Sample::Span(span)).expect("trace context");
+        assert_eq!(trace_id.to_string(), "00000000000000000000000000000001");
+        assert_eq!(span_id.to_string(), "0000000000000001");
+    }
+
+    #[test]
+    fn finding_trace_context_ignores_invalid_or_missing_ids() {
+        let mut span = create_test_span("operation");
+        span.trace_id = Some("not-a-trace-id".to_owned());
+        span.span_id = Some("0000000000000001".to_owned());
+        assert!(trace_context_from_sample(&Sample::Span(span)).is_none());
+
+        assert!(
+            trace_context_from_sample(&Sample::Attribute(create_test_attribute("key"))).is_none()
+        );
+    }
+
+    #[test]
+    fn emit_finding_sets_trace_context_from_parent_span() {
+        let exporter = InMemoryLogExporter::default();
+        let provider = SdkLoggerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let emitter = OtlpEmitter { provider };
+        let mut span = create_test_span("operation");
+        span.trace_id = Some("00000000000000000000000000000001".to_owned());
+        span.span_id = Some("0000000000000001".to_owned());
+        let finding = create_test_finding(
+            "test-finding",
+            "test message",
+            FindingLevel::Violation,
+            Some("span"),
+            Some("operation"),
+            None,
+        );
+
+        let parent_signal = Sample::Span(span);
+        let Sample::Span(parent_span) = &parent_signal else {
+            unreachable!("parent signal is a span")
+        };
+        emitter.emit_finding(&finding, &SampleRef::Span(parent_span), &parent_signal);
+
+        let emitted = exporter.get_emitted_logs().expect("emitted logs");
+        assert_eq!(emitted.len(), 1);
+        let trace_context = emitted[0]
+            .record
+            .trace_context()
+            .expect("trace context on finding");
+        assert_eq!(
+            trace_context.trace_id.to_string(),
+            "00000000000000000000000000000001"
+        );
+        assert_eq!(trace_context.span_id.to_string(), "0000000000000001");
     }
 
     // Helper function to create a test metric
@@ -838,6 +918,7 @@ mod tests {
             name: "test".to_owned(),
             attributes: vec![],
             live_check_result: None,
+            timestamp: None,
         };
         assert_eq!(
             SampleRef::SpanEvent(&event_sample).sample_type(),
@@ -847,6 +928,8 @@ mod tests {
         let link_sample = SampleSpanLink {
             attributes: vec![],
             live_check_result: None,
+            trace_id: None,
+            span_id: None,
         };
         assert_eq!(
             SampleRef::SpanLink(&link_sample).sample_type(),

--- a/crates/weaver_live_check/src/sample_log.rs
+++ b/crates/weaver_live_check/src/sample_log.rs
@@ -44,6 +44,9 @@ pub struct SampleLog {
     /// Reference to the parent resource (not serialized)
     #[serde(skip)]
     pub resource: Option<Rc<SampleResource>>,
+    /// Event timestamp from the OTLP log record in RFC3339 format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
 }
 
 impl LiveCheckRunner for SampleLog {

--- a/crates/weaver_live_check/src/sample_metric.rs
+++ b/crates/weaver_live_check/src/sample_metric.rs
@@ -58,6 +58,12 @@ pub struct SampleNumberDataPoint {
     pub exemplars: Vec<SampleExemplar>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
+    /// Start timestamp from the OTLP data point in RFC3339 format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<String>,
+    /// End timestamp from the OTLP data point in RFC3339 format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_time: Option<String>,
 }
 
 impl Advisable for SampleNumberDataPoint {
@@ -118,6 +124,12 @@ pub struct SampleHistogramDataPoint {
     pub exemplars: Vec<SampleExemplar>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
+    /// Start timestamp from the OTLP data point in RFC3339 format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<String>,
+    /// End timestamp from the OTLP data point in RFC3339 format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_time: Option<String>,
 }
 
 impl Advisable for SampleHistogramDataPoint {
@@ -193,6 +205,12 @@ pub struct SampleExponentialHistogramDataPoint {
     pub exemplars: Vec<SampleExemplar>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
+    /// Start timestamp from the OTLP data point in RFC3339 format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<String>,
+    /// End timestamp from the OTLP data point in RFC3339 format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_time: Option<String>,
 }
 
 impl Advisable for SampleExponentialHistogramDataPoint {

--- a/crates/weaver_live_check/src/sample_span.rs
+++ b/crates/weaver_live_check/src/sample_span.rs
@@ -62,6 +62,24 @@ pub struct SampleSpan {
     /// Reference to the parent resource (not serialized)
     #[serde(skip)]
     pub resource: Option<Rc<SampleResource>>,
+    /// Trace ID from the OTLP span.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    /// Span ID from the OTLP span.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
+    /// Parent span ID from the OTLP span.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_span_id: Option<String>,
+    /// W3C tracestate from the OTLP span.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_state: Option<String>,
+    /// Start timestamp from the OTLP span in RFC3339 format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<String>,
+    /// End timestamp from the OTLP span in RFC3339 format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_time: Option<String>,
 }
 
 impl Advisable for SampleSpan {
@@ -108,6 +126,9 @@ pub struct SampleSpanEvent {
     pub attributes: Vec<SampleAttribute>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
+    /// Event timestamp from the OTLP span in RFC3339 format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
 }
 
 impl Advisable for SampleSpanEvent {
@@ -144,6 +165,12 @@ pub struct SampleSpanLink {
     pub attributes: Vec<SampleAttribute>,
     /// Live check result
     pub live_check_result: Option<LiveCheckResult>,
+    /// Linked trace ID from the OTLP span.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    /// Linked span ID from the OTLP span.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
 }
 
 impl Advisable for SampleSpanLink {

--- a/crates/weaver_live_check/tests/livecheck_emit.rs
+++ b/crates/weaver_live_check/tests/livecheck_emit.rs
@@ -210,6 +210,12 @@ async fn test_livecheck_emit_roundtrip() {
             instrumentation_scope: None,
             live_check_result: None,
             resource: None,
+            trace_id: Some("00000000000000000000000000000001".to_owned()),
+            span_id: Some("0000000000000001".to_owned()),
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         };
         let parent = Sample::Span(span.clone());
         let sample_ref = SampleRef::Span(&span);
@@ -315,6 +321,12 @@ async fn test_livecheck_emit_roundtrip() {
             instrumentation_scope: None,
             live_check_result: None,
             resource: Some(Rc::new(resource)),
+            trace_id: None,
+            span_id: None,
+            parent_span_id: None,
+            trace_state: None,
+            start_time: None,
+            end_time: None,
         };
         let parent = Sample::Span(span.clone());
         let sample_ref = SampleRef::Span(&span);
@@ -351,6 +363,7 @@ async fn test_livecheck_emit_roundtrip() {
             instrumentation_scope: None,
             live_check_result: None,
             resource: Some(Rc::new(resource)),
+            timestamp: None,
         };
         let parent = Sample::Log(log.clone());
         let sample_ref = SampleRef::Log(&log);
@@ -402,6 +415,35 @@ async fn test_livecheck_emit_roundtrip() {
     assert!(
         total_entities > 0,
         "Expected total_entities > 0 (data flowed through), got {total_entities}"
+    );
+
+    let samples = report["samples"].as_array().expect("report samples");
+    let emitted_finding = samples
+        .iter()
+        .filter_map(|sample| sample.get("log"))
+        .find(|log| {
+            log["trace_id"] == "00000000000000000000000000000001"
+                && log["span_id"] == "0000000000000001"
+        })
+        .expect("captured finding log correlated with its source span");
+    assert!(
+        emitted_finding["timestamp"].is_string(),
+        "captured finding log should retain its OTLP timestamp"
+    );
+    let attributes = emitted_finding["attributes"]
+        .as_array()
+        .expect("captured finding log attributes");
+    assert!(
+        attributes
+            .iter()
+            .any(|attribute| attribute["name"] == "weaver.finding.id"),
+        "captured finding log should retain generated finding attributes"
+    );
+    assert!(
+        attributes
+            .iter()
+            .any(|attribute| attribute["name"] == "weaver.finding.context.attribute_key"),
+        "captured finding log should retain generated finding context attributes"
     );
 
     // Read violation count from statistics

--- a/src/registry/infer.rs
+++ b/src/registry/infer.rs
@@ -124,6 +124,12 @@ fn process_otlp_request(request: OtlpRequest, accumulator: &mut AccumulatedSampl
                             instrumentation_scope: None,
                             live_check_result: None,
                             resource: None,
+                            trace_id: None,
+                            span_id: None,
+                            parent_span_id: None,
+                            trace_state: None,
+                            start_time: None,
+                            end_time: None,
                         };
                         for attribute in span.attributes {
                             sample_span
@@ -135,6 +141,7 @@ fn process_otlp_request(request: OtlpRequest, accumulator: &mut AccumulatedSampl
                                 name: event.name,
                                 attributes: Vec::new(),
                                 live_check_result: None,
+                                timestamp: None,
                             };
                             for attribute in event.attributes {
                                 sample_event

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -221,8 +221,8 @@ fn generate_report(
         }
     } else {
         let report = LiveCheckReport {
-            statistics: stats,
             samples,
+            statistics: stats,
         };
         output.generate(&report)
     }
@@ -451,8 +451,8 @@ pub(crate) fn command(
                 lines.join("\n")
             } else {
                 let report = LiveCheckReport {
-                    statistics: stats,
                     samples,
+                    statistics: stats,
                 };
                 output
                     .generate_to_string(&report)

--- a/src/registry/otlp/conversion.rs
+++ b/src/registry/otlp/conversion.rs
@@ -126,7 +126,7 @@ pub fn status_from_otlp_status(
     None
 }
 
-/// Converts an OTLP metric to a SampleMetric
+/// Converts an OTLP metric to a SampleMetric.
 pub fn otlp_metric_to_sample(otlp_metric: Metric) -> SampleMetric {
     SampleMetric {
         name: otlp_metric.name,
@@ -181,6 +181,19 @@ fn otlp_data_to_data_points(data: &Option<Data>) -> Option<DataPoints> {
     }
 }
 
+/// Builds the raw-context (start/end time only; resource and scope are
+/// filled in by the caller, which holds them as `Rc`s shared across every
+/// data point in the same metric) for one metric data point.
+fn otlp_data_point_times(
+    start_time_unix_nano: u64,
+    time_unix_nano: u64,
+) -> (Option<String>, Option<String>) {
+    (
+        optional_unix_nanos_to_utc(start_time_unix_nano),
+        optional_unix_nanos_to_utc(time_unix_nano),
+    )
+}
+
 /// Converts an OTLP Exemplar to a SampleExemplar
 fn otlp_exemplar_to_sample_exemplar(
     exemplar: &super::grpc_stubs::proto::metrics::v1::Exemplar,
@@ -209,6 +222,15 @@ fn otlp_exemplar_to_sample_exemplar(
     }
 }
 
+/// `""` is how every ID conversion below signals an absent or malformed input.
+pub(crate) fn non_empty(s: String) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
 /// Converts a Unix timestamp in nanoseconds to a UTC string
 fn unix_nanos_to_utc(time_unix_nano: u64) -> String {
     if let Ok(nanos) = time_unix_nano.try_into() {
@@ -218,9 +240,22 @@ fn unix_nanos_to_utc(time_unix_nano: u64) -> String {
     }
 }
 
+/// Same conversion as `unix_nanos_to_utc`, but for a field that is legitimately
+/// unset at zero (a metric data point's `start_time_unix_nano`, for
+/// instance) rather than always populated the way a span's timestamps are.
+/// `unix_nanos_to_utc(0)` would otherwise render as the 1970 epoch instead
+/// of being absent.
+pub(crate) fn optional_unix_nanos_to_utc(time_unix_nano: u64) -> Option<String> {
+    if time_unix_nano == 0 {
+        None
+    } else {
+        non_empty(unix_nanos_to_utc(time_unix_nano))
+    }
+}
+
 /// Converts a span ID (8 bytes) to a hex string
-fn span_id_hex(span_id: &[u8]) -> String {
-    if span_id.len() == 8 {
+pub(super) fn span_id_hex(span_id: &[u8]) -> String {
+    if span_id.len() == 8 && span_id.iter().any(|byte| *byte != 0) {
         format!(
             "{:016x}",
             u64::from_be_bytes(span_id[0..8].try_into().unwrap_or([0; 8]))
@@ -231,8 +266,8 @@ fn span_id_hex(span_id: &[u8]) -> String {
 }
 
 /// Converts a trace ID (16 bytes) to a hex string
-fn trace_id_hex(trace_id: &[u8]) -> String {
-    if trace_id.len() == 16 {
+pub(super) fn trace_id_hex(trace_id: &[u8]) -> String {
+    if trace_id.len() == 16 && trace_id.iter().any(|byte| *byte != 0) {
         format!(
             "{:032x}",
             u128::from_be_bytes(trace_id[0..16].try_into().unwrap_or([0; 16]))
@@ -248,6 +283,8 @@ fn otlp_exponential_histogram_data_points(
 ) -> DataPoints {
     let mut data_points = Vec::new();
     for point in otlp {
+        let (start_time, end_time) =
+            otlp_data_point_times(point.start_time_unix_nano, point.time_unix_nano);
         let positive = point.positive.as_ref().map(|buckets| {
             weaver_live_check::sample_metric::SampleExponentialHistogramBuckets {
                 offset: buckets.offset,
@@ -287,6 +324,8 @@ fn otlp_exponential_histogram_data_points(
                 zero_threshold: point.zero_threshold,
                 exemplars,
                 live_check_result: None,
+                start_time,
+                end_time,
             };
         data_points.push(live_check_point);
     }
@@ -297,6 +336,8 @@ fn otlp_exponential_histogram_data_points(
 fn otlp_histogram_data_points(otlp: &Vec<HistogramDataPoint>) -> DataPoints {
     let mut data_points = Vec::new();
     for point in otlp {
+        let (start_time, end_time) =
+            otlp_data_point_times(point.start_time_unix_nano, point.time_unix_nano);
         let exemplars = point
             .exemplars
             .iter()
@@ -318,6 +359,8 @@ fn otlp_histogram_data_points(otlp: &Vec<HistogramDataPoint>) -> DataPoints {
             flags: point.flags,
             exemplars,
             live_check_result: None,
+            start_time,
+            end_time,
         };
         data_points.push(live_check_point);
     }
@@ -328,6 +371,8 @@ fn otlp_histogram_data_points(otlp: &Vec<HistogramDataPoint>) -> DataPoints {
 fn otlp_number_data_points(otlp: &Vec<NumberDataPoint>) -> DataPoints {
     let mut data_points = Vec::new();
     for point in otlp {
+        let (start_time, end_time) =
+            otlp_data_point_times(point.start_time_unix_nano, point.time_unix_nano);
         let exemplars = point
             .exemplars
             .iter()
@@ -354,6 +399,8 @@ fn otlp_number_data_points(otlp: &Vec<NumberDataPoint>) -> DataPoints {
             flags: point.flags,
             exemplars,
             live_check_result: None,
+            start_time,
+            end_time,
         };
         data_points.push(live_check_point);
     }
@@ -405,7 +452,7 @@ pub fn otlp_profile_to_sample(
     }
 }
 
-/// Converts an OTLP LogRecord to a SampleLog
+/// Converts an OTLP LogRecord to a SampleLog.
 pub fn otlp_log_record_to_sample_log(log_record: &LogRecord) -> SampleLog {
     SampleLog {
         event_name: log_record.event_name.clone(),
@@ -439,5 +486,7 @@ pub fn otlp_log_record_to_sample_log(log_record: &LogRecord) -> SampleLog {
         instrumentation_scope: None,
         live_check_result: None,
         resource: None,
+        timestamp: optional_unix_nanos_to_utc(log_record.time_unix_nano)
+            .or_else(|| optional_unix_nanos_to_utc(log_record.observed_time_unix_nano)),
     }
 }

--- a/src/registry/otlp/otlp_ingester.rs
+++ b/src/registry/otlp/otlp_ingester.rs
@@ -14,9 +14,10 @@ use weaver_live_check::{
 
 use super::{
     conversion::{
-        otlp_instrumentation_scope_to_sample, otlp_log_record_to_sample_log, otlp_metric_to_sample,
-        otlp_profile_to_sample, sample_attribute_from_key_value, span_kind_from_otlp_kind,
-        status_from_otlp_status,
+        non_empty, optional_unix_nanos_to_utc, otlp_instrumentation_scope_to_sample,
+        otlp_log_record_to_sample_log, otlp_metric_to_sample, otlp_profile_to_sample,
+        sample_attribute_from_key_value, span_id_hex, span_kind_from_otlp_kind,
+        status_from_otlp_status, trace_id_hex,
     },
     listen_otlp_requests, OtlpRequest, ShutdownCoordinator,
 };
@@ -171,6 +172,12 @@ impl OtlpIterator {
                                 instrumentation_scope: instrumentation_scope.clone(),
                                 live_check_result: None,
                                 resource: rc_resource.clone(),
+                                trace_id: non_empty(trace_id_hex(&span.trace_id)),
+                                span_id: non_empty(span_id_hex(&span.span_id)),
+                                parent_span_id: non_empty(span_id_hex(&span.parent_span_id)),
+                                trace_state: non_empty(span.trace_state.clone()),
+                                start_time: optional_unix_nanos_to_utc(span.start_time_unix_nano),
+                                end_time: optional_unix_nanos_to_utc(span.end_time_unix_nano),
                             };
                             for attribute in span.attributes {
                                 sample_span
@@ -182,6 +189,7 @@ impl OtlpIterator {
                                     name: event.name,
                                     attributes: Vec::new(),
                                     live_check_result: None,
+                                    timestamp: optional_unix_nanos_to_utc(event.time_unix_nano),
                                 };
                                 for attribute in event.attributes {
                                     sample_event
@@ -194,6 +202,8 @@ impl OtlpIterator {
                                 let mut sample_link = SampleSpanLink {
                                     attributes: Vec::new(),
                                     live_check_result: None,
+                                    trace_id: non_empty(trace_id_hex(&link.trace_id)),
+                                    span_id: non_empty(span_id_hex(&link.span_id)),
                                 };
                                 for attribute in link.attributes {
                                     sample_link
@@ -335,10 +345,14 @@ mod tests {
         },
         common::v1::{any_value, AnyValue, InstrumentationScope, KeyValue},
         logs::v1::{LogRecord, ResourceLogs, ScopeLogs},
-        metrics::v1::{Metric, ResourceMetrics, ScopeMetrics},
+        metrics::v1::{
+            metric::Data as MetricData, Gauge, Metric, NumberDataPoint, ResourceMetrics,
+            ScopeMetrics,
+        },
         resource::v1::Resource,
-        trace::v1::{ResourceSpans, ScopeSpans, Span},
+        trace::v1::{span::Event, span::Link, ResourceSpans, ScopeSpans, Span},
     };
+    use weaver_live_check::{DisabledStatistics, LiveCheckReport, LiveCheckStatistics};
 
     fn string_attribute(name: &str, value: &str) -> KeyValue {
         KeyValue {
@@ -644,5 +658,284 @@ mod tests {
                 .name,
             "scope.environment"
         );
+    }
+
+    #[test]
+    fn captured_telemetry_report_orders_distinct_resource_scope_groups_before_spans() {
+        let request = OtlpRequest::Traces(ExportTraceServiceRequest {
+            resource_spans: vec![
+                ResourceSpans {
+                    resource: Some(Resource {
+                        attributes: vec![string_attribute("service.name", "checkout")],
+                        ..Default::default()
+                    }),
+                    scope_spans: vec![ScopeSpans {
+                        scope: Some(scope("checkout-library")),
+                        spans: vec![Span {
+                            name: "checkout-operation".to_owned(),
+                            trace_id: vec![0u8; 15].into_iter().chain([1]).collect(),
+                            span_id: vec![0u8; 7].into_iter().chain([1]).collect(),
+                            ..Default::default()
+                        }],
+                        schema_url: "https://example.test/checkout".to_owned(),
+                    }],
+                    ..Default::default()
+                },
+                ResourceSpans {
+                    resource: Some(Resource {
+                        attributes: vec![string_attribute("service.name", "payment")],
+                        ..Default::default()
+                    }),
+                    scope_spans: vec![ScopeSpans {
+                        scope: Some(scope("payment-library")),
+                        spans: vec![Span {
+                            name: "payment-operation".to_owned(),
+                            trace_id: vec![0u8; 15].into_iter().chain([2]).collect(),
+                            span_id: vec![0u8; 7].into_iter().chain([2]).collect(),
+                            ..Default::default()
+                        }],
+                        schema_url: "https://example.test/payment".to_owned(),
+                    }],
+                    ..Default::default()
+                },
+            ],
+        });
+
+        let report = LiveCheckReport {
+            samples: collect(vec![request]),
+            statistics: LiveCheckStatistics::Disabled(DisabledStatistics),
+        };
+        let json = serde_json::to_value(report).expect("report serializes");
+        let samples = json["samples"].as_array().expect("samples array");
+
+        assert_eq!(samples.len(), 6);
+        assert_eq!(samples[0]["resource"]["attributes"][0]["value"], "checkout");
+        assert_eq!(
+            samples[1]["instrumentation_scope"]["name"],
+            "checkout-library"
+        );
+        assert_eq!(samples[2]["span"]["name"], "checkout-operation");
+        assert_eq!(
+            samples[2]["span"]["trace_id"],
+            "00000000000000000000000000000001"
+        );
+        assert_eq!(samples[3]["resource"]["attributes"][0]["value"], "payment");
+        assert_eq!(
+            samples[4]["instrumentation_scope"]["name"],
+            "payment-library"
+        );
+        assert_eq!(samples[5]["span"]["name"], "payment-operation");
+        assert_eq!(
+            samples[5]["span"]["trace_id"],
+            "00000000000000000000000000000002"
+        );
+    }
+
+    fn resource_scoped_trace_request(span: Span) -> OtlpRequest {
+        OtlpRequest::Traces(ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![string_attribute("service.name", "checkout")],
+                    ..Default::default()
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: Some(scope("trace-library")),
+                    spans: vec![span],
+                    schema_url: "https://example.test/trace".to_owned(),
+                }],
+                ..Default::default()
+            }],
+        })
+    }
+
+    fn find_span(samples: &[Sample]) -> &SampleSpan {
+        samples
+            .iter()
+            .find_map(|sample| match sample {
+                Sample::Span(span) => Some(span),
+                _ => None,
+            })
+            .expect("span sample")
+    }
+
+    #[test]
+    fn telemetry_context_is_populated_by_default() {
+        let span = Span {
+            name: "operation".to_owned(),
+            trace_id: vec![0u8; 15].into_iter().chain([1]).collect(),
+            span_id: vec![0u8; 7].into_iter().chain([1]).collect(),
+            start_time_unix_nano: 1_000,
+            end_time_unix_nano: 2_000,
+            events: vec![Event {
+                time_unix_nano: 1_500,
+                name: "event".to_owned(),
+                ..Default::default()
+            }],
+            links: vec![Link {
+                trace_id: vec![0u8; 15].into_iter().chain([2]).collect(),
+                span_id: vec![0u8; 7].into_iter().chain([2]).collect(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let samples = collect(vec![resource_scoped_trace_request(span)]);
+        let span = find_span(&samples);
+        assert!(span.trace_id.is_some());
+        assert!(span.span_events[0].timestamp.is_some());
+        assert!(span.span_links[0].trace_id.is_some());
+    }
+
+    #[test]
+    fn telemetry_context_includes_span_identity_timing_and_provenance() {
+        let span = Span {
+            name: "operation".to_owned(),
+            trace_id: vec![0u8; 15].into_iter().chain([1]).collect(),
+            span_id: vec![0u8; 7].into_iter().chain([1]).collect(),
+            parent_span_id: vec![0u8; 7].into_iter().chain([2]).collect(),
+            trace_state: "vendor=value".to_owned(),
+            start_time_unix_nano: 1_000,
+            end_time_unix_nano: 2_000,
+            ..Default::default()
+        };
+        let samples = collect(vec![resource_scoped_trace_request(span)]);
+        let span = find_span(&samples);
+        assert_eq!(
+            span.trace_id.as_deref(),
+            Some("00000000000000000000000000000001")
+        );
+        assert_eq!(span.span_id.as_deref(), Some("0000000000000001"));
+        assert_eq!(span.parent_span_id.as_deref(), Some("0000000000000002"));
+        assert_eq!(span.trace_state.as_deref(), Some("vendor=value"));
+        assert!(span.start_time.is_some());
+        assert!(span.end_time.is_some());
+    }
+
+    #[test]
+    fn telemetry_context_omits_invalid_all_zero_span_ids() {
+        let span = Span {
+            name: "operation".to_owned(),
+            trace_id: vec![0; 16],
+            span_id: vec![0; 8],
+            ..Default::default()
+        };
+
+        let samples = collect(vec![resource_scoped_trace_request(span)]);
+        let span = find_span(&samples);
+
+        assert_eq!(span.trace_id, None);
+        assert_eq!(span.span_id, None);
+    }
+
+    #[test]
+    fn telemetry_context_includes_span_event_and_link_fields() {
+        let span = Span {
+            name: "operation".to_owned(),
+            events: vec![Event {
+                time_unix_nano: 1_500,
+                name: "event".to_owned(),
+                ..Default::default()
+            }],
+            links: vec![Link {
+                trace_id: vec![0u8; 15].into_iter().chain([2]).collect(),
+                span_id: vec![0u8; 7].into_iter().chain([2]).collect(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let samples = collect(vec![resource_scoped_trace_request(span)]);
+        let span = find_span(&samples);
+
+        // A span event carries one timestamp, not identity/resource/scope.
+        assert!(span.span_events[0].timestamp.is_some());
+
+        // A span link carries the *linked* span's identity, nothing else.
+        assert_eq!(
+            span.span_links[0].trace_id.as_deref(),
+            Some("00000000000000000000000000000002")
+        );
+        assert_eq!(
+            span.span_links[0].span_id.as_deref(),
+            Some("0000000000000002")
+        );
+    }
+
+    #[test]
+    fn telemetry_context_includes_log_fields() {
+        let request = OtlpRequest::Logs(ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                resource: Some(Resource {
+                    attributes: vec![string_attribute("service.name", "checkout")],
+                    ..Default::default()
+                }),
+                scope_logs: vec![ScopeLogs {
+                    scope: Some(scope("log-library")),
+                    log_records: vec![LogRecord {
+                        event_name: "widget.created".to_owned(),
+                        time_unix_nano: 1_000,
+                        trace_id: vec![0u8; 15].into_iter().chain([1]).collect(),
+                        span_id: vec![0u8; 7].into_iter().chain([2]).collect(),
+                        ..Default::default()
+                    }],
+                    schema_url: "https://example.test/log".to_owned(),
+                }],
+                ..Default::default()
+            }],
+        });
+
+        let samples = collect(vec![request]);
+        let log = samples
+            .iter()
+            .find_map(|sample| match sample {
+                Sample::Log(log) => Some(log),
+                _ => None,
+            })
+            .expect("log sample");
+        assert!(log.timestamp.is_some());
+        assert_eq!(
+            log.trace_id.as_deref(),
+            Some("00000000000000000000000000000001")
+        );
+        assert_eq!(log.span_id.as_deref(), Some("0000000000000002"));
+    }
+
+    #[test]
+    fn telemetry_context_treats_zero_start_time_as_absent_on_a_data_point() {
+        // A data point's start_time_unix_nano is legitimately 0 for some
+        // metric types — that must not render as the 1970 epoch.
+        let request = OtlpRequest::Metrics(ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: vec![Metric {
+                        name: "widgets.count".to_owned(),
+                        data: Some(MetricData::Gauge(Gauge {
+                            data_points: vec![NumberDataPoint {
+                                start_time_unix_nano: 0,
+                                time_unix_nano: 2_000,
+                                ..Default::default()
+                            }],
+                        })),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        });
+
+        let samples = collect(vec![request]);
+        let metric = samples
+            .iter()
+            .find_map(|sample| match sample {
+                Sample::Metric(metric) => Some(metric),
+                _ => None,
+            })
+            .expect("metric sample");
+        let weaver_live_check::sample_metric::DataPoints::Number(points) =
+            metric.data_points.as_ref().expect("data points")
+        else {
+            panic!("expected number data points");
+        };
+        assert_eq!(points[0].start_time, None);
+        assert!(points[0].end_time.is_some());
     }
 }


### PR DESCRIPTION
Populate OTLP identity and timing fields directly on live-check
    samples and serialize them in reports by default. Document the
    report format and cover default propagation, finding output,
    and distinct resource/scope ordering.