### PR TITLE
feat(live-check): support virtual-directory format for --advice-policies and --advice-data

### DIFF
--- a/crates/weaver_common/src/vdir.rs
+++ b/crates/weaver_common/src/vdir.rs
@@ -322,9 +322,10 @@ static REGISTRY_REGEX: Lazy<Regex> = Lazy::new(|| {
 /// Paths may optionally specify:
 /// - A sub-folder within the archive or repository via `[sub_folder]`
 /// - [Not Yet Implemented] A specific Git refspec (branch, tag, or commit) via `@refspec`
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(try_from = "String")]
 #[serde(into = "String")]
+#[schemars(with = "String")]
 pub enum VirtualDirectoryPath {
     /// A virtual directory representing a local folder.
     LocalFolder {
@@ -600,8 +601,23 @@ enum CheckoutError {
     #[error(transparent)]
     WriteIndex(#[from] gix::index::file::write::Error),
 }
-
 impl VirtualDirectory {
+    /// Resolve an optional [`VirtualDirectoryPath`] with no HTTP credentials configured.
+    pub fn try_from_opt(vdir_path: Option<&VirtualDirectoryPath>) -> Result<Option<Self>, Error> {
+        Self::try_from_opt_with_auth(vdir_path, &HttpAuthResolver::empty())
+    }
+
+    /// Resolve an optional [`VirtualDirectoryPath`], using `auth` to look up Bearer
+    /// credentials for any remote HTTP fetches.
+    pub fn try_from_opt_with_auth(
+        vdir_path: Option<&VirtualDirectoryPath>,
+        auth: &HttpAuthResolver,
+    ) -> Result<Option<Self>, Error> {
+        vdir_path
+            .map(|p| Self::try_new_with_auth(p, auth))
+            .transpose()
+    }
+
     /// Resolve a [`VirtualDirectoryPath`] with no HTTP credentials configured.
     /// For remote paths behind private registries, use [`Self::try_new_with_auth`].
     pub fn try_new(vdir_path: &VirtualDirectoryPath) -> Result<Self, Error> {
@@ -1102,6 +1118,18 @@ impl VirtualDirectory {
     #[must_use]
     pub fn path(&self) -> &Path {
         self.path.as_path()
+    }
+
+    /// Returns the local filesystem path as a `PathBuf`.
+    #[must_use]
+    pub fn path_buf(&self) -> PathBuf {
+        self.path.clone()
+    }
+
+    /// Returns the local filesystem path as a string slice (or empty string if invalid UTF-8).
+    #[must_use]
+    pub fn path_str(&self) -> &str {
+        self.path.to_str().unwrap_or_default()
     }
 
     /// Returns the original string representation that was used to create this `VirtualDirectory`.

--- a/crates/weaver_common/src/vdir.rs
+++ b/crates/weaver_common/src/vdir.rs
@@ -32,7 +32,6 @@
 //!
 //! - `source`: Can be a local path (`/path/to/dir`, `./archive.zip`) or a URL (`https://...`).
 //! - `@refspec`: (Optional) For Git repositories, specifies a tag, branch, or commit hash.
-//!   *(Note: Currently, fetching specific refspecs is not fully implemented)*.
 //! - `[sub_folder]`: (Optional) Specifies a directory *within* the source (archive or Git repo)
 //!   that should become the root of the virtual directory.
 //!
@@ -321,7 +320,7 @@ static REGISTRY_REGEX: Lazy<Regex> = Lazy::new(|| {
 ///
 /// Paths may optionally specify:
 /// - A sub-folder within the archive or repository via `[sub_folder]`
-/// - [Not Yet Implemented] A specific Git refspec (branch, tag, or commit) via `@refspec`
+/// - A specific Git refspec (branch, tag, or commit) via `@refspec`
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(try_from = "String")]
 #[serde(into = "String")]

--- a/crates/weaver_config/src/live_check.rs
+++ b/crates/weaver_config/src/live_check.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use weaver_checker::FindingLevel;
+use weaver_common::vdir::VirtualDirectoryPath;
 
 /// Severity gate controlling when `registry live-check` exits non-zero.
 ///
@@ -119,12 +120,12 @@ pub struct LiveCheckConfig {
     /// `http` sends the report as the response to the `/stop` request on the admin port.
     pub output: Option<PathBuf>,
 
-    /// Advice policies directory. Overrides the built-in default policies.
-    pub advice_policies: Option<PathBuf>,
+    /// Advice policies directory or virtual directory. Overrides the built-in default policies.
+    pub advice_policies: Option<VirtualDirectoryPath>,
 
-    /// Glob pattern pointing to additional JSON/YAML files to load into OPA rego data.
+    /// Virtual directory, file, or glob pattern pointing to additional JSON/YAML files to load into OPA rego data.
     /// Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).
-    pub advice_data: Option<String>,
+    pub advice_data: Option<VirtualDirectoryPath>,
 
     /// Advice preprocessor — a jq script run once over the registry data before
     /// being passed to rego policies.
@@ -361,10 +362,18 @@ otlp_logs_stdout = false
         assert!(!lc.no_stream);
         assert!(lc.no_stats);
         assert_eq!(lc.fail_on, FailOnLevel::Improvement);
-        assert_eq!(lc.output.as_deref(), Some(Path::new("reports")));
-        assert_eq!(lc.advice_policies.as_deref(), Some(Path::new("policies")));
-        assert_eq!(lc.advice_data.as_deref(), Some("data"));
-        assert_eq!(lc.advice_preprocessor.as_deref(), Some(Path::new("pre.jq")));
+        assert_eq!(
+            lc.advice_policies,
+            Some(VirtualDirectoryPath::LocalFolder {
+                path: "policies".to_owned()
+            })
+        );
+        assert_eq!(
+            lc.advice_data,
+            Some(VirtualDirectoryPath::LocalFolder {
+                path: "data".to_owned()
+            })
+        );
 
         assert_eq!(lc.otlp.grpc_address, "127.0.0.1");
         assert_eq!(lc.otlp.grpc_port, 4317);

--- a/crates/weaver_config/src/live_check.rs
+++ b/crates/weaver_config/src/live_check.rs
@@ -362,6 +362,7 @@ otlp_logs_stdout = false
         assert!(!lc.no_stream);
         assert!(lc.no_stats);
         assert_eq!(lc.fail_on, FailOnLevel::Improvement);
+        assert_eq!(lc.output.as_deref(), Some(Path::new("reports")));
         assert_eq!(
             lc.advice_policies,
             Some(VirtualDirectoryPath::LocalFolder {
@@ -374,6 +375,7 @@ otlp_logs_stdout = false
                 path: "data".to_owned()
             })
         );
+        assert_eq!(lc.advice_preprocessor.as_deref(), Some(Path::new("pre.jq")));
 
         assert_eq!(lc.otlp.grpc_address, "127.0.0.1");
         assert_eq!(lc.otlp.grpc_port, 4317);

--- a/crates/weaver_live_check/README.md
+++ b/crates/weaver_live_check/README.md
@@ -124,7 +124,7 @@ As mentioned, a list of `PolicyFinding` is returned in the report for each sampl
 
 ### Custom advisors
 
-Use the `--advice-policies` command line option to provide a path to a directory containing Rego policies with the `live_check_advice` package name. Here's a very simple example that rejects any attribute name containing the string "test":
+Use the `--advice-policies` command line option to provide a path to a directory or virtual directory (such as a Git repository or archive) containing Rego policies with the `live_check_advice` package name. Here's a very simple example that rejects any attribute name containing the string "test":
 
 ```rego
 package live_check_advice

--- a/crates/weaver_live_check/src/advice/rego_advisor.rs
+++ b/crates/weaver_live_check/src/advice/rego_advisor.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 
 /// An advisor which runs a rego policy on the attribute
+#[derive(Clone)]
 pub struct RegoAdvisor {
     engine: Engine,
 }
@@ -30,8 +31,8 @@ impl RegoAdvisor {
     ) -> Result<Self, Error> {
         let mut engine = Engine::new();
         if let Some(path) = policy_dir {
-            let _ = engine
-                .add_policies(path, "*.rego")
+            engine
+                .add_policy_from_file_or_dir(path)
                 .map_err(|e| Error::AdviceError {
                     error: e.to_string(),
                 })?;

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -206,6 +206,7 @@ impl LiveChecker {
 #[cfg(test)]
 mod tests {
     use std::fs::File;
+    use std::path::Path;
 
     use crate::{
         advice::{DeprecatedAdvisor, EnumAdvisor, RegoAdvisor, StabilityAdvisor, TypeAdvisor},
@@ -1216,7 +1217,7 @@ mod tests {
         let mut live_checker = LiveChecker::new(Arc::new(registry), advisors);
         let rego_advisor = RegoAdvisor::new(
             &live_checker,
-            &Some("data/policies/live_check_advice/".into()),
+            &Some(Path::new("data/policies/live_check_advice/").into()),
             &Some("data/jq/test.jq".into()),
             &None,
         )
@@ -1368,7 +1369,7 @@ mod tests {
         let mut live_checker = LiveChecker::new(Arc::new(registry), vec![]);
         let rego_advisor = RegoAdvisor::new(
             &live_checker,
-            &Some("data/policies/live_check_advice/".into()),
+            &Some(Path::new("data/policies/live_check_advice/").into()),
             &Some("data/jq/test.jq".into()),
             &None,
         )
@@ -1508,7 +1509,7 @@ mod tests {
         let mut live_checker = LiveChecker::new(Arc::new(registry), vec![]);
         let rego_advisor = RegoAdvisor::new(
             &live_checker,
-            &Some("data/policies/live_check_advice/".into()),
+            &Some(Path::new("data/policies/live_check_advice/").into()),
             &Some("data/jq/test.jq".into()),
             &None,
         )
@@ -1558,7 +1559,7 @@ mod tests {
         let mut live_checker = LiveChecker::new(Arc::new(registry), vec![]);
         let rego_advisor = RegoAdvisor::new(
             &live_checker,
-            &Some("data/policies/live_check_advice/".into()),
+            &Some(Path::new("data/policies/live_check_advice/").into()),
             &Some("data/jq/test.jq".into()),
             &None,
         )
@@ -1939,7 +1940,7 @@ mod tests {
         let mut live_checker = LiveChecker::new(Arc::new(registry), advisors);
         let rego_advisor = RegoAdvisor::new(
             &live_checker,
-            &Some("data/policies/bad_advice/".into()),
+            &Some(Path::new("data/policies/bad_advice/").into()),
             &Some("data/jq/test.jq".into()),
             &None,
         )
@@ -2083,7 +2084,7 @@ mod tests {
 
         let rego_advisor = RegoAdvisor::new(
             &live_checker,
-            &Some("data/policies/live_check_advice/".into()),
+            &Some(Path::new("data/policies/live_check_advice/").into()),
             &Some("data/jq/test.jq".into()),
             &None,
         )
@@ -2710,13 +2711,9 @@ mod tests {
 
         let registry = make_registry(false);
         let mut live_checker = LiveChecker::new(Arc::new(registry), vec![]);
-        let rego_advisor = RegoAdvisor::new(
-            &live_checker,
-            &Some(temp_dir.path().to_path_buf()),
-            &None,
-            &None,
-        )
-        .expect("Failed to create Rego advisor");
+        let rego_advisor =
+            RegoAdvisor::new(&live_checker, &Some(temp_dir.path().into()), &None, &None)
+                .expect("Failed to create Rego advisor");
         live_checker.add_advisor(Box::new(rego_advisor));
 
         let mut sample = Sample::Span(SampleSpan {
@@ -3498,7 +3495,7 @@ mod tests {
         let mut live_checker = LiveChecker::new(Arc::new(registry), vec![]);
         let rego_advisor = RegoAdvisor::new(
             &live_checker,
-            &Some("data/policies/entity_advice/".into()),
+            &Some(Path::new("data/policies/entity_advice/").into()),
             &None,
             &None,
         )

--- a/crates/weaver_mcp/src/service.rs
+++ b/crates/weaver_mcp/src/service.rs
@@ -46,7 +46,7 @@ pub struct WeaverMcpService {
     versioned_registry: Arc<VersionedRegistry>,
     /// Path to custom Rego advice policies directory.
     advice_policies: Option<PathBuf>,
-    /// Path to the directory or file containing additional rego data (JSON/YAML files) or a glob pattern.
+    /// Glob pattern containing additional rego data (JSON/YAML files).
     advice_data: Option<String>,
     /// Path to jq preprocessor script for Rego policies.
     advice_preprocessor: Option<PathBuf>,
@@ -1506,8 +1506,9 @@ mod tests {
             advice_policies: Some(fixture_path("policies")),
             advice_data: Some(
                 fixture_path("data/denylist.json")
-                    .to_string_lossy()
-                    .into_owned(),
+                    .to_str()
+                    .unwrap()
+                    .to_owned(),
             ),
             ..McpConfig::default()
         };

--- a/crates/weaver_mcp/src/service.rs
+++ b/crates/weaver_mcp/src/service.rs
@@ -46,7 +46,7 @@ pub struct WeaverMcpService {
     versioned_registry: Arc<VersionedRegistry>,
     /// Path to custom Rego advice policies directory.
     advice_policies: Option<PathBuf>,
-    /// Glob pattern containing additional rego data (JSON/YAML files).
+    /// Path, directory, or glob pattern containing additional rego data (JSON/YAML files).
     advice_data: Option<String>,
     /// Path to jq preprocessor script for Rego policies.
     advice_preprocessor: Option<PathBuf>,
@@ -1506,9 +1506,8 @@ mod tests {
             advice_policies: Some(fixture_path("policies")),
             advice_data: Some(
                 fixture_path("data/denylist.json")
-                    .to_str()
-                    .unwrap()
-                    .to_owned(),
+                    .to_string_lossy()
+                    .into_owned(),
             ),
             ..McpConfig::default()
         };

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -537,8 +537,8 @@ Includes: Flexible input ingestion, configurable assessment, and template-based 
 
 * `--admin-port <ADMIN_PORT>` — Port used by the HTTP admin port (endpoints: /stop)
 * `--inactivity-timeout <INACTIVITY_TIMEOUT>` — Max inactivity time in seconds before stopping the listener
-* `--advice-policies <ADVICE_POLICIES>` — Advice policies directory. Set this to override the default policies
-* `--advice-data <ADVICE_DATA>` — Glob pattern pointing to additional JSON/YAML files to load into OPA rego data (other extensions are ignored). Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user)
+* `--advice-policies <ADVICE_POLICIES>` — Advice policies directory or virtual directory. Set this to override the default policies
+* `--advice-data <ADVICE_DATA>` — Virtual directory, file, or glob pattern pointing to additional JSON/YAML files to load into OPA rego data (other extensions are ignored). Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user)
 * `--advice-preprocessor <ADVICE_PREPROCESSOR>` — Advice preprocessor. A jq script to preprocess the registry data before passing to rego
 
 
@@ -576,9 +576,9 @@ The server communicates over stdio using JSON-RPC.
 
   Possible values: `true`, `false`
 
-* `--advice-policies <ADVICE_POLICIES>` — Advice policies directory. Set this to override the default policies
+* `--advice-policies <ADVICE_POLICIES>` — Advice policies directory or virtual directory. Set this to override the default policies
 * `--advice-preprocessor <ADVICE_PREPROCESSOR>` — Advice preprocessor. A jq script to preprocess the registry data before passing to rego
-* `--advice-data <ADVICE_DATA>` — Glob pattern pointing to additional JSON/YAML files to load into OPA rego data. Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user)
+* `--advice-data <ADVICE_DATA>` — Virtual directory, file, or glob pattern pointing to additional JSON/YAML files to load into OPA rego data. Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user)
 * `--namespace-separator <NAMESPACE_SEPARATOR>` — Namespace separator used in attribute keys. Defaults to ".". Used by namespace browsing and search token splitting. [default: .]
 
 

--- a/schemas/definition-manifest.v2.json
+++ b/schemas/definition-manifest.v2.json
@@ -106,7 +106,7 @@
       ]
     },
     "VirtualDirectoryPath": {
-      "description": "Represents a virtual path pointing to a directory-like resource.\n\nSupported formats include:\n- **Local directories** (`/path/to/directory`)\n- **Local archives** (`/path/to/archive.zip` or `/path/to/archive.tar.gz`)\n- **Remote archives** (`https://example.com/archive.zip` or `.tar.gz`)\n- **Git repositories** (`https://github.com/user/repo.git`)\n\nPaths may optionally specify:\n- A sub-folder within the archive or repository via `[sub_folder]`\n- [Not Yet Implemented] A specific Git refspec (branch, tag, or commit) via `@refspec`",
+      "description": "Represents a virtual path pointing to a directory-like resource.\n\nSupported formats include:\n- **Local directories** (`/path/to/directory`)\n- **Local archives** (`/path/to/archive.zip` or `/path/to/archive.tar.gz`)\n- **Remote archives** (`https://example.com/archive.zip` or `.tar.gz`)\n- **Git repositories** (`https://github.com/user/repo.git`)\n\nPaths may optionally specify:\n- A sub-folder within the archive or repository via `[sub_folder]`\n- A specific Git refspec (branch, tag, or commit) via `@refspec`",
       "type": "string"
     }
   }

--- a/schemas/publication-manifest.v2.json
+++ b/schemas/publication-manifest.v2.json
@@ -117,7 +117,7 @@
       ]
     },
     "VirtualDirectoryPath": {
-      "description": "Represents a virtual path pointing to a directory-like resource.\n\nSupported formats include:\n- **Local directories** (`/path/to/directory`)\n- **Local archives** (`/path/to/archive.zip` or `/path/to/archive.tar.gz`)\n- **Remote archives** (`https://example.com/archive.zip` or `.tar.gz`)\n- **Git repositories** (`https://github.com/user/repo.git`)\n\nPaths may optionally specify:\n- A sub-folder within the archive or repository via `[sub_folder]`\n- [Not Yet Implemented] A specific Git refspec (branch, tag, or commit) via `@refspec`",
+      "description": "Represents a virtual path pointing to a directory-like resource.\n\nSupported formats include:\n- **Local directories** (`/path/to/directory`)\n- **Local archives** (`/path/to/archive.zip` or `/path/to/archive.tar.gz`)\n- **Remote archives** (`https://example.com/archive.zip` or `.tar.gz`)\n- **Git repositories** (`https://github.com/user/repo.git`)\n\nPaths may optionally specify:\n- A sub-folder within the archive or repository via `[sub_folder]`\n- A specific Git refspec (branch, tag, or commit) via `@refspec`",
       "type": "string"
     }
   }

--- a/schemas/weaver-config.json
+++ b/schemas/weaver-config.json
@@ -209,18 +209,26 @@
       "type": "object",
       "properties": {
         "advice_data": {
-          "description": "Glob pattern pointing to additional JSON/YAML files to load into OPA rego data.\nFiles are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).",
-          "type": [
-            "string",
-            "null"
+          "description": "Virtual directory, file, or glob pattern pointing to additional JSON/YAML files to load into OPA rego data.\nFiles are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VirtualDirectoryPath"
+            },
+            {
+              "type": "null"
+            }
           ],
           "default": null
         },
         "advice_policies": {
-          "description": "Advice policies directory. Overrides the built-in default policies.",
-          "type": [
-            "string",
-            "null"
+          "description": "Advice policies directory or virtual directory. Overrides the built-in default policies.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VirtualDirectoryPath"
+            },
+            {
+              "type": "null"
+            }
           ],
           "default": null
         },
@@ -304,18 +312,26 @@
       "type": "object",
       "properties": {
         "advice_data": {
-          "description": "Glob pattern pointing to additional JSON/YAML files to load into OPA rego data.\nFiles are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).",
-          "type": [
-            "string",
-            "null"
+          "description": "Virtual directory, file, or glob pattern pointing to additional JSON/YAML files to load into OPA rego data.\nFiles are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VirtualDirectoryPath"
+            },
+            {
+              "type": "null"
+            }
           ],
           "default": null
         },
         "advice_policies": {
-          "description": "Advice policies directory. Set this to override the default policies.",
-          "type": [
-            "string",
-            "null"
+          "description": "Advice policies directory or virtual directory. Set this to override the default policies.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VirtualDirectoryPath"
+            },
+            {
+              "type": "null"
+            }
           ],
           "default": null
         },
@@ -741,6 +757,10 @@
           "minimum": 0
         }
       }
