### PR TITLE
Formal span name definition for validation and code generation in semconv v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ fuzz/corpus/
 fuzz/artifacts/
 # Track fuzz lockfile so CI doesn't silently upgrade deps
 !fuzz/Cargo.lock
+
+# Local temporary test directories
+temp/

--- a/crates/weaver_emit/src/lib.rs
+++ b/crates/weaver_emit/src/lib.rs
@@ -612,7 +612,8 @@ mod tests {
                     r#type: SignalId::from("test.comprehensive.internal".to_owned()),
                     kind: SpanKindSpec::Internal,
                     name: SpanName {
-                        note: "test span".to_owned(),
+                        note: Some("test span".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![SpanAttribute {
                         base: V2Attribute {

--- a/crates/weaver_forge/src/lib.rs
+++ b/crates/weaver_forge/src/lib.rs
@@ -1094,7 +1094,8 @@ mod tests {
                     r#type: SignalId::from("db.client".to_owned()),
                     kind: SpanKindSpec::Client,
                     name: SpanName {
-                        note: "A database client span.".to_owned(),
+                        note: Some("A database client span.".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![],
                     entity_associations: vec![],
@@ -1665,7 +1666,8 @@ mod tests {
                     r#type: SignalId::from("db.client".to_owned()),
                     kind: SpanKindSpec::Client,
                     name: SpanName {
-                        note: "A database client span.".to_owned(),
+                        note: Some("A database client span.".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![],
                     entity_associations: vec![

--- a/crates/weaver_forge/src/v2/registry.rs
+++ b/crates/weaver_forge/src/v2/registry.rs
@@ -784,7 +784,8 @@ mod tests {
                     r#type: SignalId::from("my-span".to_owned()),
                     kind: SpanKindSpec::Internal,
                     name: SpanName {
-                        note: "My Span".to_owned(),
+                        note: Some("My Span".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![span::SpanAttributeRef {
                         base: AttributeRef(0),
@@ -872,7 +873,8 @@ mod tests {
                         r#type: SignalId::from("my-span".to_owned()),
                         kind: SpanKindSpec::Client,
                         name: SpanName {
-                            note: "My Refined Span".to_owned(),
+                            note: Some("My Refined Span".to_owned()),
+                            ..Default::default()
                         },
                         attributes: vec![span::SpanAttributeRef {
                             base: AttributeRef(0),
@@ -1146,7 +1148,8 @@ mod tests {
                         r#type: SignalId::from("z-span".to_owned()),
                         kind: SpanKindSpec::Internal,
                         name: SpanName {
-                            note: "".to_owned(),
+                            note: Some("".to_owned()),
+                            ..Default::default()
                         },
                         attributes: vec![],
                         entity_associations: vec![],
@@ -1158,7 +1161,8 @@ mod tests {
                         r#type: SignalId::from("a-span".to_owned()),
                         kind: SpanKindSpec::Internal,
                         name: SpanName {
-                            note: "".to_owned(),
+                            note: Some("".to_owned()),
+                            ..Default::default()
                         },
                         attributes: vec![],
                         entity_associations: vec![],
@@ -1235,7 +1239,8 @@ mod tests {
                             r#type: SignalId::from("z-span".to_owned()),
                             kind: SpanKindSpec::Internal,
                             name: SpanName {
-                                note: "".to_owned(),
+                                note: Some("".to_owned()),
+                                ..Default::default()
                             },
                             attributes: vec![],
                             entity_associations: vec![],
@@ -1250,7 +1255,8 @@ mod tests {
                             r#type: SignalId::from("a-span".to_owned()),
                             kind: SpanKindSpec::Internal,
                             name: SpanName {
-                                note: "".to_owned(),
+                                note: Some("".to_owned()),
+                                ..Default::default()
                             },
                             attributes: vec![],
                             entity_associations: vec![],
@@ -1542,7 +1548,8 @@ mod tests {
                     r#type: SignalId::from("my-span".to_owned()),
                     kind: SpanKindSpec::Internal,
                     name: SpanName {
-                        note: "".to_owned(),
+                        note: Some("".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![span::SpanAttributeRef {
                         base: AttributeRef(10),
@@ -1621,7 +1628,8 @@ mod tests {
                         r#type: SignalId::from("my-span".to_owned()),
                         kind: SpanKindSpec::Internal,
                         name: SpanName {
-                            note: "".to_owned(),
+                            note: Some("".to_owned()),
+                            ..Default::default()
                         },
                         attributes: vec![span::SpanAttributeRef {
                             base: AttributeRef(16),
@@ -2195,7 +2203,8 @@ mod tests {
                     r#type: SignalId::from("dep-b-span".to_owned()),
                     kind: SpanKindSpec::Internal,
                     name: SpanName {
-                        note: "".to_owned(),
+                        note: Some("".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![span::SpanAttributeRef {
                         base: AttributeRef(0),
@@ -2723,7 +2732,8 @@ mod tests {
                     r#type: "my-span".to_owned().into(),
                     kind: SpanKindSpec::Internal,
                     name: SpanName {
-                        note: "My Span".to_owned(),
+                        note: Some("My Span".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![],
                     entity_associations: vec![entity::EntityAssociation::Ref(entity::EntityRef {

--- a/crates/weaver_forge/src/v2/span.rs
+++ b/crates/weaver_forge/src/v2/span.rs
@@ -91,3 +91,61 @@ pub struct SpanRefinement {
     #[serde(flatten)]
     pub span: Span,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minijinja::Environment;
+    use weaver_semconv::v2::span::{SpanName, SpanNameTemplate};
+
+    #[test]
+    fn test_forge_span_name_templates_jinja_rendering() {
+        let span = Span {
+            r#type: "http.client".into(),
+            kind: SpanKindSpec::Client,
+            name: SpanName {
+                templates: vec![
+                    SpanNameTemplate::parse("{http.request.method} {url.template}").unwrap(),
+                    SpanNameTemplate::parse("{http.request.method} {server.address}:{server.port}")
+                        .unwrap(),
+                    SpanNameTemplate::parse("{http.request.method}").unwrap(),
+                    SpanNameTemplate::parse("HTTP").unwrap(),
+                ],
+                note: None,
+            },
+            attributes: vec![],
+            entity_associations: vec![],
+            requirement_level: None,
+            common: Default::default(),
+            provenance: Default::default(),
+        };
+
+        let jinja_template = r#"
+{%- for t in span.name.templates %}
+{%- if t.attributes %}
+{% if loop.first %}if{% else %}elif{% endif %} {% for attr in t.attributes %}"{{ attr }}" in attrs{% if not loop.last %} and {% endif %}{% endfor %}:
+    return f"{% for p in t.parts %}{% if p.type == 'literal' %}{{ p.value }}{% else %}{attrs['{{ p.attribute }}']}{% endif %}{% endfor %}"
+{%- else %}
+else:
+    return "{{ t.pattern }}"
+{%- endif %}
+{%- endfor %}
+"#;
+
+        let mut env = Environment::new();
+        env.add_template("span_name.py.j2", jinja_template).unwrap();
+        let tmpl = env.get_template("span_name.py.j2").unwrap();
+
+        let rendered = tmpl.render(minijinja::context! { span => span }).unwrap();
+        let expected = r#"if "http.request.method" in attrs and "url.template" in attrs:
+    return f"{attrs['http.request.method']} {attrs['url.template']}"
+elif "http.request.method" in attrs and "server.address" in attrs and "server.port" in attrs:
+    return f"{attrs['http.request.method']} {attrs['server.address']}:{attrs['server.port']}"
+elif "http.request.method" in attrs:
+    return f"{attrs['http.request.method']}"
+else:
+    return "HTTP""#;
+
+        assert_eq!(rendered.trim(), expected.trim());
+    }
+}

--- a/crates/weaver_infer/src/lib.rs
+++ b/crates/weaver_infer/src/lib.rs
@@ -246,7 +246,8 @@ impl AccumulatedSamples {
                     r#type: SignalId::from(span.name.clone()),
                     kind: span.kind,
                     name: SpanName {
-                        note: span.name.clone(),
+                        templates: Vec::new(),
+                        note: Some(span.name.clone()),
                     },
                     attributes,
                     entity_associations: vec![],
@@ -1349,7 +1350,7 @@ mod tests {
         assert_eq!(registry.spans().len(), 1);
         assert_eq!(registry.spans()[0].r#type.to_string(), "HTTP GET");
         assert_eq!(registry.spans()[0].kind, SpanKindSpec::Client);
-        assert_eq!(registry.spans()[0].name.note, "HTTP GET");
+        assert_eq!(registry.spans()[0].name.note.as_deref(), Some("HTTP GET"));
         assert_eq!(registry.spans()[0].attributes.len(), 1);
         match &registry.spans()[0].attributes[0] {
             SpanAttributeOrGroupRef::Attribute(attribute) => {

--- a/crates/weaver_live_check/src/live_checker.rs
+++ b/crates/weaver_live_check/src/live_checker.rs
@@ -1111,7 +1111,8 @@ mod tests {
                         r#type: "custom.comprehensive.internal".to_owned().into(),
                         kind: V2SpanKindSpec::Internal,
                         name: SpanName {
-                            note: "custom.comprehensive.internal".to_owned(),
+                            note: Some("custom.comprehensive.internal".to_owned()),
+                            ..Default::default()
                         },
                         attributes: vec![SpanAttribute {
                             base: custom_string_attr.clone(),

--- a/crates/weaver_mcp/src/service.rs
+++ b/crates/weaver_mcp/src/service.rs
@@ -606,7 +606,8 @@ mod tests {
                     r#type: "http.client".to_owned().into(),
                     kind: SpanKindSpec::Client,
                     name: SpanName {
-                        note: "HTTP client span".to_owned(),
+                        note: Some("HTTP client span".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![],
                     entity_associations: vec![],

--- a/crates/weaver_resolved_schema/src/convert.rs
+++ b/crates/weaver_resolved_schema/src/convert.rs
@@ -443,13 +443,10 @@ pub fn convert_v1_to_v2(
                     .clone()
                     .map(weaver_semconv::convert::v1_span_kind_to_v2)
                     .unwrap_or(weaver_semconv::v2::span::SpanKindSpec::Internal);
-                let span_name = g
-                    .span_name
-                    .clone()
-                    .map(weaver_semconv::convert::v1_span_name_to_v2)
-                    .unwrap_or_else(|| SpanName {
-                        note: g.name.clone().unwrap_or_default(),
-                    });
+                let span_name = g.span_name.clone().unwrap_or_else(|| SpanName {
+                    templates: Vec::new(),
+                    note: g.name.clone(),
+                });
                 if !is_refinement {
                     let span = V2Span {
                         r#type: fix_span_group_id(&g.id),
@@ -1848,8 +1845,9 @@ mod tests {
             entity_associations: vec![],
             visibility: None,
             is_v2: false,
-            span_name: Some(weaver_semconv::v1::group::SpanName {
-                note: "HTTP {http.request.method}".to_owned(),
+            span_name: Some(SpanName {
+                templates: Vec::new(),
+                note: Some("HTTP {http.request.method}".to_owned()),
             }),
         };
 
@@ -1868,7 +1866,10 @@ mod tests {
             refinement.span.kind,
             weaver_semconv::v2::span::SpanKindSpec::Client
         );
-        assert_eq!(refinement.span.name.note, "HTTP {http.request.method}");
+        assert_eq!(
+            refinement.span.name.note.as_deref(),
+            Some("HTTP {http.request.method}")
+        );
     }
 
     /// Converting a public attribute group carries the group-specific requirement level.

--- a/crates/weaver_resolved_schema/src/v1/registry.rs
+++ b/crates/weaver_resolved_schema/src/v1/registry.rs
@@ -22,8 +22,9 @@ use weaver_semconv::provenance::Provenance;
 use weaver_semconv::signal_requirement_level::SignalRequirementLevel;
 use weaver_semconv::stability::Stability;
 use weaver_semconv::v1::group::{
-    AttributeGroupVisibilitySpec, GroupType, InstrumentSpec, SpanKindSpec, SpanName,
+    AttributeGroupVisibilitySpec, GroupType, InstrumentSpec, SpanKindSpec,
 };
+use weaver_semconv::v2::span::SpanName;
 use weaver_semconv::YamlValue;
 
 /// Where the `entity_associations` entries of each group resolved: group id, to

--- a/crates/weaver_resolved_schema/src/v2/mod.rs
+++ b/crates/weaver_resolved_schema/src/v2/mod.rs
@@ -416,7 +416,8 @@ mod tests {
             r#type: "http.client".to_owned().into(),
             kind: weaver_semconv::v2::span::SpanKindSpec::Client,
             name: weaver_semconv::v2::span::SpanName {
-                note: "HTTP".to_owned(),
+                note: Some("HTTP".to_owned()),
+                ..Default::default()
             },
             attributes: vec![],
             entity_associations: vec![],
@@ -439,7 +440,8 @@ mod tests {
             r#type: "http.client".to_owned().into(),
             kind: weaver_semconv::v2::span::SpanKindSpec::Client,
             name: weaver_semconv::v2::span::SpanName {
-                note: "HTTP".to_owned(),
+                note: Some("HTTP".to_owned()),
+                ..Default::default()
             },
             attributes: vec![],
             entity_associations: vec![],
@@ -645,7 +647,8 @@ mod tests {
                         r#type: "http.server.request".to_owned().into(),
                         kind: SpanKindSpec::Server,
                         name: SpanName {
-                            note: "HTTP server span".to_owned(),
+                            note: Some("HTTP server span".to_owned()),
+                            ..Default::default()
                         },
                         attributes: vec![span::SpanAttributeRef {
                             base: AttributeRef(0),
@@ -669,7 +672,8 @@ mod tests {
                         r#type: "internal.processing".to_owned().into(),
                         kind: SpanKindSpec::Internal,
                         name: SpanName {
-                            note: "Background processing".to_owned(),
+                            note: Some("Background processing".to_owned()),
+                            ..Default::default()
                         },
                         attributes: vec![],
                         entity_associations: vec![],
@@ -840,7 +844,8 @@ mod tests {
                         r#type: "http.server.request".to_owned().into(),
                         kind: SpanKindSpec::Server,
                         name: SpanName {
-                            note: "HTTP server span".to_owned(),
+                            note: Some("HTTP server span".to_owned()),
+                            ..Default::default()
                         },
                         attributes: vec![],
                         entity_associations: vec![],

--- a/crates/weaver_resolved_schema/src/v2/refinements.rs
+++ b/crates/weaver_resolved_schema/src/v2/refinements.rs
@@ -61,7 +61,8 @@ mod tests {
                     r#type: "http.client".to_owned().into(),
                     kind: weaver_semconv::v2::span::SpanKindSpec::Client,
                     name: weaver_semconv::v2::span::SpanName {
-                        note: "HTTP GET".to_owned(),
+                        note: Some("HTTP GET".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![],
                     entity_associations: vec![],

--- a/crates/weaver_resolved_schema/src/v2/registry.rs
+++ b/crates/weaver_resolved_schema/src/v2/registry.rs
@@ -300,7 +300,8 @@ mod test {
                 r#type: "test.span".to_owned().into(),
                 kind: SpanKindSpec::Client,
                 name: SpanName {
-                    note: "test".to_owned(),
+                    note: Some("test".to_owned()),
+                    ..Default::default()
                 },
                 attributes: vec![],
                 entity_associations: vec![],

--- a/crates/weaver_resolved_schema/src/v2/span.rs
+++ b/crates/weaver_resolved_schema/src/v2/span.rs
@@ -115,7 +115,8 @@ mod tests {
             r#type: SignalId::from("http.client"),
             kind: SpanKindSpec::Client,
             name: SpanName {
-                note: "HTTP {http.request.method}".to_owned(),
+                note: Some("HTTP {http.request.method}".to_owned()),
+                ..Default::default()
             },
             attributes: vec![],
             entity_associations: vec![],

--- a/crates/weaver_resolver/src/dependency.rs
+++ b/crates/weaver_resolver/src/dependency.rs
@@ -61,7 +61,7 @@ pub(crate) struct GroupSummary {
     pub span_kind: Option<SpanKindSpec>,
     /// The v2 span name specification, inherited by refinements that do not
     /// override it.
-    pub span_name: Option<weaver_semconv::v1::group::SpanName>,
+    pub span_name: Option<weaver_semconv::v2::span::SpanName>,
     /// The attributes from this group before being completely resolved to a catalog.
     pub attributes: Vec<UnresolvedAttribute>,
     /// The annotations of the group.
@@ -544,7 +544,7 @@ impl GroupRefinementLookup for V2Schema {
                 attributes,
             );
             summary.span_kind = Some(weaver_semconv::convert::v2_span_kind_to_v1(s.kind));
-            summary.span_name = Some(weaver_semconv::convert::v2_span_name_to_v1(s.name.clone()));
+            summary.span_name = Some(s.name.clone());
             return Some(summary);
         }
         None
@@ -747,7 +747,8 @@ pub(crate) mod tests {
                     r#type: "span.d".to_owned().into(),
                     kind: weaver_semconv::v2::span::SpanKindSpec::Client,
                     name: weaver_semconv::v2::span::SpanName {
-                        note: "test".to_owned(),
+                        templates: Vec::new(),
+                        note: Some("test".to_owned()),
                     },
                     attributes: vec![],
                     entity_associations: vec![],
@@ -852,8 +853,9 @@ pub(crate) mod tests {
         // not override it inherit the dependency's definition.
         assert_eq!(
             span_summary.span_name,
-            Some(weaver_semconv::v1::group::SpanName {
-                note: "test".to_owned(),
+            Some(weaver_semconv::v2::span::SpanName {
+                templates: Vec::new(),
+                note: Some("test".to_owned()),
             })
         );
 

--- a/crates/weaver_resolver/src/error.rs
+++ b/crates/weaver_resolver/src/error.rs
@@ -280,6 +280,20 @@ pub enum Error {
         attribute_id: String,
     },
 
+    /// An attribute used in a span name template is not referenced on the span.
+    #[error("Span `{span_id}` uses attribute `{attribute_key}` in its name templates, but the attribute is not declared or inherited on the span.\nProvenance: {provenance:?}")]
+    #[diagnostic(help(
+        "Add `{attribute_key}` to the span's `attributes` list, or remove it from the name template."
+    ))]
+    SpanNameAttributeNotOnSpan {
+        /// The id/type of the span.
+        span_id: String,
+        /// The attribute key referenced in the template.
+        attribute_key: String,
+        /// The provenance of the span.
+        provenance: Option<Box<Provenance>>,
+    },
+
     /// Invalid import wildcard.
     #[error("Invalid import wildcard: {error:?}")]
     #[diagnostic(help(

--- a/crates/weaver_resolver/src/imports.rs
+++ b/crates/weaver_resolver/src/imports.rs
@@ -644,7 +644,7 @@ fn upgrade_imported_group_v2<C: crate::SchemaCacheLookup>(
                 ))),
             );
             upgraded.span_kind = Some(weaver_semconv::convert::v2_span_kind_to_v1(s.kind));
-            upgraded.span_name = Some(weaver_semconv::convert::v2_span_name_to_v1(s.name.clone()));
+            upgraded.span_name = Some(s.name.clone());
             upgraded.name = Some(s.r#type.to_string());
             upgraded.entity_associations = to_named_associations(&s.entity_associations);
             upgraded.requirement_level = s.requirement_level.clone();
@@ -1123,7 +1123,7 @@ impl ImportableDependency for V2Schema {
                 Some(GroupLineage::new(v2_provenance(self, &deps, &s.provenance))),
             );
             group.span_kind = Some(weaver_semconv::convert::v2_span_kind_to_v1(s.kind));
-            group.span_name = Some(weaver_semconv::convert::v2_span_name_to_v1(s.name.clone()));
+            group.span_name = Some(s.name.clone());
             group.name = Some(s.r#type.to_string());
             group.entity_associations = to_named_associations(&s.entity_associations);
             group.requirement_level = s.requirement_level.clone();
@@ -1439,8 +1439,9 @@ mod tests {
         );
         assert_eq!(
             span.span_name,
-            Some(weaver_semconv::v1::group::SpanName {
-                note: "test".to_owned(),
+            Some(weaver_semconv::v2::span::SpanName {
+                templates: Vec::new(),
+                note: Some("test".to_owned()),
             })
         );
 

--- a/crates/weaver_resolver/src/registry.rs
+++ b/crates/weaver_resolver/src/registry.rs
@@ -229,6 +229,7 @@ pub(crate) fn resolve_registry_with_dependencies<C: crate::SchemaCacheLookup>(
     );
     check_root_attribute_id_duplicates(&result, &attr_name_index, &mut errors);
     check_v2_signal_id_collisions(&result, &mut errors);
+    check_span_name_attributes(&result, &attr_name_index, &mut errors);
 
     WResult::OkWithNFEs(result, errors)
 }
@@ -269,6 +270,52 @@ fn check_v2_signal_id_collisions(registry: &Registry, errors: &mut Vec<Error>) {
                 .unique()
                 .collect(),
         });
+    }
+}
+
+/// Checks that every attribute referenced in a span's name templates is present
+/// on the span itself (either declared directly or inherited).
+fn check_span_name_attributes(
+    registry: &Registry,
+    attr_name_index: &[String],
+    errors: &mut Vec<Error>,
+) {
+    for group in registry.groups.iter() {
+        if group.r#type != GroupType::Span {
+            continue;
+        }
+
+        let Some(span_name) = &group.span_name else {
+            continue;
+        };
+
+        if span_name.templates.is_empty() {
+            continue;
+        }
+
+        // Collect all attribute names present on this span
+        let span_attr_names: HashSet<&str> = group
+            .attributes
+            .iter()
+            .filter_map(|attr_ref| attr_name_index.get(attr_ref.0 as usize).map(String::as_str))
+            .collect();
+
+        let mut missing_attrs = HashSet::new();
+        for template in &span_name.templates {
+            for attr in &template.attributes {
+                if !span_attr_names.contains(attr.as_str()) {
+                    let _ = missing_attrs.insert(attr.as_str());
+                }
+            }
+        }
+
+        for attr in missing_attrs {
+            errors.push(Error::SpanNameAttributeNotOnSpan {
+                span_id: group.id.clone(),
+                attribute_key: attr.to_owned(),
+                provenance: group.provenance().map(Box::new),
+            });
+        }
     }
 }
 
@@ -2282,6 +2329,70 @@ groups:
             other @ AttributeSpec::Id { .. } => {
                 panic!("expected a Ref attribute, got {other:?}")
             }
+        }
+    }
+
+    #[test]
+    fn test_check_span_name_attributes_reports_missing_attribute() {
+        use crate::registry::check_span_name_attributes;
+        use crate::Error as ResolverError;
+        use std::collections::BTreeMap;
+        use weaver_resolved_schema::v1::attribute::AttributeRef;
+        use weaver_semconv::v2::span::{SpanName, SpanNameTemplate};
+
+        let attr_name_index = vec!["http.request.method".to_owned()];
+        let group = Group {
+            id: "span.http.client".to_owned(),
+            r#type: GroupType::Span,
+            brief: "".to_owned(),
+            note: "".to_owned(),
+            prefix: "".to_owned(),
+            extends: None,
+            stability: None,
+            deprecated: None,
+            attributes: vec![AttributeRef(0)], // only http.request.method
+            span_kind: None,
+            events: vec![],
+            metric_name: None,
+            instrument: None,
+            unit: None,
+            name: None,
+            lineage: None,
+            display_name: None,
+            body: None,
+            annotations: None,
+            entity_associations: vec![],
+            visibility: None,
+            is_v2: true,
+            span_name: Some(SpanName {
+                templates: vec![
+                    SpanNameTemplate::parse("{http.request.method} {url.template}").unwrap(),
+                ],
+                note: None,
+            }),
+            requirement_level: None,
+        };
+
+        let registry = Registry {
+            registry_url: "test".to_owned(),
+            groups: vec![group],
+            entity_association_origins: BTreeMap::new(),
+        };
+
+        let mut errors = vec![];
+        check_span_name_attributes(&registry, &attr_name_index, &mut errors);
+
+        assert_eq!(errors.len(), 1);
+        match &errors[0] {
+            ResolverError::SpanNameAttributeNotOnSpan {
+                span_id,
+                attribute_key,
+                ..
+            } => {
+                assert_eq!(span_id, "span.http.client");
+                assert_eq!(attribute_key, "url.template");
+            }
+            other => panic!("expected SpanNameAttributeNotOnSpan, got {other:?}"),
         }
     }
 }

--- a/crates/weaver_search/src/lib.rs
+++ b/crates/weaver_search/src/lib.rs
@@ -691,7 +691,8 @@ mod tests {
                     r#type: "http.client".to_owned().into(),
                     kind: SpanKindSpec::Client,
                     name: SpanName {
-                        note: "HTTP client span".to_owned(),
+                        note: Some("HTTP client span".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![],
                     entity_associations: vec![],

--- a/crates/weaver_semconv/src/convert.rs
+++ b/crates/weaver_semconv/src/convert.rs
@@ -327,7 +327,16 @@ pub fn v2_span_kind_to_v1(k: V2SpanKindSpec) -> V1SpanKindSpec {
 /// Converts a V2 span name to V1.
 #[must_use]
 pub fn v2_span_name_to_v1(s: crate::v2::span::SpanName) -> V1SpanName {
-    V1SpanName { note: s.note }
+    let note = match &s.note {
+        Some(note) if !note.trim().is_empty() => note.clone(),
+        _ if !s.templates.is_empty() => {
+            let parts: Vec<String> = s.templates.iter().map(|t| t.pattern.clone()).collect();
+            parts.join(", ")
+        }
+        Some(note) => note.clone(),
+        None => String::new(),
+    };
+    V1SpanName { note }
 }
 
 /// Converts a V2 metric into a V1 GroupSpec.
@@ -433,9 +442,7 @@ pub(crate) fn v2_span_to_v1(span: Span) -> V1GroupSpec {
         entity_associations: span.entity_associations,
         visibility: None,
         is_v2: true,
-        span_name: Some(V1SpanName {
-            note: span.name.note,
-        }),
+        span_name: Some(span.name),
         requirement_level: span.requirement_level,
     }
 }
@@ -471,7 +478,7 @@ pub(crate) fn v2_span_refinement_to_v1(r: SpanRefinement) -> V1GroupSpec {
         entity_associations: r.entity_associations,
         visibility: None,
         is_v2: true,
-        span_name: r.name.map(|n| V1SpanName { note: n.note }),
+        span_name: r.name,
         requirement_level: None,
     }
 }
@@ -941,7 +948,14 @@ pub fn v1_span_kind_to_v2(k: V1SpanKindSpec) -> V2SpanKindSpec {
 /// Converts V1 span name to V2.
 #[must_use]
 pub fn v1_span_name_to_v2(s: V1SpanName) -> crate::v2::span::SpanName {
-    crate::v2::span::SpanName { note: s.note }
+    crate::v2::span::SpanName {
+        templates: vec![],
+        note: if s.note.is_empty() {
+            None
+        } else {
+            Some(s.note)
+        },
+    }
 }
 
 #[cfg(test)]
@@ -949,10 +963,9 @@ mod tests {
     use super::*;
     use crate::deprecated::Deprecated;
     use crate::stability::Stability;
-    use crate::v1::group::SpanName as V1SpanName;
     use crate::v2::attribute::GroupRef;
     use crate::v2::signal_id::SignalId;
-    use crate::v2::span::{SpanGroupRef, SpanName};
+    use crate::v2::span::{SpanGroupRef, SpanName, SpanNameTemplate};
     use crate::v2::{CommonFields, GroupWildcard as V2GroupWildcard};
     use crate::YamlValue;
     use std::collections::BTreeMap;
@@ -1269,7 +1282,8 @@ mod tests {
     #[test]
     fn test_span_name_conversions() {
         let v2_span_name = SpanName {
-            note: "HTTP {method}".to_owned(),
+            templates: Vec::new(),
+            note: Some("HTTP {method}".to_owned()),
         };
         let v1_span_name = v2_span_name_to_v1(v2_span_name.clone());
         assert_eq!(v1_span_name.note, "HTTP {method}");
@@ -1494,7 +1508,8 @@ attributes:
             r#type: SignalId::from("http.client"),
             kind: V2SpanKindSpec::Client,
             name: SpanName {
-                note: "HTTP {http.request.method}".to_owned(),
+                note: Some("HTTP {http.request.method}".to_owned()),
+                ..Default::default()
             },
             common: CommonFields {
                 brief: "Client HTTP span".to_owned(),
@@ -1524,8 +1539,9 @@ attributes:
         assert_eq!(v1_group.span_kind, Some(V1SpanKindSpec::Client));
         assert_eq!(
             v1_group.span_name,
-            Some(V1SpanName {
-                note: "HTTP {http.request.method}".to_owned()
+            Some(SpanName {
+                note: Some("HTTP {http.request.method}".to_owned()),
+                ..Default::default()
             })
         );
         assert_eq!(v1_group.attributes.len(), 1);
@@ -1538,7 +1554,8 @@ attributes:
             id: SignalId::from("http.client.refined"),
             r#ref: SignalId::from("http.client"),
             name: Some(SpanName {
-                note: "Overridden name".to_owned(),
+                note: Some("Overridden name".to_owned()),
+                ..Default::default()
             }),
             brief: Some("Refined span brief".to_owned()),
             note: Some("Refined span note".to_owned()),
@@ -1555,11 +1572,37 @@ attributes:
         assert_eq!(v1_group.extends, Some("span.http.client".to_owned()));
         assert_eq!(
             v1_group.span_name,
-            Some(V1SpanName {
-                note: "Overridden name".to_owned()
+            Some(SpanName {
+                note: Some("Overridden name".to_owned()),
+                ..Default::default()
             })
         );
         assert!(v1_group.is_v2);
+    }
+
+    #[test]
+    fn test_v2_span_name_to_v1_synthesizes_note_from_templates() {
+        let v2_name = SpanName {
+            templates: vec![
+                SpanNameTemplate::parse("{http.request.method} {url.template}").unwrap(),
+                SpanNameTemplate::parse("{http.request.method}").unwrap(),
+                SpanNameTemplate::parse("HTTP").unwrap(),
+            ],
+            note: None,
+        };
+
+        let v1_name = v2_span_name_to_v1(v2_name);
+        assert_eq!(
+            v1_name.note,
+            "{http.request.method} {url.template}, {http.request.method}, HTTP"
+        );
+
+        let v2_roundtrip = v1_span_name_to_v2(v1_name);
+        assert_eq!(
+            v2_roundtrip.note.as_deref(),
+            Some("{http.request.method} {url.template}, {http.request.method}, HTTP")
+        );
+        assert!(v2_roundtrip.templates.is_empty());
     }
 
     #[test]

--- a/crates/weaver_semconv/src/semconv.rs
+++ b/crates/weaver_semconv/src/semconv.rs
@@ -427,6 +427,25 @@ mod tests {
             .unwrap();
         assert!(matches!(v1.spec, Versioned::V1(_)));
 
+        let v1_with_templates = r#"
+        groups:
+          - id: "span1"
+            brief: "description1"
+            stability: "stable"
+            type: span
+            span_kind: "internal"
+            attributes:
+              - id: "attr1"
+                type: "string"
+                brief: "test attr"
+                examples: "test"
+            span_name:
+              templates:
+                - pattern: "{foo}"
+        "#;
+        let res = semconv_from_file(v1_with_templates).into_result_failing_non_fatal();
+        assert!(res.is_err(), "v1 yaml must reject span name templates");
+
         let v2_yaml = r#"
         file_format: definition/2
         attributes:

--- a/crates/weaver_semconv/src/v1/group.rs
+++ b/crates/weaver_semconv/src/v1/group.rs
@@ -171,7 +171,7 @@ pub struct GroupSpec {
     #[serde(default)]
     #[serde(skip_serializing)]
     #[schemars(skip)]
-    pub span_name: Option<SpanName>,
+    pub span_name: Option<crate::v2::span::SpanName>,
 
     /// Requirement level of the signal (metric, span, event, entity).
     /// This is a v2-only concept carried through the v1 intermediate

--- a/crates/weaver_semconv/src/v2/mod.rs
+++ b/crates/weaver_semconv/src/v2/mod.rs
@@ -283,6 +283,24 @@ impl SemConvSpecV2 {
         }
         for s in &self.spans {
             check(s.requirement_level.is_none(), format!("span.{}", s.r#type));
+            if s.name.templates.is_empty() && s.name.note.is_none() {
+                fatal_errors.push(Error::InvalidGroup {
+                    path_or_url: provenance.to_owned(),
+                    group_id: format!("span.{}", s.r#type),
+                    error: "Span must specify `templates` or a `note` for its name".to_owned(),
+                });
+            }
+        }
+        for r in &self.span_refinements {
+            if let Some(name) = &r.name {
+                if name.templates.is_empty() && name.note.is_none() {
+                    fatal_errors.push(Error::InvalidGroup {
+                        path_or_url: provenance.to_owned(),
+                        group_id: r.id.to_string(),
+                        error: "Span refinement must specify `templates` or a `note` when overriding name".to_owned(),
+                    });
+                }
+            }
         }
         for e in &self.events {
             check(e.requirement_level.is_none(), format!("event.{}", e.name));
@@ -471,7 +489,8 @@ mod tests {
                 r#type: "http.server".into(),
                 kind: span::SpanKindSpec::Server,
                 name: span::SpanName {
-                    note: "HTTP GET".to_owned(),
+                    note: Some("HTTP GET".to_owned()),
+                    ..Default::default()
                 },
                 attributes: vec![],
                 entity_associations: vec![],
@@ -735,6 +754,39 @@ mod tests {
             events: vec![],
             metrics: vec![],
             spans: vec![],
+            attribute_groups: vec![],
+            entity_refinements: vec![],
+            event_refinements: vec![],
+            metric_refinements: vec![],
+            span_refinements: vec![],
+            imports: None,
+        };
+
+        let result = spec.validate("test_prov");
+        assert!(matches!(result, WResult::FatalErr(_)));
+    }
+
+    #[test]
+    fn test_validate_span_missing_templates_and_note() {
+        use crate::v2::span::{Span, SpanKindSpec, SpanName};
+
+        let spec = SemConvSpecV2 {
+            attributes: vec![],
+            entities: vec![],
+            events: vec![],
+            metrics: vec![],
+            spans: vec![Span {
+                r#type: "test.span".into(),
+                kind: SpanKindSpec::Internal,
+                name: SpanName {
+                    templates: vec![],
+                    note: None,
+                },
+                attributes: vec![],
+                entity_associations: vec![],
+                requirement_level: None,
+                common: Default::default(),
+            }],
             attribute_groups: vec![],
             entity_refinements: vec![],
             event_refinements: vec![],

--- a/crates/weaver_semconv/src/v2/span.rs
+++ b/crates/weaver_semconv/src/v2/span.rs
@@ -2,6 +2,7 @@
 
 //! The new way we want to define spans going forward.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 
@@ -56,14 +57,296 @@ pub struct SpanGroupRef {
     pub ref_group: String,
 }
 
-/// Specification of the span name.
+/// A parsed component of a span name template: either a literal string or an attribute reference.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TemplatePart {
+    /// A literal string component.
+    Literal {
+        /// The literal string content.
+        value: String,
+    },
+    /// An attribute reference component.
+    Attribute {
+        /// The attribute key.
+        attribute: String,
+    },
+}
+
+/// A parsed span name template pattern.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct SpanNameTemplate {
+    /// The original pattern string, e.g. "{http.request.method} {url.template}".
+    pub pattern: String,
+    /// The list of attribute keys required by this template.
+    pub attributes: Vec<String>,
+    /// The parsed components of the template.
+    pub parts: Vec<TemplatePart>,
+}
+
+impl SpanNameTemplate {
+    /// Parses a template pattern string into a `SpanNameTemplate`.
+    ///
+    /// Placeholders are delimited by `{` and `}` and contain the attribute key.
+    /// Text outside braces is treated as literal delimiters.
+    pub fn parse(pattern: &str) -> Result<Self, String> {
+        if pattern.trim().is_empty() {
+            return Err("Span name template pattern cannot be empty".to_owned());
+        }
+
+        let mut parts = Vec::new();
+        let mut attributes = Vec::new();
+        let mut chars = pattern.chars().peekable();
+        let mut current_literal = String::new();
+
+        while let Some(c) = chars.next() {
+            if c == '{' {
+                let mut attr = String::new();
+                let mut closed = false;
+                for inner in chars.by_ref() {
+                    if inner == '}' {
+                        closed = true;
+                        break;
+                    }
+                    if inner == '{' {
+                        return Err(format!("Nested '{{' in template: `{pattern}`"));
+                    }
+                    attr.push(inner);
+                }
+                if !closed {
+                    return Err(format!("Unclosed '{{' in template: `{pattern}`"));
+                }
+                if attr.is_empty()
+                    || attr.contains(char::is_whitespace)
+                    || !attr
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_')
+                {
+                    return Err(format!(
+                        "Invalid attribute placeholder `{attr}` in template: `{pattern}`"
+                    ));
+                }
+                if !current_literal.is_empty() {
+                    parts.push(TemplatePart::Literal {
+                        value: std::mem::take(&mut current_literal),
+                    });
+                }
+                if !attributes.iter().any(|a| a == &attr) {
+                    attributes.push(attr.to_owned());
+                }
+                parts.push(TemplatePart::Attribute {
+                    attribute: attr.to_owned(),
+                });
+            } else if c == '}' {
+                return Err(format!("Unmatched '}}' in template: `{pattern}`"));
+            } else {
+                current_literal.push(c);
+            }
+        }
+
+        if !current_literal.is_empty() {
+            parts.push(TemplatePart::Literal {
+                value: current_literal,
+            });
+        }
+
+        Ok(Self {
+            pattern: pattern.to_owned(),
+            attributes,
+            parts,
+        })
+    }
+
+    /// Renders the template given an attribute value lookup function.
+    /// Returns `None` if any required attribute is missing or empty.
+    pub fn render<'a, F>(&self, mut get_attr: F) -> Option<String>
+    where
+        F: FnMut(&str) -> Option<&'a str>,
+    {
+        let mut result = String::new();
+        for part in &self.parts {
+            match part {
+                TemplatePart::Literal { value } => result.push_str(value),
+                TemplatePart::Attribute { attribute } => {
+                    let val = get_attr(attribute)?;
+                    if val.is_empty() {
+                        return None;
+                    }
+                    result.push_str(val);
+                }
+            }
+        }
+        Some(result)
+    }
+}
+
+impl Display for SpanNameTemplate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.pattern)
+    }
+}
+
+impl TryFrom<String> for SpanNameTemplate {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::parse(&s)
+    }
+}
+
+impl TryFrom<&str> for SpanNameTemplate {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::parse(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for SpanNameTemplate {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct SpanNameTemplateVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for SpanNameTemplateVisitor {
+            type Value = SpanNameTemplate;
+
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a span name template string or object")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                SpanNameTemplate::parse(value).map_err(serde::de::Error::custom)
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: serde::de::MapAccess<'de>,
+            {
+                let mut pattern: Option<String> = None;
+                let mut attributes: Option<Vec<String>> = None;
+                let mut parts: Option<Vec<TemplatePart>> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "pattern" => pattern = Some(map.next_value()?),
+                        "attributes" => attributes = Some(map.next_value()?),
+                        "parts" => parts = Some(map.next_value()?),
+                        unknown => {
+                            return Err(serde::de::Error::unknown_field(
+                                unknown,
+                                &["pattern", "attributes", "parts"],
+                            ));
+                        }
+                    }
+                }
+
+                let pattern: String =
+                    pattern.ok_or_else(|| serde::de::Error::missing_field("pattern"))?;
+                let parsed = SpanNameTemplate::parse(&pattern).map_err(serde::de::Error::custom)?;
+                if let Some(attrs) = attributes {
+                    if attrs != parsed.attributes {
+                        return Err(serde::de::Error::custom(
+                            "provided 'attributes' does not match attributes extracted from 'pattern'",
+                        ));
+                    }
+                }
+                if let Some(p) = parts {
+                    if p != parsed.parts {
+                        return Err(serde::de::Error::custom(
+                            "provided 'parts' does not match parts extracted from 'pattern'",
+                        ));
+                    }
+                }
+                Ok(parsed)
+            }
+        }
+
+        deserializer.deserialize_any(SpanNameTemplateVisitor)
+    }
+}
+
+impl JsonSchema for SpanNameTemplate {
+    fn schema_name() -> Cow<'static, str> {
+        "SpanNameTemplate".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        concat!(module_path!(), "::SpanNameTemplate").into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let part_schema = generator.subschema_for::<TemplatePart>();
+        schemars::json_schema!({
+            "oneOf": [
+                { "type": "string" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "pattern": { "type": "string" },
+                        "attributes": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                        },
+                        "parts": {
+                            "type": "array",
+                            "items": part_schema
+                        }
+                    },
+                    "required": ["pattern"],
+                    "additionalProperties": false
+                }
+            ]
+        })
+    }
+}
+
+/// Specification of the span name.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub struct SpanName {
-    /// Required description of how a span name should be created.
-    pub note: String,
+    /// Ordered list of templates used to construct the span name.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub templates: Vec<SpanNameTemplate>,
+    /// Description of how a span name should be created.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+impl SpanName {
+    /// Evaluates the span name against an attribute lookup function.
+    /// Iterates through `templates` in order, returning the first match.
+    #[must_use]
+    pub fn evaluate<'a, F>(&self, mut get_attr: F) -> Option<String>
+    where
+        F: FnMut(&str) -> Option<&'a str>,
+    {
+        for template in &self.templates {
+            if let Some(rendered) = template.render(&mut get_attr) {
+                return Some(rendered);
+            }
+        }
+        None
+    }
+
+    /// Evaluates the span name against an attribute lookup function, falling back
+    /// to `default_name` (e.g. the span's type or operation name) if no template matches.
+    #[must_use]
+    pub fn evaluate_or_default<'a, F>(&self, default_name: &str, get_attr: F) -> String
+    where
+        F: FnMut(&str) -> Option<&'a str>,
+    {
+        self.evaluate(get_attr)
+            .unwrap_or_else(|| default_name.to_owned())
+    }
 }
 
 /// A refinement of an Attribute for a span.
@@ -246,5 +529,190 @@ mod tests {
         assert_eq!(attrs[0].base.r#ref, "http.status");
         assert_eq!(attrs[0].sampling_relevant, Some(true));
         assert_eq!(groups[0], "http.shared");
+    }
+
+    #[test]
+    fn test_span_name_template_parsing() {
+        let t = SpanNameTemplate::parse("{http.request.method} {url.template}").unwrap();
+        assert_eq!(t.pattern, "{http.request.method} {url.template}");
+        assert_eq!(t.attributes, vec!["http.request.method", "url.template"]);
+        assert_eq!(
+            t.parts,
+            vec![
+                TemplatePart::Attribute {
+                    attribute: "http.request.method".to_owned()
+                },
+                TemplatePart::Literal {
+                    value: " ".to_owned()
+                },
+                TemplatePart::Attribute {
+                    attribute: "url.template".to_owned()
+                },
+            ]
+        );
+
+        let literal_only = SpanNameTemplate::parse("HTTP").unwrap();
+        assert!(literal_only.attributes.is_empty());
+        assert_eq!(
+            literal_only.parts,
+            vec![TemplatePart::Literal {
+                value: "HTTP".to_owned()
+            }]
+        );
+
+        assert!(SpanNameTemplate::parse("").is_err());
+        assert!(SpanNameTemplate::parse("   ").is_err());
+        assert!(SpanNameTemplate::parse("{unclosed").is_err());
+        assert!(SpanNameTemplate::parse("{}").is_err());
+        assert!(SpanNameTemplate::parse("{   }").is_err());
+        assert!(SpanNameTemplate::parse("{a b}").is_err());
+        assert!(SpanNameTemplate::parse("{ a }").is_err());
+        assert!(SpanNameTemplate::parse("{invalid!attr}").is_err());
+        assert!(SpanNameTemplate::parse("stray}brace").is_err());
+        assert!(SpanNameTemplate::parse("{nested{brace}}").is_err());
+
+        // Consecutive placeholders
+        let consecutive = SpanNameTemplate::parse("{a}{b}").unwrap();
+        assert_eq!(consecutive.attributes, vec!["a", "b"]);
+        assert_eq!(consecutive.parts.len(), 2);
+    }
+
+    #[test]
+    fn test_span_name_template_rendering() {
+        let t = SpanNameTemplate::parse("{method} {url.template}").unwrap();
+
+        // All present and valid
+        let rendered = t.render(|key| match key {
+            "method" => Some("GET"),
+            "url.template" => Some("/users/{id}"),
+            _ => None,
+        });
+        assert_eq!(rendered.as_deref(), Some("GET /users/{id}"));
+
+        // Missing attribute
+        let rendered = t.render(|key| match key {
+            "method" => Some("GET"),
+            _ => None,
+        });
+        assert_eq!(rendered, None);
+
+        // Empty value is rejected
+        let rendered = t.render(|key| match key {
+            "method" => Some(""),
+            "url.template" => Some("/users/{id}"),
+            _ => None,
+        });
+        assert_eq!(rendered, None);
+    }
+
+    #[test]
+    fn test_span_name_evaluation() {
+        let span_name = SpanName {
+            templates: vec![
+                SpanNameTemplate::parse("{http.request.method} {url.template}").unwrap(),
+                SpanNameTemplate::parse("{http.request.method} {server.address}:{server.port}")
+                    .unwrap(),
+                SpanNameTemplate::parse("{http.request.method} {server.address}").unwrap(),
+                SpanNameTemplate::parse("{http.request.method}").unwrap(),
+                SpanNameTemplate::parse("HTTP").unwrap(),
+            ],
+            note: None,
+        };
+
+        // First template matches
+        let name = span_name.evaluate(|key| match key {
+            "http.request.method" => Some("GET"),
+            "url.template" => Some("/users/{id}"),
+            _ => None,
+        });
+        assert_eq!(name.as_deref(), Some("GET /users/{id}"));
+
+        // First template fails, second matches
+        let name = span_name.evaluate(|key| match key {
+            "http.request.method" => Some("POST"),
+            "server.address" => Some("example.com"),
+            "server.port" => Some("8080"),
+            _ => None,
+        });
+        assert_eq!(name.as_deref(), Some("POST example.com:8080"));
+
+        // Only method matches
+        let name = span_name.evaluate(|key| match key {
+            "http.request.method" => Some("DELETE"),
+            _ => None,
+        });
+        assert_eq!(name.as_deref(), Some("DELETE"));
+
+        // _OTHER for enum http.request.method causes method templates to fail, matches literal "HTTP" template
+        let name = span_name.evaluate(|key| match key {
+            "http.request.method" => Some("_OTHER").filter(|v| *v != "_OTHER"),
+            "url.template" => Some("/users/{id}"),
+            _ => None,
+        });
+        assert_eq!(name.as_deref(), Some("HTTP"));
+
+        // Non-enum attribute with value "_OTHER" is preserved
+        let custom_span = SpanName {
+            templates: vec![SpanNameTemplate::parse("{url.template}").unwrap()],
+            note: None,
+        };
+        let name = custom_span.evaluate(|key| match key {
+            "url.template" => Some("_OTHER"),
+            _ => None,
+        });
+        assert_eq!(name.as_deref(), Some("_OTHER"));
+
+        // Completely empty attributes matches literal "HTTP" template
+        let name = span_name.evaluate(|_| None);
+        assert_eq!(name.as_deref(), Some("HTTP"));
+    }
+
+    #[test]
+    fn test_span_name_deserialization() {
+        let yaml = r#"
+templates:
+  - "{http.request.method} {url.template}"
+  - "{http.request.method}"
+  - "HTTP"
+note: "test note"
+"#;
+        let parsed: SpanName = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed.templates.len(), 3);
+        assert_eq!(
+            parsed.templates[0].pattern,
+            "{http.request.method} {url.template}"
+        );
+        assert_eq!(parsed.templates[2].pattern, "HTTP");
+        assert_eq!(parsed.note.as_deref(), Some("test note"));
+
+        // Backwards compatibility: note only
+        let yaml_note_only = "note: free form note\n";
+        let parsed_note: SpanName = serde_yaml::from_str(yaml_note_only).unwrap();
+        assert!(parsed_note.templates.is_empty());
+        assert_eq!(parsed_note.note.as_deref(), Some("free form note"));
+
+        // Roundtrip serialization: templates serialize as objects with pattern, attributes, parts
+        let serialized = serde_yaml::to_string(&parsed).unwrap();
+        let roundtrip: SpanName = serde_yaml::from_str(&serialized).unwrap();
+        assert_eq!(roundtrip, parsed);
+
+        // JSON roundtrip
+        let json_serialized = serde_json::to_string(&parsed).unwrap();
+        let json_roundtrip: SpanName = serde_json::from_str(&json_serialized).unwrap();
+        assert_eq!(json_roundtrip, parsed);
+
+        // Unknown fields rejected
+        let invalid_yaml = r#"
+pattern: "HTTP"
+unknown_key: "val"
+"#;
+        assert!(serde_yaml::from_str::<SpanNameTemplate>(invalid_yaml).is_err());
+
+        // Inconsistent attributes rejected
+        let inconsistent_yaml = r#"
+pattern: "{a}"
+attributes: ["b"]
+"#;
+        assert!(serde_yaml::from_str::<SpanNameTemplate>(inconsistent_yaml).is_err());
     }
 }

--- a/crates/weaver_semconv_gen/src/v2.rs
+++ b/crates/weaver_semconv_gen/src/v2.rs
@@ -525,7 +525,8 @@ mod tests {
                     r#type: "trace.test".to_owned().into(),
                     kind: SpanKindSpec::Client,
                     name: SpanName {
-                        note: "note".to_owned(),
+                        note: Some("note".to_owned()),
+                        ..Default::default()
                     },
                     attributes: vec![SpanAttributeRef {
                         base: AttributeRef(0),
@@ -588,7 +589,8 @@ mod tests {
                         r#type: "trace.test".to_owned().into(),
                         kind: SpanKindSpec::Client,
                         name: SpanName {
-                            note: "note".to_owned(),
+                            note: Some("note".to_owned()),
+                            ..Default::default()
                         },
                         attributes: vec![SpanAttributeRef {
                             base: AttributeRef(0),

--- a/docs/specs/span-naming/span_naming.md
+++ b/docs/specs/span-naming/span_naming.md
@@ -1,0 +1,284 @@
+# Span Name Templates
+
+Status: Proposal
+
+## Introduction
+
+Semantic conventions currently describe span names via free-form text in the `note` property or in external markdown documentation. This document specifies a formal, declarative mechanism in the Weaver semantic convention schema to define span names using ordered templates.
+
+## Analysis of Existing Conventions
+
+A review of span naming across semantic conventions reveals consistent patterns across domains:
+
+1. **GenAI** (including MCP): Consistently defines span names as an ordered sequence of patterns based on attribute availability:
+   - `{gen_ai.operation.name} {gen_ai.request.model}`
+   - `{gen_ai.operation.name} {gen_ai.data_source.id}`
+   - `{gen_ai.operation.name}`
+   - `create_agent {gen_ai.agent.name}`
+   - `invoke_agent {gen_ai.agent.name}` -> `invoke_agent`
+   - `execute_tool {gen_ai.tool.name} {gen_ai.skill.name} {gen_ai.skill.resource.name}` -> `execute_tool {gen_ai.tool.name} {gen_ai.skill.resource.name}` -> `execute_tool {gen_ai.tool.name} {process.executable.name}` -> `execute_tool {gen_ai.tool.name}`
+   - `invoke_workflow {gen_ai.workflow.name}`
+   - `plan {gen_ai.agent.name}` -> `plan`
+   - `{mcp.method.name} {gen_ai.tool.name}` -> `{mcp.method.name} {gen_ai.prompt.name}` -> `{mcp.method.name}`
+
+2. **HTTP**:
+   - Client: `{http.request.method} {url.template}` -> `{http.request.method} {server.address}:{server.port}` -> `{http.request.method} {server.address}` -> `{http.request.method}` -> `HTTP`
+   - Server: `{http.request.method} {http.route}` -> `{http.request.method}` -> `HTTP`
+   - Sentinel rule: When `{http.request.method}` is `_OTHER` treat it as not provided.
+
+3. **Database**:
+   - `{db.query.summary}`
+   - `{db.operation.name} {db.collection.name}` -> `{db.operation.name} {db.namespace}` -> `{db.operation.name} {server.address}` -> `{db.operation.name}`
+   - `{db.collection.name}` -> `{db.system.name}`
+
+4. **Messaging**:
+   - `{messaging.operation.name} {messaging.destination.template}` -> `{messaging.operation.name} {messaging.destination.name}` -> `{messaging.operation.name} {server.address}:{server.port}` -> `{messaging.operation.name}`
+
+5. **RPC, GraphQL, CI/CD, FaaS**:
+   - RPC: `{rpc.method}` -> `{rpc.system.name}`
+   - GraphQL: `{graphql.operation.type}` -> `GraphQL Operation`
+   - CI/CD: `{cicd.pipeline.action.name} {cicd.pipeline.name}` -> `{cicd.pipeline.action.name}`
+   - FaaS: `{faas.name}` -> `{faas.invoked_name}`
+
+### Findings
+
+Over 90% of all span naming conventions in OpenTelemetry follow the identical pattern:
+1. An ordered list of template strings.
+2. Evaluated from top to bottom.
+3. The first template whose referenced attributes are all present (non-empty) is selected.
+4. A trailing literal template without placeholders acts as a static fallback.
+5. `_OTHER` is a specification-wide sentinel indicating an unknown enum member that must never be emitted into a span name. Non-enum attributes (e.g. URLs, addresses) are never checked against `_OTHER`.
+
+---
+
+## Design
+
+### 1. Schema Syntax
+
+The `name` object on a span is extended with `templates`:
+
+```yaml
+spans:
+  - type: gen_ai.execute_tool.command.internal
+    kind: internal
+    name:
+      templates:
+        - "execute_tool {gen_ai.tool.name} {gen_ai.skill.name} {gen_ai.skill.resource.name}"
+        - "execute_tool {gen_ai.tool.name} {gen_ai.skill.resource.name}"
+        - "execute_tool {gen_ai.tool.name} {process.executable.name}"
+        - "execute_tool {gen_ai.tool.name}"
+```
+
+And for HTTP client:
+
+```yaml
+spans:
+  - type: http.client
+    kind: client
+    name:
+      templates:
+        - "{http.request.method} {url.template}"
+        - "{http.request.method} {server.address}:{server.port}"
+        - "{http.request.method} {server.address}"
+        - "{http.request.method}"
+        - "HTTP"
+```
+
+#### Fields:
+- **`templates`** (`Vec<String>`, optional): Ordered list of template patterns. A literal template with no placeholders (e.g. `"HTTP"`) placed at the end serves as an unconditional fallback.
+- **`note`** (`Option<String>`, optional): Free-form context, explanations, and edge cases. Required if `templates` is omitted.
+
+### 2. Matching and Presence Semantics
+
+When evaluating templates:
+1. Templates are checked in order.
+2. A placeholder `{attribute.key}` is satisfied if and only if the attribute:
+   - Is present in the telemetry payload / attributes map.
+   - Has a non-empty value.
+   - If the attribute is an enum, is not equal to the sentinel value `_OTHER`.
+3. A template matches if **all** of its referenced placeholders are satisfied. A template with no placeholders always matches.
+4. If no template matches, evaluation falls back to the span type (or static operation name).
+
+### 3. Code Generation (Jinja / Weaver Forge)
+
+Jinja templates can generate fast runtime span name resolvers. By resolving referenced attributes upfront, generated code avoids repeated lookups and branches directly on local optionals. For enum attributes, `_OTHER` is filtered out. When no template matches, the resolver falls back to the span's `type`.
+
+Example Jinja template generating Rust:
+
+```jinja
+{% set all_attrs = span.name.templates | map(attribute="attributes") | flatten | unique %}
+pub fn resolve_span_name(attrs: &Attributes) -> String {
+    {%- for attr in all_attrs %}
+    {%- if attr.is_enum %}
+    let {{ attr.name | snake_case }} = attrs.get("{{ attr.name }}").filter(|v| *v != "_OTHER");
+    {%- else %}
+    let {{ attr.name | snake_case }} = attrs.get("{{ attr.name }}");
+    {%- endif %}
+    {%- endfor %}
+
+    {% for t in span.name.templates %}
+    {%- if t.attributes %}
+    if let ({% for attr in t.attributes %}Some({{ attr | snake_case }}){% if not loop.last %}, {% endif %}{% endfor %}) = ({% for attr in t.attributes %}{{ attr | snake_case }}{% if not loop.last %}, {% endif %}{% endfor %}) {
+        return format!("{{ t.pattern | replace("{", "{") }}", {% for attr in t.attributes %}{{ attr | snake_case }} = {{ attr | snake_case }}{% if not loop.last %}, {% endif %}{% endfor %});
+    }
+    {%- else %}
+    return "{{ t.pattern }}".to_string();
+    {%- endif %}
+    {%- endfor %}
+
+    "{{ span.type }}".to_string()
+}
+```
+
+Generated Rust code for `gen_ai.execute_tool.command.internal` (falling back to span type):
+
+```rust
+pub fn resolve_span_name(attrs: &Attributes) -> String {
+    let gen_ai_tool_name = attrs.get("gen_ai.tool.name");
+    let gen_ai_skill_name = attrs.get("gen_ai.skill.name");
+    let gen_ai_skill_resource_name = attrs.get("gen_ai.skill.resource.name");
+    let process_executable_name = attrs.get("process.executable.name");
+
+    if let (Some(gen_ai_tool_name), Some(gen_ai_skill_name), Some(gen_ai_skill_resource_name)) = (gen_ai_tool_name, gen_ai_skill_name, gen_ai_skill_resource_name) {
+        return format!("execute_tool {gen_ai_tool_name} {gen_ai_skill_name} {gen_ai_skill_resource_name}");
+    }
+    if let (Some(gen_ai_tool_name), Some(gen_ai_skill_resource_name)) = (gen_ai_tool_name, gen_ai_skill_resource_name) {
+        return format!("execute_tool {gen_ai_tool_name} {gen_ai_skill_resource_name}");
+    }
+    if let (Some(gen_ai_tool_name), Some(process_executable_name)) = (gen_ai_tool_name, process_executable_name) {
+        return format!("execute_tool {gen_ai_tool_name} {process_executable_name}");
+    }
+    if let Some(gen_ai_tool_name) = gen_ai_tool_name {
+        return format!("execute_tool {gen_ai_tool_name}");
+    }
+
+    "gen_ai.execute_tool.command.internal".to_string()
+}
+```
+
+When `templates` are not specified on a span, code generation cannot infer how to construct the span name automatically. In this case, codegen makes the span name a required parameter that the caller must supply explicitly (e.g. `start_span(name: &str, ...)`).
+
+### 4. Live-Check Validation (Planned)
+
+In `weaver_live_check` (planned for follow-up PR), validating incoming spans against the formal specification:
+1. Find the first template in `templates` where all attributes are present on the sample span (and not equal to `_OTHER` for enum attributes).
+2. Format that template with the sample's attribute values -> `expected_name`.
+3. If a template matched: verify `sample.name == expected_name`.
+4. If mismatched, emit an advisory with actual vs expected span name.
+
+### 5. Validation Policies
+
+**Weaver built-in checks (implemented during loading and resolution):**
+- **Syntax**: Template string must be non-empty, with matching `{` and `}`, and no nested braces.
+- **Span attribute reference**: Every attribute referenced in any template must be declared or inherited on that span.
+
+**Rego policy checks (`after_resolution` stage, planned policy proposals):**
+- **Sampling relevance**: Every attribute referenced in any template must be marked `sampling_relevant: true`.
+- **Attribute type**: Attributes in templates must be `string`, `int`, or an enum of strings/ints.
+- **Exhaustiveness**: A span with templates must include at least one guaranteed fallback: either a static literal template (no placeholders) or a template consisting solely of required attributes that do not have `_OTHER` as an enum member.
+
+Proposed Rego policies:
+
+```rego
+package after_resolution
+
+import rego.v1
+
+# 1. All attributes used in span name templates must be marked sampling_relevant: true
+deny contains span_attr_violation("span_name_sampling_relevant", span.type, attr_key) if {
+    some span in input.registry.spans
+    some template in span.name.templates
+    some attr_key in template.attributes
+
+    some attr in span.attributes
+    attr.key == attr_key
+    not attr.sampling_relevant
+}
+
+# 2. Attributes used in span name templates must be string, int, or enum of strings/ints
+deny contains span_attr_type_violation("span_name_invalid_attribute_type", span.type, attr_key) if {
+    some span in input.registry.spans
+    some template in span.name.templates
+    some attr_key in template.attributes
+
+    some attr in span.attributes
+    attr.key == attr_key
+    not is_allowed_template_attr_type(attr)
+}
+
+allowed_primitive_types := {"string", "int"}
+
+is_allowed_template_attr_type(attr) if {
+    is_string(attr.type)
+    allowed_primitive_types[attr.type]
+}
+
+is_allowed_template_attr_type(attr) if {
+    is_object(attr.type)
+    some _ in attr.type.members
+    every member in attr.type.members {
+        is_allowed_enum_value(member.value)
+    }
+}
+
+is_allowed_enum_value(val) if is_string(val)
+is_allowed_enum_value(val) if {
+    is_number(val)
+    round(val) == val
+}
+
+# 3. Span name templates must be exhaustive
+deny contains span_violation("span_name_not_exhaustive", span.type) if {
+    some span in input.registry.spans
+    count(span.name.templates) > 0
+    not has_guaranteed_template(span)
+}
+
+has_guaranteed_template(span) if {
+    some template in span.name.templates
+    every attr_key in template.attributes {
+        is_guaranteed_attribute(span, attr_key)
+    }
+}
+
+is_guaranteed_attribute(span, attr_key) if {
+    some attr in span.attributes
+    attr.key == attr_key
+    attr.requirement_level == "required"
+    not has_other_enum_member(attr)
+}
+
+has_other_enum_member(attr) if {
+    some member in attr.type.members
+    is_other_member(member)
+}
+
+is_other_member(member) if member.id == "_OTHER"
+is_other_member(member) if member.value == "_OTHER"
+
+span_violation(id, span_type) := {
+    "id": id,
+    "level": "violation",
+    "signal_type": "span",
+    "signal_name": span_type,
+    "message": sprintf("Span '%s' templates are not exhaustive: must contain at least one template consisting solely of required attributes that cannot resolve to '_OTHER' (or a static literal fallback).", [span_type]),
+}
+
+span_attr_violation(id, span_type, attr_key) := {
+    "id": id,
+    "level": "violation",
+    "signal_type": "span",
+    "signal_name": span_type,
+    "context": {"attribute_key": attr_key},
+    "message": sprintf("Span '%s' references attribute '%s' in name templates, but it is not marked 'sampling_relevant: true'.", [span_type, attr_key]),
+}
+
+span_attr_type_violation(id, span_type, attr_key) := {
+    "id": id,
+    "level": "violation",
+    "signal_type": "span",
+    "signal_name": span_type,
+    "context": {"attribute_key": attr_key},
+    "message": sprintf("Span '%s' references attribute '%s' in name templates with an invalid type: only string, int, or an enum of strings/ints are allowed.", [span_type, attr_key]),
+}
+```

--- a/schemas/semconv-syntax.v2.md
+++ b/schemas/semconv-syntax.v2.md
@@ -376,9 +376,13 @@ A span refinement definition consists of the following properties:
 
 #### Span name
 
-The `name` field specifies how the span name should be formatted. It consists of a `note` field that describes in a free form how to format span name based on the attributes. OpenTelemetry semantic conventions use `{action} {target}` format where action and target match attributes on that span. For example, [HTTP server span names](https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/http/http-spans.md#name) match `{http.request.method} {http.route}` pattern in general case.
+The `name` field specifies how the span name should be formatted. It supports:
+- `templates` - Optional. An ordered list of template patterns evaluated sequentially. The first template whose referenced attributes are all present, non-empty, and not `_OTHER` is selected. A literal template with no placeholders (e.g. `HTTP`) can be placed at the end to serve as a fallback.
+- `note` - Optional. A description in free form explaining how to format the span name based on attributes. Required if `templates` is omitted.
 
-The span name structure may be evolved in the future to formally define the naming pattern.
+OpenTelemetry semantic conventions use `{action} {target}` format where action and target match attributes on that span. For example, HTTP client span names match `{http.request.method} {url.template}` falling back to `{http.request.method}` and finally `HTTP` if `{http.request.method}` resolves to `_OTHER`.
+
+For enum attributes, `_OTHER` is treated in the same way as a missing value.
 
 ### `entities` definition
 

--- a/schemas/semconv.materialized.v2.json
+++ b/schemas/semconv.materialized.v2.json
@@ -1794,13 +1794,51 @@
       "type": "object",
       "properties": {
         "note": {
-          "description": "Required description of how a span name should be created.",
-          "type": "string"
+          "description": "Description of how a span name should be created.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "templates": {
+          "description": "Ordered list of templates used to construct the span name.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SpanNameTemplate"
+          }
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "note"
+      "additionalProperties": false
+    },
+    "SpanNameTemplate": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "parts": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/TemplatePart"
+              }
+            },
+            "pattern": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "pattern"
+          ]
+        }
       ]
     },
     "SpanRefinement": {
@@ -1925,6 +1963,47 @@
           "description": "A release candidate definition.",
           "type": "string",
           "const": "release_candidate"
+        }
+      ]
+    },
+    "TemplatePart": {
+      "description": "A parsed component of a span name template: either a literal string or an attribute reference.",
+      "oneOf": [
+        {
+          "description": "A literal string component.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "literal"
+            },
+            "value": {
+              "description": "The literal string content.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ]
+        },
+        {
+          "description": "An attribute reference component.",
+          "type": "object",
+          "properties": {
+            "attribute": {
+              "description": "The attribute key.",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "attribute"
+            }
+          },
+          "required": [
+            "type",
+            "attribute"
+          ]
         }
       ]
     },

--- a/schemas/semconv.resolved.v2.json
+++ b/schemas/semconv.resolved.v2.json
@@ -1527,13 +1527,51 @@
       "type": "object",
       "properties": {
         "note": {
-          "description": "Required description of how a span name should be created.",
-          "type": "string"
+          "description": "Description of how a span name should be created.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "templates": {
+          "description": "Ordered list of templates used to construct the span name.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SpanNameTemplate"
+          }
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "note"
+      "additionalProperties": false
+    },
+    "SpanNameTemplate": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "parts": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/TemplatePart"
+              }
+            },
+            "pattern": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "pattern"
+          ]
+        }
       ]
     },
     "SpanRefinement": {
@@ -1658,6 +1696,47 @@
           "description": "A release candidate definition.",
           "type": "string",
           "const": "release_candidate"
+        }
+      ]
+    },
+    "TemplatePart": {
+      "description": "A parsed component of a span name template: either a literal string or an attribute reference.",
+      "oneOf": [
+        {
+          "description": "A literal string component.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "literal"
+            },
+            "value": {
+              "description": "The literal string content.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ]
+        },
+        {
+          "description": "An attribute reference component.",
+          "type": "object",
+          "properties": {
+            "attribute": {
+              "description": "The attribute key.",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "attribute"
+            }
+          },
+          "required": [
+            "type",
+            "attribute"
+          ]
         }
       ]
     },

--- a/schemas/semconv.schema.v2.json
+++ b/schemas/semconv.schema.v2.json
@@ -1541,13 +1541,51 @@
       "type": "object",
       "properties": {
         "note": {
-          "description": "Required description of how a span name should be created.",
-          "type": "string"
+          "description": "Description of how a span name should be created.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "templates": {
+          "description": "Ordered list of templates used to construct the span name.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SpanNameTemplate"
+          }
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "note"
+      "additionalProperties": false
+    },
+    "SpanNameTemplate": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "parts": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/TemplatePart"
+              }
+            },
+            "pattern": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "pattern"
+          ]
+        }
       ]
     },
     "SpanRefinement": {
@@ -1670,6 +1708,47 @@
           "description": "A release candidate definition.",
           "type": "string",
           "const": "release_candidate"
+        }
+      ]
+    },
+    "TemplatePart": {
+      "description": "A parsed component of a span name template: either a literal string or an attribute reference.",
+      "oneOf": [
+        {
+          "description": "A literal string component.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "literal"
+            },
+            "value": {
+              "description": "The literal string content.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ]
+        },
+        {
+          "description": "An attribute reference component.",
+          "type": "object",
+          "properties": {
+            "attribute": {
+              "description": "The attribute key.",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "attribute"
+            }
+          },
+          "required": [
+            "type",
+            "attribute"
+          ]
         }
       ]
     },


### PR DESCRIPTION
Fixes #819 

Adds formal span name templates to semantic conventions v2, enabling live-check validation and code generation.

Design document: [`docs/specs/span-naming/span_naming.md`](https://github.com/open-telemetry/weaver/blob/979bc9b0754495f4465ae1bd8cb45987dc7453d9/docs/specs/span-naming/span_naming.md)

Key changes:
- Adds `templates` to v2 span names: a list of patterns with literals and placeholders for attributes
- Validates placeholder syntax, attribute presence on span in rust code, sampling-relevance
- allowed types (strings, ints), exhaustiveness is for rego policies

Example:
```yaml
file_format: "definition/2"

spans:
  - type: http.client.request
    kind: client
    brief: Client HTTP span
    name:
      templates:
        - pattern: "{http.request.method} {url.template}"
        - pattern: "{http.request.method}"
        - pattern: "HTTP"   # can always fallback to span type in codegen
    attributes:
      - ref: http.request.method
      - ref: url.template
```

this covers pretty much all spans we have so far in semconv and semconv-genai.

It's still possible to set `note` - free form text about span name. Codegen, when it does not see templates, would need to generate helpers that require span name. Otherwise codegen can generate it from start-time attirbutes.