### PR TITLE
v2: disallow entity refinement without identity

### DIFF
--- a/crates/weaver_resolver/data/registry-test-v2-9-identity-refinement-no-identity/expected-errors.json
+++ b/crates/weaver_resolver/data/registry-test-v2-9-identity-refinement-no-identity/expected-errors.json
@@ -1,0 +1,1 @@
+{"CompoundError":[{"EntityRefinementWithoutIdentity":{"refinement_id":"tiny.legacy.refined","ref":"entity.tiny.legacy","provenance":{"schema_url":"https://default/0.1.0","path":"data/registry-test-v2-9-identity-refinement-no-identity/registry/v2.yaml"}}}]}

--- a/crates/weaver_resolver/data/registry-test-v2-9-identity-refinement-no-identity/registry/v1.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-9-identity-refinement-no-identity/registry/v1.yaml
@@ -1,0 +1,13 @@
+file_format: definition/1
+groups:
+  - id: entity.tiny.legacy
+    type: entity
+    name: tiny.legacy
+    stability: development
+    brief: A v1 entity with no identifying attributes.
+    attributes:
+      - id: tiny.color
+        type: string
+        stability: development
+        brief: A color.
+        examples: ['red']

--- a/crates/weaver_resolver/data/registry-test-v2-9-identity-refinement-no-identity/registry/v2.yaml
+++ b/crates/weaver_resolver/data/registry-test-v2-9-identity-refinement-no-identity/registry/v2.yaml
@@ -1,0 +1,6 @@
+file_format: definition/2
+entity_refinements:
+  - id: tiny.legacy.refined
+    ref: tiny.legacy
+    stability: development
+    brief: Refinement of an entity that has no identity attributes.

--- a/crates/weaver_resolver/src/error.rs
+++ b/crates/weaver_resolver/src/error.rs
@@ -271,6 +271,20 @@ pub enum Error {
         provenance: Option<Box<Provenance>>,
     },
 
+    /// Entity refinement whose base entity has no identity attributes.
+    #[error("Entity refinement `{refinement_id}` cannot refine `{ref}`: `{ref}` does not declare any `identity` attributes and is not valid under the v2 schema.\nProvenance: {provenance:?}")]
+    #[diagnostic(help(
+        "The base entity must declare at least one `identity` attribute before it can be refined."
+    ))]
+    EntityRefinementWithoutIdentity {
+        /// The id of the refinement with the issue.
+        refinement_id: String,
+        /// The entity being refined, as written in the refinement's `ref`.
+        r#ref: String,
+        /// The provenance of the refinement (URL or path).
+        provenance: Option<Box<Provenance>>,
+    },
+
     /// A duplicate attribute id error.
     #[error("The attribute id `{attribute_id}` is declared multiple times in the following groups:\n{group_ids:?}")]
     DuplicateAttributeId {

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -1049,7 +1049,8 @@ fn resolve_extends_references(ureg: &mut UnresolvedRegistry) -> Result<(), Error
 }
 
 /// Errors when an entity refinement alters the identity of the base entity
-/// (demoting, promoting, or adding an identity attribute).
+/// (demoting, promoting, or adding an identity attribute) or refines an entity
+/// that does not declare any identity attributes.
 fn entity_identity_refinement_errors(
     group: &UnresolvedGroup,
     extends: &str,
@@ -1060,6 +1061,18 @@ fn entity_identity_refinement_errors(
     let role_of = |spec: &AttributeSpec| match spec {
         AttributeSpec::Ref { role, .. } | AttributeSpec::Id { role, .. } => role.clone(),
     };
+
+    let has_identity = parent_attrs
+        .iter()
+        .any(|p| role_of(&p.spec) == Some(AttributeRole::Identifying));
+
+    if !has_identity {
+        return vec![Error::EntityRefinementWithoutIdentity {
+            refinement_id: group.group.id.clone(),
+            r#ref: extends.to_owned(),
+            provenance: group.provenance.clone().map(Box::new),
+        }];
+    }
 
     group
         .attributes
@@ -1073,7 +1086,8 @@ fn entity_identity_refinement_errors(
                 // Attribute declared by the base entity: its identity role
                 // must not change.
                 Some(base) => {
-                    role_of(&base.spec).is_some_and(|base_role| base_role != *refined_role)
+                    let base_role = role_of(&base.spec).unwrap_or(AttributeRole::Descriptive);
+                    base_role != *refined_role
                 }
                 // Attribute introduced by the refinement: allowed only under
                 // `description`, never as a new identity attribute.

--- a/src/registry/check.rs
+++ b/src/registry/check.rs
@@ -349,4 +349,33 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn test_v2_entity_refinement_without_identity() {
+        let registry_cmd = RegistryCommand {
+            command: RegistrySubCommand::Check(RegistryCheckArgs {
+                registry: RegistryArgs {
+                    registry: Some(VirtualDirectoryPath::LocalFolder {
+                        path: "crates/weaver_resolver/data/registry-test-v2-9-identity-refinement-no-identity/registry".to_owned(),
+                    }),
+                    v2: Some(true),
+                    ..Default::default()
+                },
+                baseline_registry: None,
+                policy: PolicyArgs {
+                    ..Default::default()
+                },
+                diagnostic: Default::default(),
+            }),
+        };
+        let cmd_result = semconv_registry(&registry_cmd, None, &HttpAuthResolver::empty());
+        assert!(cmd_result.command_result.is_err());
+        if let Err(diag_msgs) = cmd_result.command_result {
+            let messages = format!("{diag_msgs:?}");
+            assert!(
+                messages.contains("Entity refinement `tiny.legacy.refined` cannot refine `entity.tiny.legacy`: `entity.tiny.legacy` does not declare any `identity` attributes and is not valid under the v2 schema"),
+                "expected refinement without identity error, got: {messages}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Disallow entity refinements whose base entity does not declare any identity attributes.

Reuses `EntityMissingIdentity` error by adding an optional `refinement_id` field to indicate which refinement attempted to refine the entity.

Fixes #1752