+    },
+    "VirtualDirectoryPath": {
+      "description": "Represents a virtual path pointing to a directory-like resource.\n\nSupported formats include:\n- **Local directories** (`/path/to/directory`)\n- **Local archives** (`/path/to/archive.zip` or `/path/to/archive.tar.gz`)\n- **Remote archives** (`https://example.com/archive.zip` or `.tar.gz`)\n- **Git repositories** (`https://github.com/user/repo.git`)\n\nPaths may optionally specify:\n- A sub-folder within the archive or repository via `[sub_folder]`\n- [Not Yet Implemented] A specific Git refspec (branch, tag, or commit) via `@refspec`",
+      "type": "string"
     }
   }
 }

--- a/schemas/weaver-config.json
+++ b/schemas/weaver-config.json
@@ -759,7 +759,7 @@
       }
     },
     "VirtualDirectoryPath": {
-      "description": "Represents a virtual path pointing to a directory-like resource.\n\nSupported formats include:\n- **Local directories** (`/path/to/directory`)\n- **Local archives** (`/path/to/archive.zip` or `/path/to/archive.tar.gz`)\n- **Remote archives** (`https://example.com/archive.zip` or `.tar.gz`)\n- **Git repositories** (`https://github.com/user/repo.git`)\n\nPaths may optionally specify:\n- A sub-folder within the archive or repository via `[sub_folder]`\n- [Not Yet Implemented] A specific Git refspec (branch, tag, or commit) via `@refspec`",
+      "description": "Represents a virtual path pointing to a directory-like resource.\n\nSupported formats include:\n- **Local directories** (`/path/to/directory`)\n- **Local archives** (`/path/to/archive.zip` or `/path/to/archive.tar.gz`)\n- **Remote archives** (`https://example.com/archive.zip` or `.tar.gz`)\n- **Git repositories** (`https://github.com/user/repo.git`)\n\nPaths may optionally specify:\n- A sub-folder within the archive or repository via `[sub_folder]`\n- A specific Git refspec (branch, tag, or commit) via `@refspec`",
       "type": "string"
     }
   }

--- a/src/registry/live_check.rs
+++ b/src/registry/live_check.rs
@@ -13,6 +13,7 @@ use include_dir::{include_dir, Dir};
 use log::info;
 use weaver_common::diagnostic::DiagnosticMessages;
 use weaver_common::http_auth::HttpAuthResolver;
+use weaver_common::vdir::{VirtualDirectory, VirtualDirectoryPath};
 use weaver_common::{log_success, log_warn};
 use weaver_config::{FailOnLevel, WeaverConfig};
 use weaver_forge::{OutputProcessor, OutputTarget};
@@ -179,15 +180,15 @@ pub struct RegistryLiveCheckArgs {
     #[config(path = "otlp.inactivity_timeout")]
     inactivity_timeout: Option<u64>,
 
-    /// Advice policies directory. Set this to override the default policies.
+    /// Advice policies directory or virtual directory. Set this to override the default policies.
     #[arg(long)]
     #[config]
-    advice_policies: Option<PathBuf>,
+    advice_policies: Option<VirtualDirectoryPath>,
 
-    /// Glob pattern pointing to additional JSON/YAML files to load into OPA rego data (other extensions are ignored). Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).
+    /// Virtual directory, file, or glob pattern pointing to additional JSON/YAML files to load into OPA rego data (other extensions are ignored). Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).
     #[arg(long)]
     #[config]
-    advice_data: Option<String>,
+    advice_data: Option<VirtualDirectoryPath>,
 
     /// Advice preprocessor. A jq script to preprocess the registry data before passing to rego.
     #[arg(long)]
@@ -305,11 +306,22 @@ pub(crate) fn command(
     live_checker.finding_modifier =
         FindingModifier::from_rules(&config.finding_filters, &config.finding_level_overrides)?;
 
+    let advice_policies_dir =
+        VirtualDirectory::try_from_opt_with_auth(config.advice_policies.as_ref(), auth)
+            .map_err(DiagnosticMessages::from_error)?;
+
+    let advice_data_dir =
+        VirtualDirectory::try_from_opt_with_auth(config.advice_data.as_ref(), auth)
+            .map_err(DiagnosticMessages::from_error)?;
+
+    let policy_path = advice_policies_dir.as_ref().map(VirtualDirectory::path_buf);
+    let data_pattern = advice_data_dir.as_ref().map(|v| v.path_str().to_owned());
+
     let rego_advisor = RegoAdvisor::new(
         &live_checker,
-        &config.advice_policies,
+        &policy_path,
         &config.advice_preprocessor,
-        &config.advice_data,
+        &data_pattern,
     )?;
     live_checker.add_advisor(Box::new(rego_advisor));
 

--- a/src/registry/mcp.rs
+++ b/src/registry/mcp.rs
@@ -16,6 +16,7 @@ use crate::weaver::WeaverEngine;
 use crate::{DiagnosticArgs, ExitDirectives};
 use weaver_common::diagnostic::DiagnosticMessages;
 use weaver_common::http_auth::HttpAuthResolver;
+use weaver_common::vdir::{VirtualDirectory, VirtualDirectoryPath};
 use weaver_config::{WeaverCommand, WeaverConfig};
 use weaver_macros::weaver_command;
 
@@ -33,21 +34,21 @@ pub struct RegistryMcpArgs {
     #[shared(diagnostic)]
     pub diagnostic: DiagnosticArgs,
 
-    /// Advice policies directory. Set this to override the default policies.
+    /// Advice policies directory or virtual directory. Set this to override the default policies.
     #[arg(long)]
     #[config]
-    pub advice_policies: Option<PathBuf>,
+    pub advice_policies: Option<VirtualDirectoryPath>,
 
     /// Advice preprocessor. A jq script to preprocess the registry data before passing to rego.
     #[arg(long)]
     #[config]
     pub advice_preprocessor: Option<PathBuf>,
 
-    /// Glob pattern pointing to additional JSON/YAML files to load into OPA rego data.
+    /// Virtual directory, file, or glob pattern pointing to additional JSON/YAML files to load into OPA rego data.
     /// Files are nested in OPA data using their relative path inside the glob base directory (e.g. schemas/user.json is loaded at data.user).
     #[arg(long)]
     #[config]
-    pub advice_data: Option<String>,
+    pub advice_data: Option<VirtualDirectoryPath>,
 
     /// Namespace separator used in attribute keys. Defaults to ".".
     /// Used by namespace browsing and search token splitting.
@@ -86,10 +87,18 @@ pub(crate) fn command(
     info!("Starting MCP server (communicating over stdio)");
     info!("The server will run until stdin is closed.");
 
-    // Build MCP config from effective config
+    // Build MCP config from effective config, resolving virtual directories upfront
+    let advice_policies_dir =
+        VirtualDirectory::try_from_opt_with_auth(cmd_config.config.advice_policies.as_ref(), auth)
+            .map_err(DiagnosticMessages::from_error)?;
+
+    let advice_data_dir =
+        VirtualDirectory::try_from_opt_with_auth(cmd_config.config.advice_data.as_ref(), auth)
+            .map_err(DiagnosticMessages::from_error)?;
+
     let mcp_config = weaver_mcp::McpConfig {
-        advice_policies: cmd_config.config.advice_policies,
-        advice_data: cmd_config.config.advice_data,
+        advice_policies: advice_policies_dir.as_ref().map(VirtualDirectory::path_buf),
+        advice_data: advice_data_dir.as_ref().map(|v| v.path_str().to_owned()),
         advice_preprocessor: cmd_config.config.advice_preprocessor,
         namespace_separator: cmd_config.config.namespace_separator,
     };

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -95,6 +95,7 @@ pub struct RegistryCommand {
 /// Sub-commands to manage a `registry`.
 #[derive(Debug, Subcommand)]
 #[clap(verbatim_doc_comment)]
+#[allow(clippy::large_enum_variant)]
 pub enum RegistrySubCommand {
     /// Validates a semantic convention registry.
     ///

--- a/tests/registry_live_check.rs
+++ b/tests/registry_live_check.rs
@@ -176,6 +176,8 @@ fn live_check_archive_advice_policies_and_data() {
     let mut zip = ZipWriter::new(zip_file);
     let options = SimpleFileOptions::default();
 
+    // VirtualDirectory unpack logic automatically strips the single top-level root folder
+    // ("bundle/"), so subfolder selectors "[policies]" and "[data]" match directly.
     zip.start_file("bundle/policies/custom.rego", options)
         .expect("Failed to add rego to zip");
     zip.write_all(rego_content.as_bytes())

--- a/tests/registry_live_check.rs
+++ b/tests/registry_live_check.rs
@@ -130,3 +130,80 @@ fn no_stats_with_none_threshold_is_silent_and_exits_zero() {
         "should not warn when --fail-on=none, got: {combined}"
     );
 }
+
+/// Advice policies and data can be loaded from a virtual directory archive (`.zip` with `[sub_folder]`).
+#[test]
+fn live_check_archive_advice_policies_and_data() {
+    use std::fs::File;
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let archive_path = temp_dir.path().join("bundle.zip");
+
+    let rego_content = r#"
+        package live_check_advice
+
+        import rego.v1
+
+        make_advice(advice_type, advice_level, advice_context, message) := {
+            "type": "advice",
+            "advice_type": advice_type,
+            "advice_level": advice_level,
+            "advice_context": advice_context,
+            "message": message,
+        }
+
+        deny contains make_advice(advice_type, advice_level, advice_context, message) if {
+            input.sample.attribute
+            input.sample.attribute.name == "task.id"
+            data.settings.enabled == true
+            advice_type := "custom_archive_violation"
+            advice_level := "violation"
+            advice_context := {"attribute_key": input.sample.attribute.name}
+            message := "Custom violation triggered from archive policy and data"
+        }
+    "#;
+
+    let json_content = r#"
+        {
+            "enabled": true
+        }
+    "#;
+
+    let zip_file = File::create(&archive_path).expect("Failed to create archive file");
+    let mut zip = ZipWriter::new(zip_file);
+    let options = SimpleFileOptions::default();
+
+    zip.start_file("bundle/policies/custom.rego", options)
+        .expect("Failed to add rego to zip");
+    zip.write_all(rego_content.as_bytes())
+        .expect("Failed to write rego");
+
+    zip.start_file("bundle/data/settings.json", options)
+        .expect("Failed to add json to zip");
+    zip.write_all(json_content.as_bytes())
+        .expect("Failed to write json");
+
+    let _ = zip.finish().expect("Failed to finish zip archive");
+
+    let archive_str = archive_path.to_str().expect("valid utf8 path");
+    let policies_arg = format!("{}[policies]", archive_str);
+    let data_arg = format!("{}[data]", archive_str);
+
+    let out = run_live_check(&[
+        "--advice-policies",
+        &policies_arg,
+        "--advice-data",
+        &data_arg,
+        "--fail-on",
+        "violation",
+    ]);
+
+    assert_eq!(
+        exit_code(&out),
+        1,
+        "custom advice finding from archive should trigger violation failure"
+    );
+}


### PR DESCRIPTION
Resolves #1751

Support virtual directory formats (archives, git repos, etc.) and auth for `--advice-policies` and `--advice-data` in `live-check` and `mcp` commands.